### PR TITLE
feat(#5): implement board-run lifecycle endpoints (create/fail/import)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -54,6 +54,488 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f156acdd2cf55f5aa53ee416c4ac851cf1222694506c0b1f78c85695e9ca9d"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dcd93c82209ac7413532388067dce79be5a8780c1786e5fae3df22e4dee2864"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.119.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d65fddc3844f902dfe1864acb8494db5f9342015ee3ab7890270d36fbd2e01c"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-json 0.61.9",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.12.1",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.10.9",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.98.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d69c77aafa20460c68b6b3213c84f6423b6e76dbf89accd3e1789a686ffd9489"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.100.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7e7b09346d5ca22a2a08267555843a6a0127fb20d8964cb6ecfb8fdb190225"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.103.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2249b81a2e73a8027c41c378463a81ec39b8510f184f2caab87de912af0f49b"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-json 0.62.5",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68dc0b907359b120170613b5c09ccc61304eac3998ff6274b97d93ee6490115a"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "p256",
+ "percent-encoding",
+ "ring",
+ "sha2 0.11.0",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.63.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87294a084b43d649d967efe58aa1f9e0adc260e13a6938eb904c0ae9b45824ae"
+dependencies = [
+ "aws-smithy-http 0.62.6",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "md-5",
+ "pin-project-lite",
+ "sha1",
+ "sha2 0.10.9",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "826141069295752372f8203c17f28e30c464d22899a43a0c9fd9c458d469c88b"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.61.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49fa1213db31ac95288d981476f78d05d9cbb0353d22cdf3472cc05bb02f6551"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http 0.63.6",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4bbcaa9304ea40902d3d5f42a0428d1bd895a2b0f6999436fb279ffddc58ac"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,10 +545,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -94,8 +576,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -106,10 +588,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -136,9 +634,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "boardflow-api"
 version = "0.0.1"
 dependencies = [
+ "aws-config",
+ "aws-sdk-s3",
  "axum",
  "boardflow-db",
  "boardflow-domain",
@@ -146,7 +655,7 @@ dependencies = [
  "http-body-util",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "tokio",
  "tower",
@@ -167,6 +676,7 @@ version = "0.0.1"
 dependencies = [
  "boardflow-domain",
  "chrono",
+ "serde_json",
  "sqlx",
  "tokio",
  "tracing",
@@ -223,12 +733,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -253,6 +775,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,6 +805,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +831,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -298,6 +860,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
+name = "crc-fast"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ddc2d09feefeee8bd78101665bd8645637828fa9317f9f292496dbbd8c65ff3"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "rand 0.9.4",
+ "regex",
+ "rustversion",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -313,6 +897,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,14 +929,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
 name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -339,10 +982,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -363,12 +1018,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve",
+ "rfc6979",
+ "signature 1.6.4",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -410,6 +1103,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -427,6 +1136,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -440,6 +1155,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures-channel"
@@ -535,15 +1256,76 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http 1.4.0",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -590,7 +1372,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -599,7 +1381,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -609,6 +1400,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -623,12 +1425,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -639,8 +1452,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -657,6 +1470,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d46837a0ed51fe95bd3b05de33cd64a1ee88fc797477ca48446872504507c5"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -666,14 +1512,47 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
  "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http 1.4.0",
+ "hyper 1.9.0",
+ "hyper-util",
+ "rustls 0.23.40",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower-service",
 ]
 
 [[package]]
@@ -682,13 +1561,21 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64",
  "bytes",
- "http",
- "http-body",
- "hyper",
+ "futures-channel",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -837,10 +1724,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
 
 [[package]]
 name = "js-sys"
@@ -925,6 +1828,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -946,7 +1858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -992,10 +1904,16 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -1032,6 +1950,29 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "sha2 0.10.9",
+]
 
 [[package]]
 name = "parking"
@@ -1090,14 +2031,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -1106,8 +2063,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1130,6 +2087,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -1170,6 +2133,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1181,8 +2150,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1192,7 +2171,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1202,6 +2191,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1246,10 +2244,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac 0.12.1",
+ "zeroize",
+]
 
 [[package]]
 name = "ring"
@@ -1271,18 +2286,39 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
- "rand_core",
- "signature",
- "spki",
+ "pkcs8 0.10.2",
+ "rand_core 0.6.4",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -1291,12 +2327,25 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -1310,10 +2359,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1332,10 +2392,66 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -1416,8 +2532,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1427,8 +2543,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -1458,12 +2585,22 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
- "rand_core",
+ "digest 0.10.7",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1479,6 +2616,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1502,12 +2649,22 @@ dependencies = [
 
 [[package]]
 name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
+name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -1547,10 +2704,10 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.40",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror",
  "tokio",
@@ -1589,7 +2746,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -1612,7 +2769,7 @@ dependencies = [
  "bytes",
  "chrono",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -1622,18 +2779,18 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
  "md-5",
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -1662,17 +2819,17 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -1789,6 +2946,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1825,7 +3012,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -1842,12 +3029,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls 0.23.40",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
  "pin-project-lite",
  "tokio",
 ]
@@ -1956,6 +3176,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,6 +3237,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -2084,6 +3316,21 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
 
 [[package]]
 name = "wasi"
@@ -2528,6 +3775,12 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,3 +27,5 @@ sha2 = "0.10"
 tower-http = { version = "0.6", features = ["request-id", "util"] }
 tower = "0.5"
 http = "1"
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -18,6 +18,8 @@ serde_json = { workspace = true }
 sha2 = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-s3 = { workspace = true }
 
 [dev-dependencies]
 http-body-util = "0.1"

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -91,6 +91,18 @@ impl AppError {
         Self::new(ErrorCode::ValidationFailed, message, request_id)
     }
 
+    pub fn not_found(message: impl Into<String>, request_id: impl Into<String>) -> Self {
+        Self::new(ErrorCode::NotFound, message, request_id)
+    }
+
+    pub fn conflict(message: impl Into<String>, request_id: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Conflict, message, request_id)
+    }
+
+    pub fn gone(message: impl Into<String>, request_id: impl Into<String>) -> Self {
+        Self::new(ErrorCode::Gone, message, request_id)
+    }
+
     pub fn internal_error(message: impl Into<String>, request_id: impl Into<String>) -> Self {
         Self::new(ErrorCode::InternalError, message, request_id)
     }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -4,17 +4,20 @@ pub mod extractors;
 pub mod middleware;
 pub mod routes;
 
-use axum::{Json, Router};
+use axum::{Extension, Json, Router};
 use sqlx::PgPool;
 use utoipa::openapi::security::{Http, HttpAuthScheme, SecurityScheme};
 use utoipa::{Modify, OpenApi};
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_axum::routes;
 
-pub fn create_app(pool: PgPool) -> Router {
+pub fn create_app(pool: PgPool, s3_client: Option<aws_sdk_s3::Client>) -> Router {
     let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
         .routes(routes!(routes::health::healthz))
         .routes(routes!(routes::plan::plan_run))
+        .routes(routes!(routes::board_run::create_board_run))
+        .routes(routes!(routes::board_run::fail_board_run))
+        .routes(routes!(routes::board_run::import_artifact_bundle))
         .split_for_parts();
 
     router
@@ -25,6 +28,7 @@ pub fn create_app(pool: PgPool) -> Router {
                 move || async move { Json(api) }
             }),
         )
+        .layer(Extension(s3_client))
         .layer(axum::middleware::from_fn(
             middleware::request_id::request_id_middleware,
         ))

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -15,7 +15,27 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let pool = boardflow_db::create_pool(&config.database_url).await?;
     tracing::info!("Database connection established");
 
-    let app = boardflow_api::create_app(pool);
+    let s3_client = if let Some(endpoint) = &config.minio_endpoint {
+        let creds = aws_sdk_s3::config::Credentials::new(
+            config.minio_access_key.as_deref().unwrap_or("minioadmin"),
+            config.minio_secret_key.as_deref().unwrap_or("minioadmin"),
+            None,
+            None,
+            "env",
+        );
+        let s3_config = aws_sdk_s3::Config::builder()
+            .endpoint_url(endpoint)
+            .region(aws_sdk_s3::config::Region::new("us-east-1"))
+            .credentials_provider(creds)
+            .force_path_style(true)
+            .behavior_version_latest()
+            .build();
+        Some(aws_sdk_s3::Client::from_conf(s3_config))
+    } else {
+        None
+    };
+
+    let app = boardflow_api::create_app(pool, s3_client);
 
     let addr = format!("{}:{}", config.api_host, config.api_port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/crates/api/src/routes/board_run.rs
+++ b/crates/api/src/routes/board_run.rs
@@ -433,18 +433,25 @@ pub async fn import_artifact_bundle(
     let board_run_id = parse_board_run_id(&board_run_id_str)
         .ok_or_else(|| AppError::validation_failed("invalid board_run_id format", rid))?;
 
-    // 2. Find board_run
-    let board_run = boardflow_db::queries::board_run::find_by_id(&pool, board_run_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("board_run lookup failed: {e}");
-            AppError::internal_error("database error", rid)
-        })?
-        .ok_or_else(|| AppError::not_found("board run not found", rid))?;
+    // 2. Begin transaction BEFORE any DB reads
+    let mut tx = pool.begin().await.map_err(|e| {
+        tracing::error!("transaction begin failed: {e}");
+        AppError::internal_error("database error", rid)
+    })?;
 
-    // 3. Verify ownership via board_project
+    // 3. Find board_run with FOR UPDATE lock
+    let board_run =
+        boardflow_db::queries::board_run::find_by_id_for_update(&mut *tx, board_run_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("board_run lookup failed: {e}");
+                AppError::internal_error("database error", rid)
+            })?
+            .ok_or_else(|| AppError::not_found("board run not found", rid))?;
+
+    // 4. Verify ownership via board_project
     let board_project =
-        boardflow_db::queries::board_project::find_by_id(&pool, board_run.board_project_id)
+        boardflow_db::queries::board_project::find_by_id(&mut *tx, board_run.board_project_id)
             .await
             .map_err(|e| {
                 tracing::error!("board_project lookup failed: {e}");
@@ -459,24 +466,28 @@ pub async fn import_artifact_bundle(
         ));
     }
 
-    // 4. Check run status
+    // 5. Check run status
     match board_run.status {
         BoardRunStatus::Failed | BoardRunStatus::TimedOut => {
-            return Err(AppError::gone(
-                "board run is no longer active",
-                rid,
-            ));
+            return Err(AppError::gone("board run is no longer active", rid));
         }
         BoardRunStatus::Completed => {
             // Return existing bundle info
             if let Some(bundle) =
-                boardflow_db::queries::artifact_bundle::find_by_board_run_id(&pool, board_run_id)
-                    .await
-                    .map_err(|e| {
-                        tracing::error!("artifact_bundle lookup failed: {e}");
-                        AppError::internal_error("database error", rid)
-                    })?
+                boardflow_db::queries::artifact_bundle::find_by_board_run_id(
+                    &mut *tx,
+                    board_run_id,
+                )
+                .await
+                .map_err(|e| {
+                    tracing::error!("artifact_bundle lookup failed: {e}");
+                    AppError::internal_error("database error", rid)
+                })?
             {
+                tx.commit().await.map_err(|e| {
+                    tracing::error!("transaction commit failed: {e}");
+                    AppError::internal_error("database error", rid)
+                })?;
                 return Ok(Json(ImportArtifactBundleResponse {
                     bundle_id: format_bundle_id(bundle.id),
                     status: "completed".to_string(),
@@ -490,9 +501,9 @@ pub async fn import_artifact_bundle(
         _ => {}
     }
 
-    // 5. Idempotency check: same key + sha256
+    // 6. Idempotency check: same key + sha256 (within tx)
     if let Some(existing) = boardflow_db::queries::artifact_bundle::find_by_import_key(
-        &pool,
+        &mut *tx,
         board_run_id,
         &req.staging_object_key,
         &req.bundle_sha256,
@@ -502,34 +513,32 @@ pub async fn import_artifact_bundle(
         tracing::error!("idempotency check failed: {e}");
         AppError::internal_error("database error", rid)
     })? {
+        tx.commit().await.map_err(|e| {
+            tracing::error!("transaction commit failed: {e}");
+            AppError::internal_error("database error", rid)
+        })?;
         return Ok(Json(ImportArtifactBundleResponse {
             bundle_id: format_bundle_id(existing.id),
             status: "queued".to_string(),
         }));
     }
 
-    // 6. Conflict check: different staging_object_key or sha256 for same run
-    if let Some(_existing) = boardflow_db::queries::artifact_bundle::find_existing_for_run(
-        &pool, board_run_id,
-    )
-    .await
-    .map_err(|e| {
-        tracing::error!("conflict check failed: {e}");
-        AppError::internal_error("database error", rid)
-    })? {
+    // 7. Conflict check: different staging_object_key or sha256 for same run (within tx)
+    if let Some(_existing) =
+        boardflow_db::queries::artifact_bundle::find_existing_for_run(&mut *tx, board_run_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("conflict check failed: {e}");
+                AppError::internal_error("database error", rid)
+            })?
+    {
         return Err(AppError::conflict(
             "different bundle already submitted for this run",
             rid,
         ));
     }
 
-    // 7. Begin transaction for bundle update + mark_importing + enqueue
-    let mut tx = pool.begin().await.map_err(|e| {
-        tracing::error!("transaction begin failed: {e}");
-        AppError::internal_error("database error", rid)
-    })?;
-
-    // 7a. Find or create ArtifactBundle and update for import
+    // 8. Find or create ArtifactBundle and update for import
     let bundle = match boardflow_db::queries::artifact_bundle::find_by_board_run_id(
         &mut *tx,
         board_run_id,
@@ -539,22 +548,10 @@ pub async fn import_artifact_bundle(
         tracing::error!("artifact_bundle lookup failed: {e}");
         AppError::internal_error("database error", rid)
     })? {
-        Some(existing_bundle) => {
-            boardflow_db::queries::artifact_bundle::update_for_import(
-                &mut *tx,
-                existing_bundle.id,
-                &req.bundle_sha256,
-                req.bundle_size_bytes,
-            )
-            .await
-            .map_err(|e| {
-                tracing::error!("artifact_bundle update failed: {e}");
-                AppError::internal_error("database error", rid)
-            })?
-        }
+        Some(existing_bundle) => existing_bundle,
         None => {
             let bundle_id = Uuid::now_v7();
-            let bundle = boardflow_db::queries::artifact_bundle::insert_staging(
+            boardflow_db::queries::artifact_bundle::insert_staging(
                 &mut *tx,
                 bundle_id,
                 board_run_id,
@@ -564,22 +561,34 @@ pub async fn import_artifact_bundle(
             .map_err(|e| {
                 tracing::error!("artifact_bundle insert failed: {e}");
                 AppError::internal_error("database error", rid)
-            })?;
-            boardflow_db::queries::artifact_bundle::update_for_import(
-                &mut *tx,
-                bundle.id,
-                &req.bundle_sha256,
-                req.bundle_size_bytes,
-            )
-            .await
-            .map_err(|e| {
-                tracing::error!("artifact_bundle update failed: {e}");
-                AppError::internal_error("database error", rid)
             })?
         }
     };
 
-    // 7b. Mark run as importing
+    let updated = boardflow_db::queries::artifact_bundle::update_for_import(
+        &mut *tx,
+        bundle.id,
+        &req.staging_object_key,
+        &req.bundle_sha256,
+        req.bundle_size_bytes,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("artifact_bundle update failed: {e}");
+        AppError::internal_error("database error", rid)
+    })?;
+
+    let bundle = match updated {
+        Some(b) => b,
+        None => {
+            return Err(AppError::conflict(
+                "bundle was concurrently modified",
+                rid,
+            ));
+        }
+    };
+
+    // 9. Mark run as importing
     boardflow_db::queries::board_run::mark_importing(&mut *tx, board_run_id)
         .await
         .map_err(|e| {
@@ -587,7 +596,7 @@ pub async fn import_artifact_bundle(
             AppError::internal_error("database error", rid)
         })?;
 
-    // 7c. Enqueue import job
+    // 10. Enqueue import job
     let job_id = Uuid::now_v7();
     let payload_json = serde_json::json!({
         "bundle_id": bundle.id.to_string(),
@@ -611,7 +620,7 @@ pub async fn import_artifact_bundle(
         AppError::internal_error("database error", rid)
     })?;
 
-    // 7d. Commit transaction
+    // 11. Commit transaction
     tx.commit().await.map_err(|e| {
         tracing::error!("transaction commit failed: {e}");
         AppError::internal_error("database error", rid)

--- a/crates/api/src/routes/board_run.rs
+++ b/crates/api/src/routes/board_run.rs
@@ -1,0 +1,610 @@
+use axum::extract::rejection::JsonRejection;
+use axum::extract::{Path, State};
+use axum::{Extension, Json};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use boardflow_domain::models::board_run::BoardRunStatus;
+
+use crate::error::{AppError, RequestId};
+use crate::extractors::AuthenticatedToken;
+
+// ─── ID prefix helpers ───────────────────────────────────────────────────────
+
+fn parse_board_project_id(s: &str) -> Option<Uuid> {
+    s.strip_prefix("bp_").and_then(|v| Uuid::parse_str(v).ok())
+}
+
+fn parse_board_run_id(s: &str) -> Option<Uuid> {
+    s.strip_prefix("br_").and_then(|v| Uuid::parse_str(v).ok())
+}
+
+fn format_board_run_id(id: Uuid) -> String {
+    format!("br_{id}")
+}
+
+fn format_bundle_id(id: Uuid) -> String {
+    format!("ab_{id}")
+}
+
+// ─── Request/Response types ──────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct CreateBoardRunRequest {
+    pub board_project_id: String,
+    pub project_path: String,
+    pub tree_hash: String,
+    pub commit_sha: String,
+    pub branch: String,
+    #[serde(rename = "ref")]
+    pub ref_: String,
+    pub github_run_id: String,
+    pub github_run_attempt: String,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct CreateBoardRunResponse {
+    pub board_run_id: String,
+    pub status: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_bundle: Option<ArtifactBundleInfo>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ArtifactBundleInfo {
+    pub upload_mode: String,
+    pub object_key: String,
+    pub upload_url: String,
+    pub method: String,
+    pub expires_at: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct FailBoardRunRequest {
+    pub status: String,
+    pub error: FailErrorInfo,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct FailErrorInfo {
+    pub message: String,
+    #[serde(default)]
+    pub details: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct FailBoardRunResponse {
+    pub board_run_id: String,
+    pub status: String,
+    pub failed_at: String,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct ImportArtifactBundleRequest {
+    pub staging_object_key: String,
+    pub bundle_sha256: String,
+    pub bundle_size_bytes: i64,
+}
+
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ImportArtifactBundleResponse {
+    pub bundle_id: String,
+    pub status: String,
+}
+
+// ─── Presigned URL generation ────────────────────────────────────────────────
+
+async fn generate_upload_info(
+    s3_client: &Option<aws_sdk_s3::Client>,
+    object_key: &str,
+    expires_in_secs: u64,
+) -> Result<ArtifactBundleInfo, AppError> {
+    let bucket = std::env::var("MINIO_BUCKET_STAGING")
+        .unwrap_or_else(|_| "boardflow-staging".to_string());
+
+    match s3_client {
+        Some(client) => {
+            let presigning_config = aws_sdk_s3::presigning::PresigningConfig::expires_in(
+                std::time::Duration::from_secs(expires_in_secs),
+            )
+            .map_err(|_| AppError::internal_error("presigned config error", ""))?;
+
+            let presigned = client
+                .put_object()
+                .bucket(&bucket)
+                .key(object_key)
+                .presigned(presigning_config)
+                .await
+                .map_err(|e| {
+                    tracing::error!("presigned URL generation failed: {e}");
+                    AppError::internal_error("failed to generate upload URL", "")
+                })?;
+
+            let expires_at =
+                chrono::Utc::now() + chrono::Duration::seconds(expires_in_secs as i64);
+            Ok(ArtifactBundleInfo {
+                upload_mode: "staging_s3".to_string(),
+                object_key: object_key.to_string(),
+                upload_url: presigned.uri().to_string(),
+                method: "PUT".to_string(),
+                expires_at: expires_at.to_rfc3339(),
+            })
+        }
+        None => {
+            // Test mode: return placeholder
+            let expires_at =
+                chrono::Utc::now() + chrono::Duration::seconds(expires_in_secs as i64);
+            Ok(ArtifactBundleInfo {
+                upload_mode: "staging_s3".to_string(),
+                object_key: object_key.to_string(),
+                upload_url: format!(
+                    "http://localhost:9000/{bucket}/{object_key}?presigned=test"
+                ),
+                method: "PUT".to_string(),
+                expires_at: expires_at.to_rfc3339(),
+            })
+        }
+    }
+}
+
+// ─── POST /api/v1/board-runs ─────────────────────────────────────────────────
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/board-runs",
+    request_body = CreateBoardRunRequest,
+    responses(
+        (status = 200, description = "Board run created or existing returned", body = CreateBoardRunResponse),
+        (status = 400, description = "Validation error", body = crate::error::ErrorResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+        (status = 403, description = "Forbidden", body = crate::error::ErrorResponse),
+        (status = 500, description = "Internal error", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn create_board_run(
+    auth: AuthenticatedToken,
+    Extension(request_id): Extension<RequestId>,
+    State(pool): State<PgPool>,
+    Extension(s3_client): Extension<Option<aws_sdk_s3::Client>>,
+    payload: Result<Json<CreateBoardRunRequest>, JsonRejection>,
+) -> Result<Json<CreateBoardRunResponse>, AppError> {
+    let rid = &request_id.0;
+    let Json(req) = payload.map_err(|e| AppError::validation_failed(e.body_text(), rid))?;
+
+    // 1. Parse board_project_id
+    let board_project_id = parse_board_project_id(&req.board_project_id)
+        .ok_or_else(|| AppError::validation_failed("invalid board_project_id format", rid))?;
+
+    // 2. Lookup board_project and verify ownership
+    let board_project = boardflow_db::queries::board_project::find_by_id(&pool, board_project_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("board_project lookup failed: {e}");
+            AppError::internal_error("database error", rid)
+        })?
+        .ok_or_else(|| AppError::not_found("board project not found", rid))?;
+
+    if board_project.repository_id != auth.0.repository_id {
+        return Err(AppError::forbidden(
+            "token does not have access to this board project",
+            rid,
+        ));
+    }
+
+    // 3. Parse numeric fields
+    let github_run_id: i64 = req
+        .github_run_id
+        .parse()
+        .map_err(|_| AppError::validation_failed("invalid github_run_id", rid))?;
+    let github_run_attempt: i32 = req
+        .github_run_attempt
+        .parse()
+        .map_err(|_| AppError::validation_failed("invalid github_run_attempt", rid))?;
+
+    // 4. Idempotency check
+    if let Some(existing) = boardflow_db::queries::board_run::find_by_idempotency_key(
+        &pool,
+        board_project_id,
+        github_run_id,
+        github_run_attempt,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("idempotency check failed: {e}");
+        AppError::internal_error("database error", rid)
+    })? {
+        let status_str = match existing.status {
+            BoardRunStatus::Completed => "completed",
+            BoardRunStatus::Failed => "failed",
+            BoardRunStatus::TimedOut => "timed_out",
+            BoardRunStatus::Importing => "importing",
+            BoardRunStatus::Created | BoardRunStatus::Uploading => "created",
+        };
+
+        // For terminal or importing statuses, return without artifact_bundle
+        if matches!(
+            existing.status,
+            BoardRunStatus::Completed
+                | BoardRunStatus::Failed
+                | BoardRunStatus::TimedOut
+                | BoardRunStatus::Importing
+        ) {
+            return Ok(Json(CreateBoardRunResponse {
+                board_run_id: format_board_run_id(existing.id),
+                status: status_str.to_string(),
+                artifact_bundle: None,
+            }));
+        }
+
+        // For created/uploading, generate new presigned URL
+        let object_key = format!(
+            "uploads/{}/{}.zip",
+            board_project_id, existing.id
+        );
+        let upload_info = generate_upload_info(&s3_client, &object_key, 3600).await?;
+        return Ok(Json(CreateBoardRunResponse {
+            board_run_id: format_board_run_id(existing.id),
+            status: status_str.to_string(),
+            artifact_bundle: Some(upload_info),
+        }));
+    }
+
+    // 5. Insert new BoardRun
+    let run_id = Uuid::now_v7();
+    let board_run = boardflow_db::queries::board_run::insert(
+        &pool,
+        run_id,
+        board_project_id,
+        &req.commit_sha,
+        &req.branch,
+        &req.ref_,
+        github_run_id,
+        github_run_attempt,
+        &req.tree_hash,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("board_run insert failed: {e}");
+        AppError::internal_error("database error", rid)
+    })?;
+
+    // 6. Create ArtifactBundle
+    let bundle_id = Uuid::now_v7();
+    let object_key = format!("uploads/{}/{}.zip", board_project_id, board_run.id);
+    boardflow_db::queries::artifact_bundle::insert_staging(&pool, bundle_id, board_run.id, &object_key)
+        .await
+        .map_err(|e| {
+            tracing::error!("artifact_bundle insert failed: {e}");
+            AppError::internal_error("database error", rid)
+        })?;
+
+    // 7. Generate presigned URL
+    let upload_info = generate_upload_info(&s3_client, &object_key, 3600).await?;
+
+    Ok(Json(CreateBoardRunResponse {
+        board_run_id: format_board_run_id(board_run.id),
+        status: "created".to_string(),
+        artifact_bundle: Some(upload_info),
+    }))
+}
+
+// ─── POST /api/v1/board-runs/:board_run_id/fail ──────────────────────────────
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/board-runs/{board_run_id}/fail",
+    params(("board_run_id" = String, Path, description = "Board run ID with br_ prefix")),
+    request_body = FailBoardRunRequest,
+    responses(
+        (status = 200, description = "Board run marked as failed", body = FailBoardRunResponse),
+        (status = 400, description = "Validation error", body = crate::error::ErrorResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+        (status = 403, description = "Forbidden", body = crate::error::ErrorResponse),
+        (status = 404, description = "Not found", body = crate::error::ErrorResponse),
+        (status = 409, description = "Conflict", body = crate::error::ErrorResponse),
+        (status = 410, description = "Gone", body = crate::error::ErrorResponse),
+        (status = 500, description = "Internal error", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn fail_board_run(
+    auth: AuthenticatedToken,
+    Extension(request_id): Extension<RequestId>,
+    State(pool): State<PgPool>,
+    Path(board_run_id_str): Path<String>,
+    payload: Result<Json<FailBoardRunRequest>, JsonRejection>,
+) -> Result<Json<FailBoardRunResponse>, AppError> {
+    let rid = &request_id.0;
+    let _req = payload.map_err(|e| AppError::validation_failed(e.body_text(), rid))?;
+
+    // 1. Parse board_run_id
+    let board_run_id = parse_board_run_id(&board_run_id_str)
+        .ok_or_else(|| AppError::validation_failed("invalid board_run_id format", rid))?;
+
+    // 2. Find board_run
+    let board_run = boardflow_db::queries::board_run::find_by_id(&pool, board_run_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("board_run lookup failed: {e}");
+            AppError::internal_error("database error", rid)
+        })?
+        .ok_or_else(|| AppError::not_found("board run not found", rid))?;
+
+    // 3. Verify ownership via board_project
+    let board_project =
+        boardflow_db::queries::board_project::find_by_id(&pool, board_run.board_project_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("board_project lookup failed: {e}");
+                AppError::internal_error("database error", rid)
+            })?
+            .ok_or_else(|| AppError::internal_error("board project not found", rid))?;
+
+    if board_project.repository_id != auth.0.repository_id {
+        return Err(AppError::forbidden(
+            "token does not have access to this board run",
+            rid,
+        ));
+    }
+
+    // 4. Check status
+    match board_run.status {
+        BoardRunStatus::Failed => {
+            // Idempotent: already failed
+            let failed_at = board_run
+                .completed_at
+                .unwrap_or_else(chrono::Utc::now)
+                .to_rfc3339();
+            return Ok(Json(FailBoardRunResponse {
+                board_run_id: format_board_run_id(board_run.id),
+                status: "failed".to_string(),
+                failed_at,
+            }));
+        }
+        BoardRunStatus::Completed => {
+            return Err(AppError::conflict(
+                "board run is already completed",
+                rid,
+            ));
+        }
+        BoardRunStatus::TimedOut => {
+            return Err(AppError::gone("board run has timed out", rid));
+        }
+        _ => {
+            // created, uploading, importing → mark failed
+        }
+    }
+
+    // 5. Mark failed
+    let updated = boardflow_db::queries::board_run::mark_failed(&pool, board_run_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("mark_failed failed: {e}");
+            AppError::internal_error("database error", rid)
+        })?;
+
+    let failed_at = updated
+        .completed_at
+        .unwrap_or_else(chrono::Utc::now)
+        .to_rfc3339();
+
+    Ok(Json(FailBoardRunResponse {
+        board_run_id: format_board_run_id(updated.id),
+        status: "failed".to_string(),
+        failed_at,
+    }))
+}
+
+// ─── POST /api/v1/board-runs/:board_run_id/artifact-bundles/import ───────────
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/board-runs/{board_run_id}/artifact-bundles/import",
+    params(("board_run_id" = String, Path, description = "Board run ID with br_ prefix")),
+    request_body = ImportArtifactBundleRequest,
+    responses(
+        (status = 200, description = "Import queued or existing returned", body = ImportArtifactBundleResponse),
+        (status = 400, description = "Validation error", body = crate::error::ErrorResponse),
+        (status = 401, description = "Unauthorized", body = crate::error::ErrorResponse),
+        (status = 403, description = "Forbidden", body = crate::error::ErrorResponse),
+        (status = 404, description = "Not found", body = crate::error::ErrorResponse),
+        (status = 409, description = "Conflict", body = crate::error::ErrorResponse),
+        (status = 410, description = "Gone", body = crate::error::ErrorResponse),
+        (status = 500, description = "Internal error", body = crate::error::ErrorResponse),
+    ),
+    security(("bearer_auth" = []))
+)]
+pub async fn import_artifact_bundle(
+    auth: AuthenticatedToken,
+    Extension(request_id): Extension<RequestId>,
+    State(pool): State<PgPool>,
+    Path(board_run_id_str): Path<String>,
+    payload: Result<Json<ImportArtifactBundleRequest>, JsonRejection>,
+) -> Result<Json<ImportArtifactBundleResponse>, AppError> {
+    let rid = &request_id.0;
+    let Json(req) = payload.map_err(|e| AppError::validation_failed(e.body_text(), rid))?;
+
+    // 1. Parse board_run_id
+    let board_run_id = parse_board_run_id(&board_run_id_str)
+        .ok_or_else(|| AppError::validation_failed("invalid board_run_id format", rid))?;
+
+    // 2. Find board_run
+    let board_run = boardflow_db::queries::board_run::find_by_id(&pool, board_run_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("board_run lookup failed: {e}");
+            AppError::internal_error("database error", rid)
+        })?
+        .ok_or_else(|| AppError::not_found("board run not found", rid))?;
+
+    // 3. Verify ownership via board_project
+    let board_project =
+        boardflow_db::queries::board_project::find_by_id(&pool, board_run.board_project_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("board_project lookup failed: {e}");
+                AppError::internal_error("database error", rid)
+            })?
+            .ok_or_else(|| AppError::internal_error("board project not found", rid))?;
+
+    if board_project.repository_id != auth.0.repository_id {
+        return Err(AppError::forbidden(
+            "token does not have access to this board run",
+            rid,
+        ));
+    }
+
+    // 4. Check run status
+    match board_run.status {
+        BoardRunStatus::Failed | BoardRunStatus::TimedOut => {
+            return Err(AppError::gone(
+                "board run is no longer active",
+                rid,
+            ));
+        }
+        BoardRunStatus::Completed => {
+            // Return existing bundle info
+            if let Some(bundle) =
+                boardflow_db::queries::artifact_bundle::find_by_board_run_id(&pool, board_run_id)
+                    .await
+                    .map_err(|e| {
+                        tracing::error!("artifact_bundle lookup failed: {e}");
+                        AppError::internal_error("database error", rid)
+                    })?
+            {
+                return Ok(Json(ImportArtifactBundleResponse {
+                    bundle_id: format_bundle_id(bundle.id),
+                    status: "completed".to_string(),
+                }));
+            }
+            return Err(AppError::internal_error(
+                "completed run has no artifact bundle",
+                rid,
+            ));
+        }
+        _ => {}
+    }
+
+    // 5. Idempotency check: same key + sha256
+    if let Some(existing) = boardflow_db::queries::artifact_bundle::find_by_import_key(
+        &pool,
+        board_run_id,
+        &req.staging_object_key,
+        &req.bundle_sha256,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("idempotency check failed: {e}");
+        AppError::internal_error("database error", rid)
+    })? {
+        return Ok(Json(ImportArtifactBundleResponse {
+            bundle_id: format_bundle_id(existing.id),
+            status: "queued".to_string(),
+        }));
+    }
+
+    // 6. Conflict check: different sha256 for same run
+    if let Some(_existing) = boardflow_db::queries::artifact_bundle::find_existing_for_run(
+        &pool, board_run_id,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("conflict check failed: {e}");
+        AppError::internal_error("database error", rid)
+    })? {
+        return Err(AppError::conflict(
+            "a different artifact bundle has already been imported for this run",
+            rid,
+        ));
+    }
+
+    // 7. Find or create ArtifactBundle and update for import
+    let bundle = match boardflow_db::queries::artifact_bundle::find_by_board_run_id(
+        &pool,
+        board_run_id,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("artifact_bundle lookup failed: {e}");
+        AppError::internal_error("database error", rid)
+    })? {
+        Some(existing_bundle) => {
+            boardflow_db::queries::artifact_bundle::update_for_import(
+                &pool,
+                existing_bundle.id,
+                &req.bundle_sha256,
+                req.bundle_size_bytes,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("artifact_bundle update failed: {e}");
+                AppError::internal_error("database error", rid)
+            })?
+        }
+        None => {
+            let bundle_id = Uuid::now_v7();
+            let bundle = boardflow_db::queries::artifact_bundle::insert_staging(
+                &pool,
+                bundle_id,
+                board_run_id,
+                &req.staging_object_key,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("artifact_bundle insert failed: {e}");
+                AppError::internal_error("database error", rid)
+            })?;
+            boardflow_db::queries::artifact_bundle::update_for_import(
+                &pool,
+                bundle.id,
+                &req.bundle_sha256,
+                req.bundle_size_bytes,
+            )
+            .await
+            .map_err(|e| {
+                tracing::error!("artifact_bundle update failed: {e}");
+                AppError::internal_error("database error", rid)
+            })?
+        }
+    };
+
+    // 8. Mark run as importing
+    boardflow_db::queries::board_run::mark_importing(&pool, board_run_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("mark_importing failed: {e}");
+            AppError::internal_error("database error", rid)
+        })?;
+
+    // 9. Enqueue import job
+    let job_id = Uuid::now_v7();
+    let payload_json = serde_json::json!({
+        "bundle_id": bundle.id.to_string(),
+        "board_run_id": board_run_id.to_string(),
+        "staging_object_key": req.staging_object_key,
+        "bundle_sha256": req.bundle_sha256,
+        "bundle_size_bytes": req.bundle_size_bytes,
+    });
+    boardflow_db::queries::github_job::enqueue_import(
+        &pool,
+        job_id,
+        auth.0.installation_id,
+        board_project.repository_id,
+        board_project.id,
+        board_run_id,
+        &payload_json,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("enqueue_import failed: {e}");
+        AppError::internal_error("database error", rid)
+    })?;
+
+    Ok(Json(ImportArtifactBundleResponse {
+        bundle_id: format_bundle_id(bundle.id),
+        status: "queued".to_string(),
+    }))
+}

--- a/crates/api/src/routes/board_run.rs
+++ b/crates/api/src/routes/board_run.rs
@@ -6,6 +6,7 @@ use sqlx::PgPool;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
+use boardflow_domain::models::artifact_bundle::ArtifactBundleStatus;
 use boardflow_domain::models::board_run::BoardRunStatus;
 
 use crate::error::{AppError, RequestId};
@@ -27,6 +28,16 @@ fn format_board_run_id(id: Uuid) -> String {
 
 fn format_bundle_id(id: Uuid) -> String {
     format!("ab_{id}")
+}
+
+fn bundle_status_str(status: ArtifactBundleStatus) -> &'static str {
+    match status {
+        ArtifactBundleStatus::Pending => "queued",
+        ArtifactBundleStatus::Validating => "running",
+        ArtifactBundleStatus::Importing => "running",
+        ArtifactBundleStatus::Completed => "completed",
+        ArtifactBundleStatus::Failed => "failed",
+    }
 }
 
 // ─── Request/Response types ──────────────────────────────────────────────────
@@ -490,7 +501,7 @@ pub async fn import_artifact_bundle(
                 })?;
                 return Ok(Json(ImportArtifactBundleResponse {
                     bundle_id: format_bundle_id(bundle.id),
-                    status: "completed".to_string(),
+                    status: bundle_status_str(bundle.status).to_string(),
                 }));
             }
             return Err(AppError::internal_error(
@@ -519,7 +530,7 @@ pub async fn import_artifact_bundle(
         })?;
         return Ok(Json(ImportArtifactBundleResponse {
             bundle_id: format_bundle_id(existing.id),
-            status: "queued".to_string(),
+            status: bundle_status_str(existing.status).to_string(),
         }));
     }
 

--- a/crates/api/src/routes/board_run.rs
+++ b/crates/api/src/routes/board_run.rs
@@ -240,10 +240,7 @@ pub async fn create_board_run(
         }
 
         // For created/uploading, generate new presigned URL
-        let object_key = format!(
-            "uploads/{}/{}.zip",
-            board_project_id, existing.id
-        );
+        let object_key = format!("staging/runs/{}/bundle.zip", format_board_run_id(existing.id));
         let upload_info = generate_upload_info(&s3_client, &object_key, 3600).await?;
         return Ok(Json(CreateBoardRunResponse {
             board_run_id: format_board_run_id(existing.id),
@@ -273,7 +270,7 @@ pub async fn create_board_run(
 
     // 6. Create ArtifactBundle
     let bundle_id = Uuid::now_v7();
-    let object_key = format!("uploads/{}/{}.zip", board_project_id, board_run.id);
+    let object_key = format!("staging/runs/{}/bundle.zip", format_board_run_id(board_run.id));
     boardflow_db::queries::artifact_bundle::insert_staging(&pool, bundle_id, board_run.id, &object_key)
         .await
         .map_err(|e| {
@@ -318,13 +315,18 @@ pub async fn fail_board_run(
     payload: Result<Json<FailBoardRunRequest>, JsonRejection>,
 ) -> Result<Json<FailBoardRunResponse>, AppError> {
     let rid = &request_id.0;
-    let _req = payload.map_err(|e| AppError::validation_failed(e.body_text(), rid))?;
+    let Json(req) = payload.map_err(|e| AppError::validation_failed(e.body_text(), rid))?;
 
-    // 1. Parse board_run_id
+    // 1. Validate status field
+    if req.status != "failed" {
+        return Err(AppError::validation_failed("status must be 'failed'", rid));
+    }
+
+    // 2. Parse board_run_id
     let board_run_id = parse_board_run_id(&board_run_id_str)
         .ok_or_else(|| AppError::validation_failed("invalid board_run_id format", rid))?;
 
-    // 2. Find board_run
+    // 3. Find board_run
     let board_run = boardflow_db::queries::board_run::find_by_id(&pool, board_run_id)
         .await
         .map_err(|e| {
@@ -333,7 +335,7 @@ pub async fn fail_board_run(
         })?
         .ok_or_else(|| AppError::not_found("board run not found", rid))?;
 
-    // 3. Verify ownership via board_project
+    // 4. Verify ownership via board_project
     let board_project =
         boardflow_db::queries::board_project::find_by_id(&pool, board_run.board_project_id)
             .await
@@ -350,7 +352,7 @@ pub async fn fail_board_run(
         ));
     }
 
-    // 4. Check status
+    // 5. Check status
     match board_run.status {
         BoardRunStatus::Failed => {
             // Idempotent: already failed
@@ -378,7 +380,7 @@ pub async fn fail_board_run(
         }
     }
 
-    // 5. Mark failed
+    // 6. Mark failed
     let updated = boardflow_db::queries::board_run::mark_failed(&pool, board_run_id)
         .await
         .map_err(|e| {
@@ -506,7 +508,7 @@ pub async fn import_artifact_bundle(
         }));
     }
 
-    // 6. Conflict check: different sha256 for same run
+    // 6. Conflict check: different staging_object_key or sha256 for same run
     if let Some(_existing) = boardflow_db::queries::artifact_bundle::find_existing_for_run(
         &pool, board_run_id,
     )
@@ -516,14 +518,20 @@ pub async fn import_artifact_bundle(
         AppError::internal_error("database error", rid)
     })? {
         return Err(AppError::conflict(
-            "a different artifact bundle has already been imported for this run",
+            "different bundle already submitted for this run",
             rid,
         ));
     }
 
-    // 7. Find or create ArtifactBundle and update for import
+    // 7. Begin transaction for bundle update + mark_importing + enqueue
+    let mut tx = pool.begin().await.map_err(|e| {
+        tracing::error!("transaction begin failed: {e}");
+        AppError::internal_error("database error", rid)
+    })?;
+
+    // 7a. Find or create ArtifactBundle and update for import
     let bundle = match boardflow_db::queries::artifact_bundle::find_by_board_run_id(
-        &pool,
+        &mut *tx,
         board_run_id,
     )
     .await
@@ -533,7 +541,7 @@ pub async fn import_artifact_bundle(
     })? {
         Some(existing_bundle) => {
             boardflow_db::queries::artifact_bundle::update_for_import(
-                &pool,
+                &mut *tx,
                 existing_bundle.id,
                 &req.bundle_sha256,
                 req.bundle_size_bytes,
@@ -547,7 +555,7 @@ pub async fn import_artifact_bundle(
         None => {
             let bundle_id = Uuid::now_v7();
             let bundle = boardflow_db::queries::artifact_bundle::insert_staging(
-                &pool,
+                &mut *tx,
                 bundle_id,
                 board_run_id,
                 &req.staging_object_key,
@@ -558,7 +566,7 @@ pub async fn import_artifact_bundle(
                 AppError::internal_error("database error", rid)
             })?;
             boardflow_db::queries::artifact_bundle::update_for_import(
-                &pool,
+                &mut *tx,
                 bundle.id,
                 &req.bundle_sha256,
                 req.bundle_size_bytes,
@@ -571,15 +579,15 @@ pub async fn import_artifact_bundle(
         }
     };
 
-    // 8. Mark run as importing
-    boardflow_db::queries::board_run::mark_importing(&pool, board_run_id)
+    // 7b. Mark run as importing
+    boardflow_db::queries::board_run::mark_importing(&mut *tx, board_run_id)
         .await
         .map_err(|e| {
             tracing::error!("mark_importing failed: {e}");
             AppError::internal_error("database error", rid)
         })?;
 
-    // 9. Enqueue import job
+    // 7c. Enqueue import job
     let job_id = Uuid::now_v7();
     let payload_json = serde_json::json!({
         "bundle_id": bundle.id.to_string(),
@@ -589,7 +597,7 @@ pub async fn import_artifact_bundle(
         "bundle_size_bytes": req.bundle_size_bytes,
     });
     boardflow_db::queries::github_job::enqueue_import(
-        &pool,
+        &mut *tx,
         job_id,
         auth.0.installation_id,
         board_project.repository_id,
@@ -600,6 +608,12 @@ pub async fn import_artifact_bundle(
     .await
     .map_err(|e| {
         tracing::error!("enqueue_import failed: {e}");
+        AppError::internal_error("database error", rid)
+    })?;
+
+    // 7d. Commit transaction
+    tx.commit().await.map_err(|e| {
+        tracing::error!("transaction commit failed: {e}");
         AppError::internal_error("database error", rid)
     })?;
 

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -1,2 +1,3 @@
+pub mod board_run;
 pub mod health;
 pub mod plan;

--- a/crates/api/tests/board_run_test.rs
+++ b/crates/api/tests/board_run_test.rs
@@ -955,3 +955,90 @@ async fn test_import_artifact_bundle_not_found() {
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }
+
+/// Race condition: 先着リクエスト成功後、後着が異なる sha256 で 409 になることを確認
+/// (トランザクション内で conflict 判定が行われることを順次実行で擬似テスト)
+#[tokio::test]
+async fn test_import_artifact_bundle_update_conflict() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2019;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "created").await;
+
+    // Create an artifact_bundle for this run (sha256 is NULL initially)
+    let bundle_id = Uuid::now_v7();
+    let object_key = format!("staging/runs/br_{}/bundle.zip", br_id);
+    sqlx::query(
+        "INSERT INTO artifact_bundles (id, board_run_id, intake_mode, staging_object_key, status, received_at) \
+         VALUES ($1, $2, 'staging_s3', $3, 'pending', NOW())",
+    )
+    .bind(bundle_id)
+    .bind(br_id)
+    .bind(&object_key)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // First request: import succeeds with sha256_a
+    let app = create_app(pool.clone(), None);
+    let body1 = serde_json::json!({
+        "staging_object_key": object_key,
+        "bundle_sha256": "aaaa1234567890abcdef1234567890abcdef1234567890abcdef1234567890aa",
+        "bundle_size_bytes": 10000
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/board-runs/br_{}/artifact-bundles/import",
+                    br_id
+                ))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body1).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(json["status"], "queued");
+
+    // Second request: different sha256 → should get 409 Conflict
+    // (The bundle already has sha256 set from the first request)
+    let app = create_app(pool.clone(), None);
+    let body2 = serde_json::json!({
+        "staging_object_key": object_key,
+        "bundle_sha256": "bbbb1234567890abcdef1234567890abcdef1234567890abcdef1234567890bb",
+        "bundle_size_bytes": 20000
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!(
+                    "/api/v1/board-runs/br_{}/artifact-bundles/import",
+                    br_id
+                ))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body2).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}

--- a/crates/api/tests/board_run_test.rs
+++ b/crates/api/tests/board_run_test.rs
@@ -1,0 +1,679 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use boardflow_api::create_app;
+use http_body_util::BodyExt;
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+async fn setup_pool() -> Option<PgPool> {
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("Skipping test: DATABASE_URL not set");
+            return None;
+        }
+    };
+    let pool = PgPool::connect(&database_url).await.unwrap();
+    sqlx::migrate!("../db/migrations").run(&pool).await.unwrap();
+    Some(pool)
+}
+
+async fn create_test_token(pool: &PgPool, repository_id: Uuid, installation_id: i64) -> String {
+    let raw_token = format!("test_token_{}", Uuid::now_v7());
+    let mut hasher = Sha256::new();
+    hasher.update(raw_token.as_bytes());
+    let token_hash = format!("{:x}", hasher.finalize());
+    let token_id = Uuid::now_v7();
+
+    sqlx::query(
+        "INSERT INTO boardflow_api_tokens (id, installation_id, repository_id, name, token_hash, created_at) \
+         VALUES ($1, $2, $3, $4, $5, NOW())",
+    )
+    .bind(token_id)
+    .bind(installation_id)
+    .bind(repository_id)
+    .bind("test-token")
+    .bind(&token_hash)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    raw_token
+}
+
+async fn create_test_repository(pool: &PgPool, github_repository_id: i64, installation_id: i64) -> Uuid {
+    let id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO repositories (id, github_repository_id, owner, name, installation_id, created_at, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, NOW(), NOW()) \
+         ON CONFLICT (github_repository_id) DO UPDATE SET updated_at = NOW() \
+         RETURNING id",
+    )
+    .bind(id)
+    .bind(github_repository_id)
+    .bind("test-owner")
+    .bind("test-repo")
+    .bind(installation_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn create_test_board_project(pool: &PgPool, repository_id: Uuid) -> Uuid {
+    let id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO board_projects (id, repository_id, project_path, project_dir, display_name, \
+         issue_sync_status, recreate_issue_on_update, created_at, updated_at) \
+         VALUES ($1, $2, $3, $4, $5, 'pending', true, NOW(), NOW()) \
+         ON CONFLICT (repository_id, project_path) DO UPDATE SET updated_at = NOW() \
+         RETURNING id",
+    )
+    .bind(id)
+    .bind(repository_id)
+    .bind(format!("hardware/Project_{}.kicad_pro", id))
+    .bind("hardware")
+    .bind("TestProject")
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+async fn create_test_board_run(pool: &PgPool, board_project_id: Uuid, status: &str) -> Uuid {
+    let id = Uuid::now_v7();
+    let run_id = rand_i64();
+    sqlx::query(
+        "INSERT INTO board_runs (id, board_project_id, commit_sha, branch, ref, github_run_id, github_run_attempt, \
+         tree_hash, status, erc_errors, erc_warnings, drc_errors, drc_warnings, review_status, diff_status, created_at, completed_at) \
+         VALUES ($1, $2, 'abc123', 'main', 'refs/heads/main', $3, 1, 'treehash', $4, 0, 0, 0, 0, 'pending', 'pending', NOW(), \
+         CASE WHEN $4 IN ('failed', 'completed', 'timed_out') THEN NOW() ELSE NULL END)",
+    )
+    .bind(id)
+    .bind(board_project_id)
+    .bind(run_id)
+    .bind(status)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+fn rand_i64() -> i64 {
+    let uuid = Uuid::now_v7();
+    let bytes = uuid.as_bytes();
+    i64::from_be_bytes(bytes[0..8].try_into().unwrap()).abs()
+}
+
+// ─── POST /api/v1/board-runs ─────────────────────────────────────────────────
+
+/// 正常系: board run 作成成功、presigned URL 取得
+#[tokio::test]
+async fn test_create_board_run_success() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2001;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "board_project_id": format!("bp_{}", bp_id),
+        "project_path": "hardware/Test.kicad_pro",
+        "tree_hash": "deadbeef123",
+        "commit_sha": "abc123",
+        "branch": "main",
+        "ref": "refs/heads/main",
+        "github_run_id": "99999",
+        "github_run_attempt": "1"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/board-runs")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(json["board_run_id"].as_str().unwrap().starts_with("br_"));
+    assert_eq!(json["status"], "created");
+    assert!(json["artifact_bundle"].is_object());
+    assert_eq!(json["artifact_bundle"]["upload_mode"], "staging_s3");
+    assert_eq!(json["artifact_bundle"]["method"], "PUT");
+    assert!(json["artifact_bundle"]["upload_url"].as_str().unwrap().contains("presigned=test"));
+}
+
+/// 冪等性: 同じ run_id + attempt で再送すると同じ結果
+#[tokio::test]
+async fn test_create_board_run_idempotent() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2002;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+
+    let run_id_val = rand_i64().to_string();
+    let body = serde_json::json!({
+        "board_project_id": format!("bp_{}", bp_id),
+        "project_path": "hardware/Test.kicad_pro",
+        "tree_hash": "deadbeef123",
+        "commit_sha": "abc123",
+        "branch": "main",
+        "ref": "refs/heads/main",
+        "github_run_id": run_id_val,
+        "github_run_attempt": "1"
+    });
+
+    // First request
+    let app = create_app(pool.clone(), None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/board-runs")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json1: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    // Second request (same payload)
+    let app = create_app(pool, None);
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/board-runs")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json2: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(json1["board_run_id"], json2["board_run_id"]);
+}
+
+/// 認証なし → 401
+#[tokio::test]
+async fn test_create_board_run_unauthorized() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "board_project_id": "bp_00000000-0000-0000-0000-000000000000",
+        "project_path": "hardware/Test.kicad_pro",
+        "tree_hash": "deadbeef",
+        "commit_sha": "abc",
+        "branch": "main",
+        "ref": "refs/heads/main",
+        "github_run_id": "1",
+        "github_run_attempt": "1"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/board-runs")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// 他リポジトリの project → 403
+#[tokio::test]
+async fn test_create_board_run_forbidden() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2004;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+
+    // Create board_project belonging to a DIFFERENT repository
+    let other_repo_id = create_test_repository(&pool, rand_i64(), 9999).await;
+    let other_bp_id = create_test_board_project(&pool, other_repo_id).await;
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "board_project_id": format!("bp_{}", other_bp_id),
+        "project_path": "hardware/Test.kicad_pro",
+        "tree_hash": "deadbeef",
+        "commit_sha": "abc",
+        "branch": "main",
+        "ref": "refs/heads/main",
+        "github_run_id": "1",
+        "github_run_attempt": "1"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/board-runs")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+// ─── POST /api/v1/board-runs/:id/fail ────────────────────────────────────────
+
+/// 正常系: fail 成功
+#[tokio::test]
+async fn test_fail_board_run_success() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2005;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "created").await;
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "status": "failed",
+        "error": {
+            "message": "KiCad export failed",
+            "details": null
+        }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/fail", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(json["board_run_id"], format!("br_{}", br_id));
+    assert_eq!(json["status"], "failed");
+    assert!(json["failed_at"].as_str().is_some());
+}
+
+/// 冪等性: 既に failed → 同じ結果を返す
+#[tokio::test]
+async fn test_fail_board_run_idempotent() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2006;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "failed").await;
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "status": "failed",
+        "error": { "message": "already failed" }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/fail", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(json["status"], "failed");
+}
+
+/// completed run を fail → 409 Conflict
+#[tokio::test]
+async fn test_fail_board_run_conflict() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2007;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "completed").await;
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "status": "failed",
+        "error": { "message": "cannot fail" }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/fail", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+/// timed_out run を fail → 410 Gone
+#[tokio::test]
+async fn test_fail_board_run_gone() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2008;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "timed_out").await;
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "status": "failed",
+        "error": { "message": "too late" }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/fail", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::GONE);
+}
+
+// ─── POST /api/v1/board-runs/:id/artifact-bundles/import ─────────────────────
+
+/// 正常系: import 成功
+#[tokio::test]
+async fn test_import_artifact_bundle_success() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2009;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "created").await;
+
+    // Create an artifact_bundle for this run (as would be done by create_board_run)
+    let bundle_id = Uuid::now_v7();
+    let object_key = format!("uploads/{}/{}.zip", bp_id, br_id);
+    sqlx::query(
+        "INSERT INTO artifact_bundles (id, board_run_id, intake_mode, staging_object_key, status, received_at) \
+         VALUES ($1, $2, 'staging_s3', $3, 'pending', NOW())",
+    )
+    .bind(bundle_id)
+    .bind(br_id)
+    .bind(&object_key)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "staging_object_key": object_key,
+        "bundle_sha256": "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
+        "bundle_size_bytes": 12345
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/artifact-bundles/import", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert!(json["bundle_id"].as_str().unwrap().starts_with("ab_"));
+    assert_eq!(json["status"], "queued");
+}
+
+/// 冪等性: 同じ key + sha256 で再送
+#[tokio::test]
+async fn test_import_artifact_bundle_idempotent() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2010;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "created").await;
+
+    let object_key = format!("uploads/{}/{}.zip", bp_id, br_id);
+    let sha256 = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
+
+    // Pre-create an artifact_bundle with sha256 already set (simulating prior import)
+    let bundle_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO artifact_bundles (id, board_run_id, intake_mode, staging_object_key, sha256, size_bytes, status, received_at) \
+         VALUES ($1, $2, 'staging_s3', $3, $4, 12345, 'pending', NOW())",
+    )
+    .bind(bundle_id)
+    .bind(br_id)
+    .bind(&object_key)
+    .bind(sha256)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "staging_object_key": object_key,
+        "bundle_sha256": sha256,
+        "bundle_size_bytes": 12345
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/artifact-bundles/import", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(json["bundle_id"], format!("ab_{}", bundle_id));
+    assert_eq!(json["status"], "queued");
+}
+
+/// 異なる sha256 → 409 Conflict
+#[tokio::test]
+async fn test_import_artifact_bundle_conflict() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2011;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "created").await;
+
+    let object_key = format!("uploads/{}/{}.zip", bp_id, br_id);
+
+    // Pre-create bundle with a DIFFERENT sha256
+    let bundle_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO artifact_bundles (id, board_run_id, intake_mode, staging_object_key, sha256, size_bytes, status, received_at) \
+         VALUES ($1, $2, 'staging_s3', $3, 'different_sha256_value', 999, 'pending', NOW())",
+    )
+    .bind(bundle_id)
+    .bind(br_id)
+    .bind(&object_key)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "staging_object_key": object_key,
+        "bundle_sha256": "new_sha256_that_differs",
+        "bundle_size_bytes": 12345
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/artifact-bundles/import", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+/// failed run に import → 410 Gone
+#[tokio::test]
+async fn test_import_artifact_bundle_gone() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2012;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "failed").await;
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "staging_object_key": "uploads/test.zip",
+        "bundle_sha256": "abc123",
+        "bundle_size_bytes": 100
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/artifact-bundles/import", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::GONE);
+}

--- a/crates/api/tests/board_run_test.rs
+++ b/crates/api/tests/board_run_test.rs
@@ -487,7 +487,7 @@ async fn test_import_artifact_bundle_success() {
 
     // Create an artifact_bundle for this run (as would be done by create_board_run)
     let bundle_id = Uuid::now_v7();
-    let object_key = format!("uploads/{}/{}.zip", bp_id, br_id);
+    let object_key = format!("staging/runs/br_{}/bundle.zip", br_id);
     sqlx::query(
         "INSERT INTO artifact_bundles (id, board_run_id, intake_mode, staging_object_key, status, received_at) \
          VALUES ($1, $2, 'staging_s3', $3, 'pending', NOW())",
@@ -542,7 +542,7 @@ async fn test_import_artifact_bundle_idempotent() {
     let bp_id = create_test_board_project(&pool, repo_id).await;
     let br_id = create_test_board_run(&pool, bp_id, "created").await;
 
-    let object_key = format!("uploads/{}/{}.zip", bp_id, br_id);
+    let object_key = format!("staging/runs/br_{}/bundle.zip", br_id);
     let sha256 = "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
 
     // Pre-create an artifact_bundle with sha256 already set (simulating prior import)
@@ -602,7 +602,7 @@ async fn test_import_artifact_bundle_conflict() {
     let bp_id = create_test_board_project(&pool, repo_id).await;
     let br_id = create_test_board_run(&pool, bp_id, "created").await;
 
-    let object_key = format!("uploads/{}/{}.zip", bp_id, br_id);
+    let object_key = format!("staging/runs/br_{}/bundle.zip", br_id);
 
     // Pre-create bundle with a DIFFERENT sha256
     let bundle_id = Uuid::now_v7();
@@ -676,4 +676,282 @@ async fn test_import_artifact_bundle_gone() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::GONE);
+}
+
+/// completed run への import → 既存 bundle 状態を返し、新 job を作らない
+#[tokio::test]
+async fn test_import_artifact_bundle_completed_run() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2013;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "completed").await;
+
+    // Pre-create bundle for the completed run
+    let bundle_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO artifact_bundles (id, board_run_id, intake_mode, staging_object_key, sha256, size_bytes, status, received_at) \
+         VALUES ($1, $2, 'staging_s3', $3, $4, 12345, 'completed', NOW())",
+    )
+    .bind(bundle_id)
+    .bind(br_id)
+    .bind("staging/runs/br_test/bundle.zip")
+    .bind("sha256_completed")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = create_app(pool.clone(), None);
+    let body = serde_json::json!({
+        "staging_object_key": "staging/runs/br_test/bundle.zip",
+        "bundle_sha256": "sha256_completed",
+        "bundle_size_bytes": 12345
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/artifact-bundles/import", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body_bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+
+    assert_eq!(json["bundle_id"], format!("ab_{}", bundle_id));
+    assert_eq!(json["status"], "completed");
+
+    // Verify no new job was created
+    let job_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM github_jobs WHERE board_run_id = $1 AND type = 'artifact_bundle_import'",
+    )
+    .bind(br_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(job_count.0, 0);
+}
+
+/// 同一 run に異なる staging_object_key で 409 Conflict
+#[tokio::test]
+async fn test_import_artifact_bundle_different_staging_key_conflict() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2014;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "created").await;
+
+    // Pre-create bundle with a specific staging_object_key and sha256
+    let bundle_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO artifact_bundles (id, board_run_id, intake_mode, staging_object_key, sha256, size_bytes, status, received_at) \
+         VALUES ($1, $2, 'staging_s3', $3, $4, 999, 'pending', NOW())",
+    )
+    .bind(bundle_id)
+    .bind(br_id)
+    .bind("staging/runs/br_original/bundle.zip")
+    .bind("original_sha256")
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Send request with DIFFERENT staging_object_key
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "staging_object_key": "staging/runs/br_different/bundle.zip",
+        "bundle_sha256": "different_sha256",
+        "bundle_size_bytes": 12345
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/artifact-bundles/import", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CONFLICT);
+}
+
+/// status != "failed" で 400 validation_failed
+#[tokio::test]
+async fn test_fail_board_run_invalid_status() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2015;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+    let bp_id = create_test_board_project(&pool, repo_id).await;
+    let br_id = create_test_board_run(&pool, bp_id, "created").await;
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "status": "completed",
+        "error": {
+            "message": "wrong status value"
+        }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/fail", br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+/// 存在しない board_project_id で 404
+#[tokio::test]
+async fn test_create_board_run_not_found_project() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2016;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+
+    // Use a valid-format but non-existent board_project_id
+    let fake_bp_id = Uuid::now_v7();
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "board_project_id": format!("bp_{}", fake_bp_id),
+        "project_path": "hardware/Test.kicad_pro",
+        "tree_hash": "deadbeef123",
+        "commit_sha": "abc123",
+        "branch": "main",
+        "ref": "refs/heads/main",
+        "github_run_id": "99999",
+        "github_run_attempt": "1"
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/board-runs")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// 存在しない board_run_id で fail → 404
+#[tokio::test]
+async fn test_fail_board_run_not_found() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2017;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+
+    let fake_br_id = Uuid::now_v7();
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "status": "failed",
+        "error": { "message": "not found test" }
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/fail", fake_br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+/// 存在しない board_run_id で import → 404
+#[tokio::test]
+async fn test_import_artifact_bundle_not_found() {
+    let pool = match setup_pool().await {
+        Some(p) => p,
+        None => return,
+    };
+
+    let github_repo_id = rand_i64();
+    let installation_id: i64 = 2018;
+    let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
+    let token = create_test_token(&pool, repo_id, installation_id).await;
+
+    let fake_br_id = Uuid::now_v7();
+
+    let app = create_app(pool, None);
+    let body = serde_json::json!({
+        "staging_object_key": "staging/runs/br_fake/bundle.zip",
+        "bundle_sha256": "abc123",
+        "bundle_size_bytes": 100
+    });
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/api/v1/board-runs/br_{}/artifact-bundles/import", fake_br_id))
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {}", token))
+                .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
 }

--- a/crates/api/tests/integration_test.rs
+++ b/crates/api/tests/integration_test.rs
@@ -21,7 +21,7 @@ async fn test_openapi_endpoint_returns_json() {
     };
 
     let pool = PgPool::connect(&database_url).await.unwrap();
-    let app = create_app(pool);
+    let app = create_app(pool, None);
 
     let response = app
         .oneshot(
@@ -56,7 +56,7 @@ async fn test_healthz_returns_ok_with_db() {
     };
 
     let pool = PgPool::connect(&database_url).await.unwrap();
-    let app = create_app(pool);
+    let app = create_app(pool, None);
 
     let response = app
         .oneshot(

--- a/crates/api/tests/plan_test.rs
+++ b/crates/api/tests/plan_test.rs
@@ -138,7 +138,7 @@ async fn plan_new_project_returns_build_new_project() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = plan_request_body(&github_repo_id.to_string());
 
     let response = app
@@ -180,7 +180,7 @@ async fn plan_mode_all_returns_build_manual_dispatch() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let mut body = plan_request_body(&github_repo_id.to_string());
     body["mode"] = serde_json::json!("all");
 
@@ -214,7 +214,7 @@ async fn plan_without_auth_returns_401() {
         None => return,
     };
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = plan_request_body("12345");
 
     let response = app
@@ -249,7 +249,7 @@ async fn plan_wrong_repository_returns_403() {
     let token = create_test_token(&pool, different_repo_id, installation_id).await;
 
     // The request targets github_repo_id, but the token belongs to different_github_repo_id → 403
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = plan_request_body(&github_repo_id.to_string());
 
     let response = app
@@ -285,7 +285,7 @@ async fn plan_invalid_github_repository_id_returns_400() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = plan_request_body("not_a_number");
 
     let response = app
@@ -321,7 +321,7 @@ async fn plan_invalid_json_returns_400() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
 
     let response = app
         .oneshot(
@@ -358,7 +358,7 @@ async fn plan_duplicate_project_path_returns_error() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = serde_json::json!({
         "repository": {
             "github_repository_id": github_repo_id.to_string(),
@@ -432,7 +432,7 @@ async fn plan_empty_project_path_returns_error() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = serde_json::json!({
         "repository": {
             "github_repository_id": github_repo_id.to_string(),
@@ -495,7 +495,7 @@ async fn plan_invalid_project_path_extension_returns_error() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = serde_json::json!({
         "repository": {
             "github_repository_id": github_repo_id.to_string(),
@@ -558,7 +558,7 @@ async fn plan_path_traversal_project_path_returns_error() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = serde_json::json!({
         "repository": {
             "github_repository_id": github_repo_id.to_string(),
@@ -621,7 +621,7 @@ async fn plan_path_traversal_config_path_returns_error() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = serde_json::json!({
         "repository": {
             "github_repository_id": github_repo_id.to_string(),
@@ -684,7 +684,7 @@ async fn plan_empty_tree_hash_returns_error() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = serde_json::json!({
         "repository": {
             "github_repository_id": github_repo_id.to_string(),
@@ -747,7 +747,7 @@ async fn plan_empty_config_path_returns_error() {
     let repo_id = create_test_repository(&pool, github_repo_id, installation_id).await;
     let token = create_test_token(&pool, repo_id, installation_id).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = serde_json::json!({
         "repository": {
             "github_repository_id": github_repo_id.to_string(),
@@ -813,7 +813,7 @@ async fn plan_existing_project_hash_changed() {
     let project_path = "hardware/LightStick.kicad_pro";
     create_existing_board_project(&pool, repo_id, project_path, Some("old_hash_value")).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let mut body = plan_request_body(&github_repo_id.to_string());
     body["projects"][0]["tree_hash"] = serde_json::json!("new_different_hash");
 
@@ -856,7 +856,7 @@ async fn plan_existing_project_unchanged() {
     let tree_hash = "deadbeef1234567890";
     create_existing_board_project(&pool, repo_id, project_path, Some(tree_hash)).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = plan_request_body(&github_repo_id.to_string());
     // body's tree_hash is "deadbeef1234567890" by default, matching the stored value
 
@@ -898,7 +898,7 @@ async fn plan_existing_project_no_previous_snapshot() {
     let project_path = "hardware/LightStick.kicad_pro";
     create_existing_board_project(&pool, repo_id, project_path, None).await;
 
-    let app = create_app(pool);
+    let app = create_app(pool, None);
     let body = plan_request_body(&github_repo_id.to_string());
 
     let response = app

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -10,3 +10,4 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/db/migrations/20260501000000_add_github_jobs_idempotent_index.down.sql
+++ b/crates/db/migrations/20260501000000_add_github_jobs_idempotent_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_github_jobs_board_run_id_type;

--- a/crates/db/migrations/20260501000000_add_github_jobs_idempotent_index.up.sql
+++ b/crates/db/migrations/20260501000000_add_github_jobs_idempotent_index.up.sql
@@ -1,0 +1,3 @@
+CREATE UNIQUE INDEX idx_github_jobs_board_run_id_type
+ON github_jobs (board_run_id, type)
+WHERE board_run_id IS NOT NULL;

--- a/crates/db/src/queries/artifact_bundle.rs
+++ b/crates/db/src/queries/artifact_bundle.rs
@@ -1,0 +1,82 @@
+use boardflow_domain::models::artifact_bundle::ArtifactBundle;
+use uuid::Uuid;
+
+/// Find ArtifactBundle by board_run_id
+pub async fn find_by_board_run_id(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    board_run_id: Uuid,
+) -> Result<Option<ArtifactBundle>, sqlx::Error> {
+    sqlx::query_as::<_, ArtifactBundle>(
+        "SELECT * FROM artifact_bundles WHERE board_run_id = $1 ORDER BY received_at DESC LIMIT 1",
+    )
+    .bind(board_run_id)
+    .fetch_optional(executor)
+    .await
+}
+
+/// Insert a new ArtifactBundle (staging_s3 mode)
+pub async fn insert_staging(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+    board_run_id: Uuid,
+    staging_object_key: &str,
+) -> Result<ArtifactBundle, sqlx::Error> {
+    sqlx::query_as::<_, ArtifactBundle>(
+        r#"INSERT INTO artifact_bundles (id, board_run_id, intake_mode, staging_object_key, status, received_at)
+        VALUES ($1, $2, 'staging_s3', $3, 'pending', NOW())
+        RETURNING *"#,
+    )
+    .bind(id)
+    .bind(board_run_id)
+    .bind(staging_object_key)
+    .fetch_one(executor)
+    .await
+}
+
+/// Update ArtifactBundle with sha256 and size_bytes, set status to 'pending' (import queued)
+pub async fn update_for_import(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+    sha256: &str,
+    size_bytes: i64,
+) -> Result<ArtifactBundle, sqlx::Error> {
+    sqlx::query_as::<_, ArtifactBundle>(
+        r#"UPDATE artifact_bundles SET sha256 = $2, size_bytes = $3, status = 'pending'
+        WHERE id = $1 RETURNING *"#,
+    )
+    .bind(id)
+    .bind(sha256)
+    .bind(size_bytes)
+    .fetch_one(executor)
+    .await
+}
+
+/// Find ArtifactBundle by board_run_id + staging_object_key + sha256 (idempotency check)
+pub async fn find_by_import_key(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    board_run_id: Uuid,
+    staging_object_key: &str,
+    sha256: &str,
+) -> Result<Option<ArtifactBundle>, sqlx::Error> {
+    sqlx::query_as::<_, ArtifactBundle>(
+        "SELECT * FROM artifact_bundles WHERE board_run_id = $1 AND staging_object_key = $2 AND sha256 = $3",
+    )
+    .bind(board_run_id)
+    .bind(staging_object_key)
+    .bind(sha256)
+    .fetch_optional(executor)
+    .await
+}
+
+/// Find any existing bundle for the run (for conflict check)
+pub async fn find_existing_for_run(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    board_run_id: Uuid,
+) -> Result<Option<ArtifactBundle>, sqlx::Error> {
+    sqlx::query_as::<_, ArtifactBundle>(
+        "SELECT * FROM artifact_bundles WHERE board_run_id = $1 AND sha256 IS NOT NULL LIMIT 1",
+    )
+    .bind(board_run_id)
+    .fetch_optional(executor)
+    .await
+}

--- a/crates/db/src/queries/artifact_bundle.rs
+++ b/crates/db/src/queries/artifact_bundle.rs
@@ -33,21 +33,26 @@ pub async fn insert_staging(
     .await
 }
 
-/// Update ArtifactBundle with sha256 and size_bytes, set status to 'pending' (import queued)
+/// Update ArtifactBundle with sha256 and size_bytes, set status to 'pending' (import queued).
+/// Only updates if sha256 is currently NULL and staging_object_key matches.
+/// Returns None if conditions not met (another request already set sha256).
 pub async fn update_for_import(
     executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
     id: Uuid,
+    staging_object_key: &str,
     sha256: &str,
     size_bytes: i64,
-) -> Result<ArtifactBundle, sqlx::Error> {
+) -> Result<Option<ArtifactBundle>, sqlx::Error> {
     sqlx::query_as::<_, ArtifactBundle>(
-        r#"UPDATE artifact_bundles SET sha256 = $2, size_bytes = $3, status = 'pending'
-        WHERE id = $1 RETURNING *"#,
+        r#"UPDATE artifact_bundles SET sha256 = $3, size_bytes = $4, status = 'pending'
+        WHERE id = $1 AND staging_object_key = $2 AND sha256 IS NULL
+        RETURNING *"#,
     )
     .bind(id)
+    .bind(staging_object_key)
     .bind(sha256)
     .bind(size_bytes)
-    .fetch_one(executor)
+    .fetch_optional(executor)
     .await
 }
 

--- a/crates/db/src/queries/board_project.rs
+++ b/crates/db/src/queries/board_project.rs
@@ -1,6 +1,16 @@
 use boardflow_domain::models::board_project::BoardProject;
 use uuid::Uuid;
 
+pub async fn find_by_id(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+) -> Result<Option<BoardProject>, sqlx::Error> {
+    sqlx::query_as::<_, BoardProject>("SELECT * FROM board_projects WHERE id = $1")
+        .bind(id)
+        .fetch_optional(executor)
+        .await
+}
+
 pub async fn upsert(
     executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
     repository_id: Uuid,

--- a/crates/db/src/queries/board_run.rs
+++ b/crates/db/src/queries/board_run.rs
@@ -1,0 +1,85 @@
+use boardflow_domain::models::board_run::BoardRun;
+use uuid::Uuid;
+
+/// Find a BoardRun by its ID
+pub async fn find_by_id(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+) -> Result<Option<BoardRun>, sqlx::Error> {
+    sqlx::query_as::<_, BoardRun>("SELECT * FROM board_runs WHERE id = $1")
+        .bind(id)
+        .fetch_optional(executor)
+        .await
+}
+
+/// Find a BoardRun by idempotency key
+pub async fn find_by_idempotency_key(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    board_project_id: Uuid,
+    github_run_id: i64,
+    github_run_attempt: i32,
+) -> Result<Option<BoardRun>, sqlx::Error> {
+    sqlx::query_as::<_, BoardRun>(
+        "SELECT * FROM board_runs WHERE board_project_id = $1 AND github_run_id = $2 AND github_run_attempt = $3",
+    )
+    .bind(board_project_id)
+    .bind(github_run_id)
+    .bind(github_run_attempt)
+    .fetch_optional(executor)
+    .await
+}
+
+/// Insert a new BoardRun
+pub async fn insert(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+    board_project_id: Uuid,
+    commit_sha: &str,
+    branch: &str,
+    ref_: &str,
+    github_run_id: i64,
+    github_run_attempt: i32,
+    tree_hash: &str,
+) -> Result<BoardRun, sqlx::Error> {
+    sqlx::query_as::<_, BoardRun>(
+        r#"INSERT INTO board_runs (id, board_project_id, commit_sha, branch, ref, github_run_id, github_run_attempt, tree_hash, status, erc_errors, erc_warnings, drc_errors, drc_warnings, review_status, diff_status, created_at)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'created', 0, 0, 0, 0, 'pending', 'pending', NOW())
+        RETURNING *"#,
+    )
+    .bind(id)
+    .bind(board_project_id)
+    .bind(commit_sha)
+    .bind(branch)
+    .bind(ref_)
+    .bind(github_run_id)
+    .bind(github_run_attempt)
+    .bind(tree_hash)
+    .fetch_one(executor)
+    .await
+}
+
+/// Update BoardRun status to 'failed'
+pub async fn mark_failed(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+) -> Result<BoardRun, sqlx::Error> {
+    sqlx::query_as::<_, BoardRun>(
+        "UPDATE board_runs SET status = 'failed', completed_at = NOW() WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .fetch_one(executor)
+    .await
+}
+
+/// Update BoardRun status to 'importing'
+pub async fn mark_importing(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+) -> Result<BoardRun, sqlx::Error> {
+    sqlx::query_as::<_, BoardRun>(
+        "UPDATE board_runs SET status = 'importing' WHERE id = $1 RETURNING *",
+    )
+    .bind(id)
+    .fetch_one(executor)
+    .await
+}

--- a/crates/db/src/queries/board_run.rs
+++ b/crates/db/src/queries/board_run.rs
@@ -12,6 +12,17 @@ pub async fn find_by_id(
         .await
 }
 
+/// Find a BoardRun by its ID with FOR UPDATE lock
+pub async fn find_by_id_for_update(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+) -> Result<Option<BoardRun>, sqlx::Error> {
+    sqlx::query_as::<_, BoardRun>("SELECT * FROM board_runs WHERE id = $1 FOR UPDATE")
+        .bind(id)
+        .fetch_optional(executor)
+        .await
+}
+
 /// Find a BoardRun by idempotency key
 pub async fn find_by_idempotency_key(
     executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,

--- a/crates/db/src/queries/github_job.rs
+++ b/crates/db/src/queries/github_job.rs
@@ -1,0 +1,29 @@
+use boardflow_domain::models::github_job::GithubJob;
+use uuid::Uuid;
+
+/// Enqueue an import job (idempotent via partial unique index)
+pub async fn enqueue_import(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    id: Uuid,
+    installation_id: i64,
+    repository_id: Uuid,
+    board_project_id: Uuid,
+    board_run_id: Uuid,
+    payload: &serde_json::Value,
+) -> Result<GithubJob, sqlx::Error> {
+    sqlx::query_as::<_, GithubJob>(
+        r#"INSERT INTO github_jobs (id, installation_id, repository_id, board_project_id, board_run_id, type, payload_json, status, attempts, run_after, created_at, updated_at)
+        VALUES ($1, $2, $3, $4, $5, 'artifact_bundle_import', $6, 'pending', 0, NOW(), NOW(), NOW())
+        ON CONFLICT (board_run_id, type) WHERE board_run_id IS NOT NULL
+        DO UPDATE SET updated_at = NOW()
+        RETURNING *"#,
+    )
+    .bind(id)
+    .bind(installation_id)
+    .bind(repository_id)
+    .bind(board_project_id)
+    .bind(board_run_id)
+    .bind(payload)
+    .fetch_one(executor)
+    .await
+}

--- a/crates/db/src/queries/mod.rs
+++ b/crates/db/src/queries/mod.rs
@@ -1,3 +1,6 @@
 pub mod api_token;
+pub mod artifact_bundle;
 pub mod board_project;
+pub mod board_run;
+pub mod github_job;
 pub mod repository;

--- a/docs/external/aws-sdk-s3-presigned-url.md
+++ b/docs/external/aws-sdk-s3-presigned-url.md
@@ -1,0 +1,145 @@
+# S3 互換 Presigned URL 生成 (Rust + aws-sdk-s3)
+
+対象Issue: #5
+
+## 要約
+
+BoardRun作成APIのレスポンスで `artifact_bundle.upload_url` として staging bucket への presigned PUT URL を返す必要がある。Rust では `aws-sdk-s3` クレートが公式 AWS SDK であり、presigned URL 生成に対応している。MinIO互換のカスタムエンドポイント設定も `aws-config` + `force_path_style(true)` で可能。
+
+## 確認した情報
+
+### 推奨クレート
+
+| クレート | 最新安定版 | 推奨指定 |
+|---|---|---|
+| `aws-sdk-s3` | 1.131.0+ (2026-04時点) | `"1"` + `features = ["behavior-version-latest"]` |
+| `aws-config` | 1.8.16 (2026-04時点) | `"1"` + `features = ["behavior-version-latest"]` |
+
+代替として `rust-s3` (durch/rust-s3) もあるが、AWS公式SDKの方が長期メンテナンス・互換性面で推奨。
+
+### Cargo.toml 追加
+
+```toml
+[workspace.dependencies]
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
+```
+
+### MinIO 互換カスタムエンドポイント設定
+
+```rust
+use aws_config::BehaviorVersion;
+use aws_sdk_s3::config::Builder as S3ConfigBuilder;
+
+pub async fn create_s3_client(
+    endpoint_url: &str,
+    access_key: &str,
+    secret_key: &str,
+    region: &str,
+) -> aws_sdk_s3::Client {
+    let creds = aws_sdk_s3::config::Credentials::new(
+        access_key,
+        secret_key,
+        None, // session token
+        None, // expiry
+        "boardflow-static",
+    );
+
+    let config = aws_config::defaults(BehaviorVersion::latest())
+        .endpoint_url(endpoint_url)
+        .credentials_provider(creds)
+        .region(aws_config::Region::new(region.to_owned()))
+        .load()
+        .await;
+
+    let s3_config = S3ConfigBuilder::from(&config)
+        .force_path_style(true) // MinIO requires path-style
+        .build();
+
+    aws_sdk_s3::Client::from_conf(s3_config)
+}
+```
+
+重要: MinIO は virtual-hosted style (`bucket.endpoint`) に対応しないため、`force_path_style(true)` が必須。
+
+### Presigned PUT URL 生成
+
+```rust
+use aws_sdk_s3::presigning::PresigningConfig;
+use std::time::Duration;
+
+pub async fn generate_presigned_put_url(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    object_key: &str,
+    expires_in_secs: u64,
+) -> Result<String, aws_sdk_s3::error::SdkError<aws_sdk_s3::operation::put_object::PutObjectError>> {
+    let expires_in = Duration::from_secs(expires_in_secs);
+    let presigning_config = PresigningConfig::expires_in(expires_in)
+        .expect("expiration within one week");
+
+    let presigned_request = client
+        .put_object()
+        .bucket(bucket)
+        .key(object_key)
+        .presigned(presigning_config)
+        .await?;
+
+    Ok(presigned_request.uri().to_string())
+}
+```
+
+### 環境変数マッピング
+
+| 環境変数 | 用途 |
+|---|---|
+| `MINIO_ENDPOINT` | S3互換エンドポイントURL (例: `http://localhost:9000`) |
+| `MINIO_ACCESS_KEY` | アクセスキー |
+| `MINIO_SECRET_KEY` | シークレットキー |
+| `MINIO_BUCKET_STAGING` | staging bucket名 |
+| `MINIO_REGION` | リージョン (MinIOでは任意、例: `us-east-1`) |
+
+### 有効期限の設計
+
+- BoardRun作成API仕様では `expires_at` を返す
+- 推奨有効期限: 1時間 (3600秒) — zip bundle upload に十分な時間
+- `PresigningConfig` の上限は7日 (604800秒)
+
+## BoardFlow への示唆
+
+- `crates/artifact/` に S3 クライアント初期化と presigned URL 生成ロジックを配置する
+- `AppState` に S3 client を保持し、DI する
+- BoardRun作成時に `staging/runs/{board_run_id}/bundle.zip` の presigned PUT URL を生成して返す
+- `expires_at` は生成時刻 + 有効期限から計算して UTC RFC3339 で返す
+
+## 採用/不採用判断
+
+**採用**: `aws-sdk-s3` + `aws-config` を workspace dependencies に追加する。
+
+理由:
+- AWS公式メンテナンス、MinIO互換確認済み
+- presigned URL生成がSDK組み込み機能として提供されている
+- Tokio非同期ランタイムとの親和性が高い
+- `force_path_style` でMinIO対応が容易
+
+## 制約とpitfall
+
+- `force_path_style(true)` を忘れるとMinIOで `BucketNotFound` エラーになる
+- presigned URLの有効期限は最大7日。それ以上は生成時エラーになる
+- `aws-sdk-s3` は STS / IAM 機能を含まないため、静的クレデンシャルの場合は `Credentials::new()` で直接渡す
+- `behavior-version-latest` feature を有効にしないと `BehaviorVersion::latest()` が使えない
+- MinIOのbucketが事前に存在する必要がある (docker-compose で `createbuckets` サービスを追加する)
+
+## 未解決の疑問
+
+- 本番環境で使用するS3互換サービスの決定 (MinIO自前運用 or クラウドS3 or Cloudflare R2)
+- presigned URLの有効期限を設定ファイルから変更可能にするか (MVP では固定値で十分)
+
+## 参照URL
+
+- https://docs.aws.amazon.com/sdk-for-rust/latest/dg/rust_s3_code_examples.html
+- https://docs.rs/aws-sdk-s3/latest/aws_sdk_s3/
+- https://docs.rs/aws-config/latest/aws_config/
+- https://crates.io/crates/aws-sdk-s3
+- https://crates.io/crates/aws-config
+- https://github.com/awslabs/aws-sdk-rust/issues/390 (force_path_style for MinIO)

--- a/docs/external/postgresql-job-queue-enqueue.md
+++ b/docs/external/postgresql-job-queue-enqueue.md
@@ -1,0 +1,229 @@
+# PostgreSQL Job Queue Enqueue パターン (Rust + SQLx)
+
+対象Issue: #5
+
+## 要約
+
+Artifact Bundle Import APIで、import jobをPostgreSQLキュー (`github_jobs` テーブル) にenqueueする必要がある。SQLx 0.8 の `query` / `query_as` で INSERT を行い、`ON CONFLICT` で冪等性を担保するパターンを調査した。既存の `github_jobs` テーブルスキーマに合わせた具体的な実装方針を整理する。
+
+## 確認した情報
+
+### 既存スキーマ (github_jobs)
+
+```sql
+CREATE TABLE github_jobs (
+    id UUID PRIMARY KEY,
+    installation_id BIGINT NOT NULL,
+    repository_id UUID NOT NULL REFERENCES repositories(id),
+    board_project_id UUID REFERENCES board_projects(id),
+    board_run_id UUID REFERENCES board_runs(id),
+    type TEXT NOT NULL,
+    payload_json JSONB NOT NULL,
+    status TEXT NOT NULL DEFAULT 'pending',
+    attempts INTEGER NOT NULL DEFAULT 0,
+    run_after TIMESTAMPTZ NOT NULL,
+    last_error TEXT,
+    created_at TIMESTAMPTZ NOT NULL,
+    updated_at TIMESTAMPTZ NOT NULL
+);
+```
+
+### 冪等性のための UNIQUE 制約追加
+
+現状のスキーマには `board_run_id + type` の UNIQUE 制約がない。import jobの重複防止には、以下のいずれかが必要:
+
+**方法A: UNIQUE INDEX を追加** (推奨)
+```sql
+CREATE UNIQUE INDEX idx_github_jobs_board_run_id_type
+ON github_jobs (board_run_id, type)
+WHERE board_run_id IS NOT NULL;
+```
+
+部分インデックスを使うことで `board_run_id IS NULL` のジョブ (repository レベルのジョブ) には影響しない。
+
+**方法B: アプリケーション層で SELECT + INSERT**
+```sql
+SELECT id FROM github_jobs
+WHERE board_run_id = $1 AND type = $2
+LIMIT 1;
+-- 存在しなければ INSERT
+```
+
+推奨はA。DB制約でrace conditionを防止できる。
+
+### Enqueue パターン (INSERT ... ON CONFLICT)
+
+```rust
+use sqlx::PgPool;
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+
+pub async fn enqueue_import_job(
+    pool: &PgPool,
+    id: Uuid,
+    installation_id: i64,
+    repository_id: Uuid,
+    board_project_id: Uuid,
+    board_run_id: Uuid,
+    payload: &serde_json::Value,
+    now: DateTime<Utc>,
+) -> Result<Uuid, sqlx::Error> {
+    let row = sqlx::query_scalar::<_, Uuid>(
+        r#"
+        INSERT INTO github_jobs (
+            id, installation_id, repository_id, board_project_id,
+            board_run_id, type, payload_json, status,
+            attempts, run_after, created_at, updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, 'artifact_bundle_import', $6, 'pending', 0, $7, $7, $7)
+        ON CONFLICT (board_run_id, type) WHERE board_run_id IS NOT NULL
+        DO UPDATE SET updated_at = $7
+        RETURNING id
+        "#,
+    )
+    .bind(id)
+    .bind(installation_id)
+    .bind(repository_id)
+    .bind(board_project_id)
+    .bind(board_run_id)
+    .bind(payload)
+    .bind(now)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(row)
+}
+```
+
+### Job Type 設計
+
+| type | 用途 | trigger |
+|---|---|---|
+| `artifact_bundle_import` | staging zip → 検証 → final bucket保存 → DB保存 | Import API |
+| `create_issue` | BoardProject の GitHub Issue 作成 | import 完了後 (worker) |
+| `update_dashboard_comment` | Dashboard コメント更新 | import 完了後 (worker) |
+| `create_run_result_comment` | Run Result コメント作成 | import 完了後 (worker) |
+
+### payload_json 設計 (artifact_bundle_import)
+
+```json
+{
+  "bundle_id": "ab_abc123",
+  "staging_object_key": "staging/runs/br_abc123/bundle.zip",
+  "bundle_sha256": "sha256:...",
+  "bundle_size_bytes": 12345678
+}
+```
+
+### トランザクション内でのenqueue
+
+Import API では BoardRun のステータス更新と job enqueue を同一トランザクションで行う:
+
+```rust
+use sqlx::PgPool;
+
+pub async fn process_import_request(
+    pool: &PgPool,
+    board_run_id: Uuid,
+    // ... other params
+) -> Result<(), sqlx::Error> {
+    let mut tx = pool.begin().await?;
+
+    // 1. BoardRun status を 'importing' に更新
+    sqlx::query(
+        "UPDATE board_runs SET status = 'importing' WHERE id = $1 AND status IN ('created', 'uploading')"
+    )
+    .bind(board_run_id)
+    .execute(&mut *tx)
+    .await?;
+
+    // 2. artifact_bundles レコード作成
+    // ...
+
+    // 3. github_jobs に import job を enqueue
+    sqlx::query(
+        r#"
+        INSERT INTO github_jobs (
+            id, installation_id, repository_id, board_project_id,
+            board_run_id, type, payload_json, status,
+            attempts, run_after, created_at, updated_at
+        )
+        VALUES ($1, $2, $3, $4, $5, 'artifact_bundle_import', $6, 'pending', 0, NOW(), NOW(), NOW())
+        ON CONFLICT (board_run_id, type) WHERE board_run_id IS NOT NULL
+        DO NOTHING
+        "#,
+    )
+    // ... bind params
+    .execute(&mut *tx)
+    .await?;
+
+    tx.commit().await?;
+    Ok(())
+}
+```
+
+### Worker の pull パターン (FOR UPDATE SKIP LOCKED)
+
+既存の `github_jobs` テーブルに対する worker pull パターン:
+
+```rust
+pub async fn pull_jobs(
+    pool: &PgPool,
+    limit: i32,
+) -> Result<Vec<GithubJob>, sqlx::Error> {
+    sqlx::query_as::<_, GithubJob>(
+        r#"
+        UPDATE github_jobs
+        SET status = 'running', updated_at = NOW(), attempts = attempts + 1
+        WHERE id IN (
+            SELECT id
+            FROM github_jobs
+            WHERE status = 'pending' AND run_after <= NOW()
+            ORDER BY run_after ASC
+            FOR UPDATE SKIP LOCKED
+            LIMIT $1
+        )
+        RETURNING *
+        "#,
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await
+}
+```
+
+`FOR UPDATE SKIP LOCKED` により、複数 worker が同時にポーリングしても同じジョブを重複取得しない。
+
+## BoardFlow への示唆
+
+- マイグレーションで `idx_github_jobs_board_run_id_type` 部分ユニークインデックスを追加する
+- `crates/jobs/src/lib.rs` に enqueue ユーティリティ関数を実装する
+- Import API handler は transaction 内で BoardRun ステータス変更 + bundle 作成 + job enqueue を行う
+- `ON CONFLICT DO NOTHING` (冪等 insert) と `ON CONFLICT DO UPDATE` (upsert) を用途で使い分ける:
+  - Import API の冪等性: 同一 `board_run_id + type` の再送では既存 job を返す → `DO UPDATE SET updated_at` + `RETURNING id`
+  - Worker 側の job enqueue (後続ジョブ生成): 重複しても問題ないなら `DO NOTHING`
+
+## 採用/不採用判断
+
+**採用**: 既存の `github_jobs` テーブルを活用し、部分ユニークインデックス追加 + `ON CONFLICT` パターンで冪等enqueueを実装する。
+
+## 制約とpitfall
+
+- `ON CONFLICT` で部分インデックスを対象にする場合、`WHERE` 句がインデックス定義と完全一致する必要がある
+- `board_run_id IS NULL` のジョブ (repository レベル) にはこの制約が適用されないため、別途 `board_project_id + type` や他のキーで冪等性を担保する必要がある
+- `FOR UPDATE SKIP LOCKED` は PostgreSQL 9.5+ で利用可能 (既に前提)
+- transaction が長引くと他の INSERT がブロックされるため、enqueue は軽量に保つ
+- `run_after` を現在時刻にするとすぐ実行対象になる。遅延実行が必要な場合は未来時刻を設定
+
+## 未解決の疑問
+
+- `github_jobs` テーブルの最大 attempts 数 (5回? 設定可能?) — worker 実装時に決定
+- failed job の再実行タイミング (exponential backoff の具体値) — worker 実装時に決定
+- `board_run_id` が NULL のジョブ種別に対する冪等キーの設計 — Issue #5 の scope 外
+
+## 参照URL
+
+- https://kerkour.com/rust-job-queue-with-postgresql
+- https://cetra3.github.io/blog/implementing-a-jobq-sqlx/
+- https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE
+- https://www.prisma.io/dataguide/postgresql/inserting-and-modifying-data/insert-on-conflict

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -402,6 +402,62 @@ running 2 tests (integration_test.rs) — 全pass
 
 ---
 
+## 再レビューフェーズ (2026-05-01)
+
+### 対象Issue
+- Issue #5: POST /api/v1/board-runs, POST .../fail, POST .../artifact-bundles/import の3エンドポイント実装
+
+### 再レビュー結果
+- `pr_ready: false`
+
+### 総評
+- 前回の必須修正4件はコード上で反映を確認した。
+- 追加テスト6件は実装済みで、`cargo test -p boardflow-api --test board_run_test -- --nocapture` により 18 件全 pass を確認した。
+- さらに `cargo test -p boardflow-api -- --nocapture` でも 45 件全 pass を確認し、worklog 記載の総テスト結果は再現できた。
+- ただし Import API には並行実行時の read-check-update 競合が残っており、異なる bundle 情報が同一 run へ同時投入された場合に `artifact_bundles` と `github_jobs.payload_json` の整合が崩れるため、現時点では PR ready 判定は出せない。
+
+### 確認できた修正
+1. Import API は `pool.begin()` を使って bundle 更新、run status 更新、job enqueue を同一 transaction にまとめている。
+2. `staging_object_key` の順次競合チェックが追加され、同一 run に別 key / sha256 を順次送った場合は `409 conflict` になる。
+3. Fail API で `status != "failed"` を `400 validation_failed` として拒否している。
+4. create/import の object key は `staging/runs/br_{uuid}/bundle.zip` 形式に揃っている。
+5. 追加テスト6件はすべて存在し、実行も成功した。
+
+### 重大指摘
+1. **Import API の競合判定が transaction の外で行われており、並行リクエストで整合が崩れる**
+  - 実装は [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L512) で `find_existing_for_run` を transaction 開始前に実行し、その後 [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L527) で transaction を開始している。
+  - そのため、`sha256 IS NULL` の staging bundle を持つ初期状態で異なる2リクエストが同時に入ると、両方とも conflict check を通過し、それぞれが [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L543) / [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L568) の `update_for_import` を実行できる。
+  - `update_for_import` は [crates/db/src/queries/artifact_bundle.rs](crates/db/src/queries/artifact_bundle.rs#L37) の通り条件付き更新ではなく、`sha256` と `size_bytes` を無条件に上書きする。さらに job enqueue は [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L599) で `ON CONFLICT` により既存 job を再利用するため、先着リクエストの `payload_json` と後着リクエストで上書きされた `artifact_bundles` の値が食い違う可能性がある。
+  - 外部調査でも、job enqueue は transaction 化だけでなく read-modify-write の競合を避ける設計が前提とされており、[docs/external/postgresql-job-queue-enqueue.md](docs/external/postgresql-job-queue-enqueue.md#L130) でも transaction 内一括処理を採用方針にしている。一般的にも `SELECT FOR UPDATE` などで read-check-update の競合を防ぐべきという指針と一致する。
+
+### 必須修正
+1. Import API の conflict 判定と bundle 取得を transaction 内へ移し、対象 bundle または board_run を行ロックしたうえで判定すること。
+2. `artifact_bundles.update_for_import` を条件付き更新にするか、`sha256 IS NULL` かつ `staging_object_key` 一致時のみ更新できるようにして、後着リクエストが先着内容を上書きできないようにすること。
+3. 並行 import を再現するテスト、または少なくとも上書き防止を保証する DB 条件付き更新のテストを追加すること。
+
+### 任意改善
+- `github_jobs` の `ON CONFLICT DO UPDATE` で `updated_at` のみ更新しているため、将来 retry / dedupe 方針を明確にしないと payload 差し替えの有無が曖昧になる。今回の必須修正に合わせて意図をコメントまたは query 名で明確にした方がよい。
+
+### テスト結果
+- `cargo test -p boardflow-api --test board_run_test -- --nocapture` → 18 passed, 0 failed
+- `cargo test -p boardflow-api -- --nocapture` → 45 passed, 0 failed
+
+### ドキュメント確認
+- [docs/backend/api.md](docs/backend/api.md#L298) [docs/backend/api.md](docs/backend/api.md#L300) の順次 idempotency / conflict 要件には概ね一致した。
+- ただし current worklog の「異なる staging_object_key / sha256 のリクエストを正しく拒否」との記述は、順次実行では正しい一方で、並行実行時の競合まで満たしているとは言えないため補足が必要。
+
+### PR/完了結果
+- `pr_ready: false`
+
+### 残リスク
+- 並行 import が発生すると `artifact_bundles` と `github_jobs.payload_json` の整合が崩れ、worker が想定外の bundle 情報で動く可能性がある。
+- 現状のテストは順次実行のみを確認しており、race condition の不在までは証明できていない。
+
+### 更新した作業ログパス
+- `docs/logs/5/worklog.md`
+
+---
+
 ## レビュー指摘修正フェーズ (2026-05-01)
 
 ### 修正内容

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -518,3 +518,55 @@ total: 45 passed; 0 failed
 ### 更新した作業ログパス
 - `docs/logs/5/worklog.md`
 
+---
+
+## Race Condition 修正 (2026-05-01)
+
+### 問題
+`import_artifact_bundle` ハンドラで `find_by_import_key` と `find_existing_for_run` がトランザクション外で実行されており、並行リクエストで整合性が崩れる可能性があった。また `update_for_import` が無条件に sha256/size_bytes を上書きしていた。
+
+### 修正内容
+
+#### 1. DB層の変更
+- `crates/db/src/queries/board_run.rs`: `find_by_id_for_update` 追加 (SELECT ... FOR UPDATE)
+- `crates/db/src/queries/artifact_bundle.rs`: `update_for_import` を条件付き更新に変更
+  - シグネチャに `staging_object_key` パラメータ追加
+  - `WHERE sha256 IS NULL AND staging_object_key = $2` ガード追加
+  - 戻り値を `Result<Option<ArtifactBundle>>` に変更 (条件不一致時 None)
+
+#### 2. ハンドラの変更
+- `crates/api/src/routes/board_run.rs`: `import_artifact_bundle` を全面リファクタ
+  - トランザクション開始をハンドラ冒頭に移動
+  - `find_by_id_for_update` で board_run をロック
+  - 全 DB 読み取り (`find_by_import_key`, `find_existing_for_run`, `find_by_board_run_id`) をトランザクション内に移動
+  - `update_for_import` の結果が None の場合 409 Conflict を返す
+
+#### 3. テスト追加
+- `crates/api/tests/board_run_test.rs`: `test_import_artifact_bundle_update_conflict` 追加
+  - 先着リクエスト成功 → 後着が異なる sha256 で 409 になることを確認
+  - トランザクション内 conflict 判定の正しさを順次実行で擬似テスト
+
+### テスト結果
+```
+cargo test -p boardflow-api
+
+board_run_test: 19 passed; 0 failed (新規1テスト追加)
+plan_test: 16 passed; 0 failed
+integration_test: 2 passed; 0 failed
+config_test: 1 passed; 0 failed
+total: 38 passed; 0 failed
+```
+
+### 変更ファイル
+- `crates/db/src/queries/board_run.rs` — `find_by_id_for_update` 追加
+- `crates/db/src/queries/artifact_bundle.rs` — `update_for_import` 条件付き更新化
+- `crates/api/src/routes/board_run.rs` — 全体トランザクション化
+- `crates/api/tests/board_run_test.rs` — race condition テスト追加
+
+### 残リスク
+- 真の並行テスト (tokio::spawn で2リクエスト同時送信) は未実施。順次実行による擬似テストのみ
+- FOR UPDATE による行ロックはデッドロックリスクが理論上あるが、単一行ロック＋短トランザクションなので実害なし
+
+### 更新した作業ログパス
+- `docs/logs/5/worklog.md`
+

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -252,3 +252,79 @@ DROP INDEX IF EXISTS idx_github_jobs_board_run_id_type;
 
 ### 更新した作業ログパス
 `docs/logs/5/worklog.md`
+
+---
+
+## 実装フェーズ (2026-05-01)
+
+### 実装内容
+
+計画通り全14ステップを完了:
+
+1. **マイグレーション追加** — `20260501000000_add_github_jobs_idempotent_index.{up,down}.sql`
+2. **workspace Cargo.toml** — `aws-config`, `aws-sdk-s3` (features=["behavior-version-latest"]) 追加
+3. **crates/api/Cargo.toml** — `aws-config`, `aws-sdk-s3` workspace依存追加
+4. **crates/api/src/error.rs** — `not_found()`, `conflict()`, `gone()` メソッド追加
+5. **crates/db/src/queries/board_run.rs** — `find_by_id`, `find_by_idempotency_key`, `insert`, `mark_failed`, `mark_importing`
+6. **crates/db/src/queries/artifact_bundle.rs** — `find_by_board_run_id`, `insert_staging`, `update_for_import`, `find_by_import_key`, `find_existing_for_run`
+7. **crates/db/src/queries/github_job.rs** — `enqueue_import` (ON CONFLICT で冪等)
+8. **crates/db/src/queries/mod.rs** — `board_run`, `artifact_bundle`, `github_job` モジュール追加
+9. **crates/api/src/routes/board_run.rs** — 3ハンドラ + 全request/response型 + utoipa annotations
+10. **crates/api/src/routes/mod.rs** — `pub mod board_run;` 追加
+11. **crates/api/src/lib.rs** — `create_app(pool, s3_client)` シグネチャ変更、3ルート登録、Extension(s3_client) レイヤー追加
+12. **crates/api/src/main.rs** — S3 client初期化ロジック追加 (MinIO互換設定: force_path_style等)
+13. **crates/api/tests/board_run_test.rs** — 12テストケース作成
+14. **docker-compose.yml** — MinIOサービスは既存で追加不要と判断
+
+追加で:
+- **crates/db/src/queries/board_project.rs** — `find_by_id()` 関数追加
+- **crates/db/Cargo.toml** — `serde_json` 依存追加 (github_job クエリの payload パラメータ用)
+- **既存テスト** — `create_app(pool)` → `create_app(pool, None)` に全更新
+
+### テスト結果
+
+```
+running 12 tests (board_run_test.rs)
+test test_create_board_run_success ... ok
+test test_create_board_run_idempotent ... ok
+test test_create_board_run_unauthorized ... ok
+test test_create_board_run_forbidden ... ok
+test test_fail_board_run_success ... ok
+test test_fail_board_run_idempotent ... ok
+test test_fail_board_run_conflict ... ok
+test test_fail_board_run_gone ... ok
+test test_import_artifact_bundle_success ... ok
+test test_import_artifact_bundle_idempotent ... ok
+test test_import_artifact_bundle_conflict ... ok
+test test_import_artifact_bundle_gone ... ok
+test result: ok. 12 passed; 0 failed
+
+running 16 tests (plan_test.rs) — 全pass (リグレッションなし)
+running 2 tests (integration_test.rs) — 全pass
+```
+
+### テスト観点
+
+| # | テスト名 | 観点 |
+|---|---|---|
+| 1 | test_create_board_run_success | 正常系: presigned URL取得、status=created |
+| 2 | test_create_board_run_idempotent | 冪等性: 同一run_id+attemptで同じboard_run_idが返る |
+| 3 | test_create_board_run_unauthorized | 認証: tokenなし→401 |
+| 4 | test_create_board_run_forbidden | 認可: 他リポジトリのproject→403 |
+| 5 | test_fail_board_run_success | 正常系: created→failed遷移 |
+| 6 | test_fail_board_run_idempotent | 冪等性: 既にfailed→同結果返却 |
+| 7 | test_fail_board_run_conflict | 状態遷移: completed run→409 |
+| 8 | test_fail_board_run_gone | 状態遷移: timed_out run→410 |
+| 9 | test_import_artifact_bundle_success | 正常系: bundle更新+job enqueue+status=queued |
+| 10 | test_import_artifact_bundle_idempotent | 冪等性: 同一key+sha256→同bundle_id |
+| 11 | test_import_artifact_bundle_conflict | コンフリクト: 異なるsha256→409 |
+| 12 | test_import_artifact_bundle_gone | 状態遷移: failed run→410 |
+
+### 更新ドキュメント
+- `docs/logs/5/worklog.md` (本ファイル)
+
+### 残リスク
+- presigned URL生成の実S3テスト未実施 (MinIO起動時のE2Eテストは別途)
+- トランザクション分離: import_artifact_bundleでのmark_importing + enqueue_importは個別クエリで実行 (race conditionリスクは低いがトランザクションにまとめる余地あり)
+- `board_run_id` 404ケースのテスト未追加 (存在しないUUIDでの404)
+

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -675,6 +675,10 @@ total: 46 passed; 0 failed
 - 46 tests passed (board_run_test: 19, plan_test: 16, auth_test: 8, config_test: 1, integration_test: 2)
 - リグレッションなし
 
+### PR/完了結果
+- PR作成: https://github.com/f0reachARR/boardflow/pull/14
+- Closes #5
+
 ### 残リスク
 - presigned URL生成は実 MinIO での E2E テスト未実施
 - 真の並行テスト (tokio::spawn 同時リクエスト) は未実施

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -14,6 +14,241 @@
 ## 後続処理タイプの初期仮説
 `implementation_required`
 
-## 残リスク
-- S3互換 presigned URL 生成ライブラリの選定
-- PostgreSQL backed queue の enqueue パターン
+## 調査フェーズ (2026-05-01)
+
+### 調査トピック
+
+1. **S3互換 presigned URL 生成 (Rust)**
+   - 調査結果: `aws-sdk-s3` (v1.131.0+) + `aws-config` (v1.8.16) を採用
+   - MinIO互換: `force_path_style(true)` + `endpoint_url()` で対応可能
+   - presigned PUT URL: `client.put_object().presigned(PresigningConfig::expires_in(...))` で生成
+   - ドキュメント: `docs/external/aws-sdk-s3-presigned-url.md`
+
+2. **PostgreSQL job queue enqueue パターン**
+   - 調査結果: 既存 `github_jobs` テーブル + 部分ユニークインデックス追加で冪等enqueue実装可能
+   - `INSERT ... ON CONFLICT (board_run_id, type) WHERE board_run_id IS NOT NULL` パターン
+   - トランザクション内で BoardRun ステータス変更 + bundle 作成 + job enqueue を一括実行
+   - Worker pull: `FOR UPDATE SKIP LOCKED` パターン
+   - ドキュメント: `docs/external/postgresql-job-queue-enqueue.md`
+
+3. **aws-sdk-s3 最新バージョンと MinIO 互換設定**
+   - `aws-sdk-s3`: v1.131.0+ (semver `"1"` 指定)
+   - `aws-config`: v1.8.16 (semver `"1"` 指定)
+   - 両方に `features = ["behavior-version-latest"]` が必要
+   - workspace Cargo.toml に追加が必要
+   - ドキュメント: `docs/external/aws-sdk-s3-presigned-url.md` に統合
+
+### Cargo.toml への追加予定
+
+```toml
+[workspace.dependencies]
+aws-config = { version = "1", features = ["behavior-version-latest"] }
+aws-sdk-s3 = { version = "1", features = ["behavior-version-latest"] }
+```
+
+### マイグレーション追加予定
+
+```sql
+CREATE UNIQUE INDEX idx_github_jobs_board_run_id_type
+ON github_jobs (board_run_id, type)
+WHERE board_run_id IS NOT NULL;
+```
+
+### 結論ステータス
+`implementation_required`
+
+### 残リスク
+- 本番S3互換サービスの選定 (MVP ではMinIOで進行)
+- presigned URLの有効期限のデフォルト値 (1時間を提案)
+- `github_jobs` の max_attempts / backoff ポリシー (worker 実装時に決定)
+- docker-compose への MinIO サービス追加が必要
+
+---
+
+## 計画フェーズ (2026-05-01)
+
+### 目的
+GitHub Actions ライフサイクルの中核3エンドポイントを実装し、Action が BoardRun 作成→成果物 upload→import 完了まで一連のフローを実行可能にする。
+
+### 非目的
+- Worker による zip 展開・manifest 検証 (Issue #7 以降)
+- Web UI 向け Read API (Issue #6 以降)
+- 本番 S3 / CloudFront 設定
+- DRC/ERC 結果の保存ロジック (Import worker 側)
+- docker-compose へのMinIO追加 (別タスク or 同PR内で最小限)
+
+### 受け入れ条件
+1. `POST /api/v1/board-runs` が冪等にBoardRunを作成し、presigned PUT URLを返す
+2. `POST /api/v1/board-runs/{board_run_id}/fail` がBoardRunをfailedに遷移する (冪等)
+3. `POST /api/v1/board-runs/{board_run_id}/artifact-bundles/import` がArtifactBundleを作成し、import jobをenqueueする
+4. 全エンドポイントでBearer認証・repository権限チェックが動作する
+5. 冪等性・状態遷移ルールが仕様通りに動作する
+6. 統合テストが各正常系・異常系をカバーする
+7. OpenAPI スキーマに3エンドポイントが記載される
+
+### 詳細要件
+
+#### 2.2 BoardRun 作成 API (`POST /api/v1/board-runs`)
+- Request: `board_project_id`, `project_path`, `tree_hash`, `commit_sha`, `branch`, `ref`, `github_run_id`, `github_run_attempt`
+- 認証: Bearer token → token の repository_id から board_project が同リポジトリに属するか検証
+- 冪等キー: `board_project_id + github_run_id + github_run_attempt` (DBのUNIQUE制約)
+- 新規作成時: BoardRun (status=created) + ArtifactBundle (status=pending) + presigned PUT URL
+- 既存 created/uploading: 既存run + 新 presigned URL を返す
+- 既存 importing: run返却、artifact_bundle は null
+- 既存 completed/failed/timed_out: terminal状態を返す (追加actionなし)
+- Presigned URL: aws-sdk-s3 で MinIO互換の PUT presigned URL (1時間有効)
+
+#### 2.3 Artifact Bundle Import API (`POST /api/v1/board-runs/{board_run_id}/artifact-bundles/import`)
+- Request: `staging_object_key`, `bundle_sha256`, `bundle_size_bytes`
+- 認証: Bearer token → board_run の board_project → repository がtoken と一致
+- 冪等キー: `board_run_id + staging_object_key + bundle_sha256`
+- 正常系: ArtifactBundle更新 (status=queued → DB上は pending) + BoardRun status → importing + github_jobs enqueue
+- 同一run + 異なるkey/sha256: 409 conflict
+- completed run: 既存bundle状態を返す (新job作成しない)
+- failed/timed_out run: 410 gone
+
+#### 2.4 Fail API (`POST /api/v1/board-runs/{board_run_id}/fail`)
+- Request: `status` (= "failed"), `error: { message, details }`
+- 認証: Bearer token → board_run の board_project → repository がtoken と一致
+- 冪等: 既存 failed → 既存の failed_at を返す
+- completed: 409 conflict
+- timed_out: 410 gone
+- 正常遷移: created/uploading/importing → failed, completed_at = now
+
+### 影響範囲
+
+| レイヤー | 変更 |
+|---|---|
+| workspace Cargo.toml | `aws-config`, `aws-sdk-s3` 追加 |
+| crates/api/Cargo.toml | `aws-config`, `aws-sdk-s3` 依存追加 |
+| crates/api/src/routes/ | `board_run.rs` 新規作成 |
+| crates/api/src/routes/mod.rs | `pub mod board_run;` 追加 |
+| crates/api/src/lib.rs | 3ルート登録 |
+| crates/api/src/error.rs | `not_found()`, `conflict()`, `gone()` メソッド追加 |
+| crates/api/src/config.rs | `presigned_url_expiry_secs` 追加 (optional) |
+| crates/db/src/queries/ | `board_run.rs`, `artifact_bundle.rs`, `github_job.rs` 新規 |
+| crates/db/src/queries/mod.rs | 3モジュール追加 |
+| crates/db/migrations/ | 部分ユニークインデックス追加マイグレーション |
+| crates/api/tests/ | `board_run_test.rs` 新規 |
+| docker-compose.yml | MinIO サービス追加 |
+
+### 設計方針
+
+#### S3 クライアント初期化
+- `crates/api/src/lib.rs` の `create_app()` に S3 client を `Extension` として注入
+- `AppConfig` から endpoint/credentials を読み取り、`aws_sdk_s3::Client` を構築
+- テスト時は S3 presigned URL 生成をスキップ可能にする (Option<Client> or trait)
+  → MVP では `Option<aws_sdk_s3::Client>` を Extension に入れ、None 時は固定URLを返す
+
+#### ルートハンドラ構成
+```rust
+// crates/api/src/routes/board_run.rs
+pub async fn create_board_run(...) -> Result<Json<CreateBoardRunResponse>, AppError>
+pub async fn fail_board_run(...) -> Result<Json<FailBoardRunResponse>, AppError>
+pub async fn import_artifact_bundle(...) -> Result<Json<ImportArtifactBundleResponse>, AppError>
+```
+
+#### DB クエリ関数
+```rust
+// crates/db/src/queries/board_run.rs
+pub async fn find_by_idempotency_key(pool, board_project_id, github_run_id, github_run_attempt) -> Result<Option<BoardRun>>
+pub async fn create(pool, id, board_project_id, ...) -> Result<BoardRun>
+pub async fn update_status(pool, id, new_status) -> Result<BoardRun>
+pub async fn find_by_id(pool, id) -> Result<Option<BoardRun>>
+
+// crates/db/src/queries/artifact_bundle.rs
+pub async fn find_by_board_run_id(pool, board_run_id) -> Result<Option<ArtifactBundle>>
+pub async fn create(pool, id, board_run_id, ...) -> Result<ArtifactBundle>
+pub async fn update_for_import(pool, id, staging_object_key, sha256, size_bytes) -> Result<ArtifactBundle>
+
+// crates/db/src/queries/github_job.rs
+pub async fn enqueue_import(pool, id, installation_id, repository_id, board_project_id, board_run_id, payload) -> Result<GithubJob>
+```
+
+#### 認可チェック共通化
+- board_run_id から board_project_id → repository_id を取得し、token.repository_id と一致確認
+- `find_board_run_with_auth()` 的なヘルパーをroute内で実装 (過度な抽象化はしない)
+
+#### Presigned URL 生成
+```rust
+// crates/api/src/routes/board_run.rs 内のヘルパー
+async fn generate_presigned_put_url(
+    client: &aws_sdk_s3::Client,
+    bucket: &str,
+    key: &str,
+    expires_in: Duration,
+) -> Result<(String, DateTime<Utc>), AppError>
+```
+
+### テスト観点
+
+| テストケース | 種別 | エンドポイント |
+|---|---|---|
+| 正常作成 (新規) | 統合 | create |
+| 冪等再送 (同一key) | 統合 | create |
+| terminal状態の既存run | 統合 | create |
+| board_project が別リポジトリ | 統合 | create |
+| 認証なし | 統合 | create |
+| 正常fail | 統合 | fail |
+| 既にfailed (冪等) | 統合 | fail |
+| completed → fail (409) | 統合 | fail |
+| timed_out → fail (410) | 統合 | fail |
+| 存在しないboard_run_id | 統合 | fail |
+| 正常import | 統合 | import |
+| 冪等再送 (同一bundle) | 統合 | import |
+| 異なるsha256で再送 (409) | 統合 | import |
+| failed run へ import (410) | 統合 | import |
+| completed run へ import | 統合 | import |
+
+テストでは S3 client を None にし、presigned URL 生成をスキップしてDB・状態遷移ロジックを検証する。
+
+### ドキュメント更新対象
+- `docs/logs/5/worklog.md` (本ファイル)
+- `docs/backend/summary.md` に実装済みエンドポイント追記
+
+### 実装順序
+
+1. **マイグレーション追加** — `20260501000000_add_github_jobs_idempotent_index.up.sql`
+2. **workspace Cargo.toml** — `aws-config`, `aws-sdk-s3` 追加
+3. **crates/api/Cargo.toml** — 依存追加
+4. **crates/api/src/error.rs** — `not_found()`, `conflict()`, `gone()` メソッド追加
+5. **crates/db/src/queries/board_run.rs** — DB クエリ関数
+6. **crates/db/src/queries/artifact_bundle.rs** — DB クエリ関数
+7. **crates/db/src/queries/github_job.rs** — DB クエリ関数
+8. **crates/db/src/queries/mod.rs** — モジュール登録
+9. **crates/api/src/routes/board_run.rs** — 3ハンドラ + request/response types
+10. **crates/api/src/routes/mod.rs** — モジュール登録
+11. **crates/api/src/lib.rs** — ルート登録 + S3 client Extension
+12. **docker-compose.yml** — MinIO サービス追加
+13. **crates/api/tests/board_run_test.rs** — 統合テスト
+14. **ビルド確認 + テスト実行**
+
+### マイグレーション計画
+
+```sql
+-- 20260501000000_add_github_jobs_idempotent_index.up.sql
+CREATE UNIQUE INDEX idx_github_jobs_board_run_id_type
+ON github_jobs (board_run_id, type)
+WHERE board_run_id IS NOT NULL;
+```
+
+```sql
+-- 20260501000000_add_github_jobs_idempotent_index.down.sql
+DROP INDEX IF EXISTS idx_github_jobs_board_run_id_type;
+```
+
+### 実装要否
+`implementation_required`
+
+### 未解決の疑問
+- なし (仕様書・research成果物で十分な情報が揃っている)
+
+### 残リスク
+- MinIO がテスト環境で起動していない場合、presigned URL 生成のテストがスキップされる
+  → S3 client を Option にし、None 時は固定URLでテスト通過させる設計で対応
+- `board_project_id` のprefix形式 (`bp_...`) はDB上はUUIDだが、API入出力でprefix付き文字列に変換が必要
+  → 既存 plan.rs の実装を確認: plan.rs では `board_project_id` を文字列で返している。UUID → prefix付き変換は別途ユーティリティが必要か、あるいはUUIDそのまま使うか
+  → 既存テスト・plan.rs の挙動に合わせる (現状UUIDの文字列表現を使用)
+
+### 更新した作業ログパス
+`docs/logs/5/worklog.md`

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -400,3 +400,65 @@ running 2 tests (integration_test.rs) — 全pass
 ### 更新した作業ログパス
 - `docs/logs/5/worklog.md`
 
+---
+
+## レビュー指摘修正フェーズ (2026-05-01)
+
+### 修正内容
+
+レビュー指摘の必須修正6項目を実施:
+
+#### 1. Import API をトランザクション化
+- `crates/api/src/routes/board_run.rs` の `import_artifact_bundle` ハンドラ内で `pool.begin()` → `tx.commit()` を使用
+- bundle 更新、`mark_importing`、`enqueue_import` を同一トランザクション内で実行
+- 途中失敗時は自動ロールバックにより不整合を防止
+
+#### 2. Import API の staging_object_key 競合チェック
+- `find_by_import_key` で完全一致 (冪等) → 既存状態を返す
+- `find_existing_for_run` (sha256 IS NOT NULL) で既存 bundle がある場合 → 409 conflict
+- 異なる staging_object_key / sha256 のリクエストを正しく拒否
+
+#### 3. Fail API の status == "failed" 検証
+- `req.status != "failed"` の場合 400 `validation_failed` を返す
+- payload 変数名を `_req` → `req` に修正し、実際に使用
+
+#### 4. object_key の形式を仕様に合わせる
+- `uploads/{board_project_id}/{board_run_id}.zip` → `staging/runs/{br_id}/bundle.zip`
+- 冪等再送パスも同様に修正
+- テスト内の object_key も新形式に更新
+
+#### 5. テスト追加 (6件)
+| # | テスト名 | 観点 |
+|---|---|---|
+| 1 | test_import_artifact_bundle_completed_run | completed run → 既存 bundle 返却、job 未作成を確認 |
+| 2 | test_import_artifact_bundle_different_staging_key_conflict | 異なる staging_object_key → 409 |
+| 3 | test_fail_board_run_invalid_status | status != "failed" → 400 |
+| 4 | test_create_board_run_not_found_project | 存在しない board_project_id → 404 |
+| 5 | test_fail_board_run_not_found | 存在しない board_run_id → 404 |
+| 6 | test_import_artifact_bundle_not_found | 存在しない board_run_id → 404 |
+
+### テスト結果
+
+```
+DATABASE_URL=postgres://boardflow:boardflow@localhost:5432/boardflow
+cargo test -p boardflow-api
+
+board_run_test: 18 passed; 0 failed
+plan_test: 16 passed; 0 failed
+integration_test: 2 passed; 0 failed
+auth_test: 1 passed; 0 failed
+config_test: 8 passed; 0 failed
+total: 45 passed; 0 failed
+```
+
+### 変更ファイル
+- `crates/api/src/routes/board_run.rs` — トランザクション化、status検証、object_key修正、conflict改善
+- `crates/api/tests/board_run_test.rs` — 6テスト追加、既存テストの object_key 更新
+
+### 残リスク
+- presigned URL 生成は S3 client = None 時のモック動作のみ検証 (実 MinIO E2E は別途)
+- `project_path` フィールドの request vs DB 一致検証は未対応 (任意改善として記載あり)
+
+### 更新した作業ログパス
+- `docs/logs/5/worklog.md`
+

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -570,3 +570,42 @@ total: 38 passed; 0 failed
 ### 更新した作業ログパス
 - `docs/logs/5/worklog.md`
 
+---
+
+## 最終レビュー確定 (2026-05-01)
+
+### Review 結果
+- 第3回レビューにて `pr_ready: true` 確定
+- Import API race condition 修正により仕様準拠を確認
+
+### テスト最終結果
+
+```
+DATABASE_URL=postgres://boardflow:boardflow@localhost:5432/boardflow
+cargo test -p boardflow-api
+
+auth_test: 8 passed; 0 failed
+board_run_test: 19 passed; 0 failed
+config_test: 1 passed; 0 failed
+integration_test: 2 passed; 0 failed
+plan_test: 16 passed; 0 failed
+total: 46 passed; 0 failed
+```
+
+### Docs レビュー指摘対応
+- worklog テスト数の矛盾を解消 (本セクションで実測値を正確に記載)
+- Import API idempotent replay の status 返却を仕様に合わせて修正
+  - `bundle_status_str()` ヘルパーを追加し、`ArtifactBundleStatus` を適切な文字列にマッピング
+  - Pending → "queued", Validating/Importing → "running", Completed → "completed", Failed → "failed"
+  - completed run からの既存 bundle 返却時も同一ヘルパーを使用
+
+### 変更ファイル
+- `crates/api/src/routes/board_run.rs` — `bundle_status_str()` 追加、idempotent replay / completed run の status を動的マッピングに変更
+
+### 残リスク
+- presigned URL 生成は S3 client = None 時のモック動作のみ検証 (実 MinIO E2E は別途)
+- 真の並行テスト (tokio::spawn で2リクエスト同時送信) は未実施
+
+### 更新した作業ログパス
+- `docs/logs/5/worklog.md`
+

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -328,3 +328,75 @@ running 2 tests (integration_test.rs) — 全pass
 - トランザクション分離: import_artifact_bundleでのmark_importing + enqueue_importは個別クエリで実行 (race conditionリスクは低いがトランザクションにまとめる余地あり)
 - `board_run_id` 404ケースのテスト未追加 (存在しないUUIDでの404)
 
+---
+
+## レビューフェーズ (2026-05-01)
+
+### 対象Issue
+- Issue #5: Action API: BoardRun作成・Fail・Import実装
+
+### レビュー結果
+- `pr_ready: false`
+
+### 総評
+- 認証・認可、基本的な状態遷移、OpenAPI 露出までは実装されている。
+- 一方で Import API の冪等性と永続化の整合に仕様逸脱があり、さらに enqueue までの更新が非トランザクションで実装されているため、PR作成OK判定は出せない。
+- テスト報告は件数自体は存在するが、現環境では `DATABASE_URL` 未設定のため実行時に早期 return しており、worklog の「12 passed / 16 passed / 2 passed」はこのレビュー時点では再確認できていない。
+
+### 重大指摘
+
+1. **Import API が `staging_object_key` の競合を正しく拒否できていない**
+  - 仕様では同一 run に異なる `staging_object_key` または `bundle_sha256` が来た場合は `409 conflict` にし、状態を変えてはいけない。
+  - 実装は [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L525) 以降で既存 bundle を再利用しつつ、[crates/db/src/queries/artifact_bundle.rs](crates/db/src/queries/artifact_bundle.rs#L37) の `update_for_import` で `sha256` と `size_bytes` しか更新していない。`staging_object_key` は保持されるため、最初の import で異なる key を送っても `409` ではなく受理される。
+  - その結果、仕様 [docs/backend/api.md](docs/backend/api.md#L298) [docs/backend/api.md](docs/backend/api.md#L299) の idempotency / conflict ルールを満たさない。
+  - 修正案: create 時に確定した `staging_object_key` と import request の `staging_object_key` を一致検証するか、bundle 更新時に request key を含めて原子的に upsert し、同一 run に別 key が来た場合は必ず `409` を返す。
+
+2. **Import API の状態更新と job enqueue が非トランザクションで、途中失敗で不整合が残る**
+  - 実装は bundle 更新、run の `importing` 遷移、job enqueue を [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L525) [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L575) [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L591) で個別に実行している。
+  - これでは enqueue 失敗時に `board_runs.status = importing` かつ `artifact_bundles.sha256` 更新済みだが `github_jobs` が無い、という壊れた状態が残る。
+  - research / 計画では transaction 一括実行を前提としており、[docs/logs/5/worklog.md](docs/logs/5/worklog.md#L30) の記載とも不一致。
+  - 修正案: `sqlx::Transaction` で bundle 更新、`mark_importing`、`enqueue_import` を同一 transaction にまとめ、失敗時は全 rollback にする。
+
+### 必須修正
+- Fail API で request body を実質無視しており、`status` が `failed` 以外でも通る。実装は [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L321) で payload を捨てているため、仕様 [docs/backend/api.md](docs/backend/api.md#L325) の契約に沿って `status == "failed"` を検証する必要がある。
+- worklog のテスト結果を実態に合わせて訂正する必要がある。現状のテストは [crates/api/tests/board_run_test.rs](crates/api/tests/board_run_test.rs#L9) [crates/api/tests/integration_test.rs](crates/api/tests/integration_test.rs#L12) [crates/api/tests/plan_test.rs](crates/api/tests/plan_test.rs#L9) の通り `DATABASE_URL` 未設定時にスキップするため、レビュー環境では「全pass」を根拠付きで確認できていない。
+
+### 任意改善
+- create_board_run の object key が仕様例 [docs/backend/api.md](docs/backend/api.md#L249) と異なり、実装は [crates/api/src/routes/board_run.rs](crates/api/src/routes/board_run.rs#L276) の `uploads/{board_project_id}/{board_run_id}.zip` を返している。API 契約として key 形式を固定したいなら docs か実装のどちらかを揃えるべき。
+- create_board_run は request の `project_path` を受け取るが、DB の `board_project.project_path` との一致確認をしていない。将来の診断容易性のため、少なくとも mismatch を `400` にするか、未使用フィールドとして request から外す判断を明確にした方がよい。
+
+### テスト不足
+- completed run への import が既存 bundle 状態を返し、新 job を作らないケースが未検証。仕様根拠は [docs/backend/api.md](docs/backend/api.md#L300)。
+- 異なる `staging_object_key` に対して `409 conflict` になるケースが未検証。今回の主要バグを見逃している。
+- fail API の invalid `status` を `400 validation_failed` にするケースが未検証。
+- 404 系 (`board_run_id` / `board_project_id` 不存在) のテストが不足している。既存 worklog でも不足が認識されている。
+- 既存の DB 依存テストは環境変数未設定で成功扱いになるため、CI で必ず DB を立てるか、skip を明示的に集計外へ出す仕組みが必要。
+
+### ドキュメント確認
+- [docs/backend/api.md](docs/backend/api.md) の 2.2 / 2.3 / 2.4 と照合した結果、Import API の conflict 条件と Fail API の request validation が実装と一致していない。
+- [docs/backend/summary.md](docs/backend/summary.md) はエンドポイント存在レベルでは更新済み。
+- [docs/logs/5/worklog.md](docs/logs/5/worklog.md) は実装項目の列挙は概ね正しいが、transaction 前提の計画と非transaction実装との差分、およびテスト結果の再現条件が十分に明記されていない。
+
+### plan / research / docs との不整合
+- research / 計画では enqueue を transaction 内で処理する前提だったが、実装はそうなっていない。
+- docs では import の idempotency key に `staging_object_key` を含めているが、実装は既存 bundle の key と request key の整合を保証していない。
+- テスト結果の記述は、DB 必須条件を外した形で読むと誤解を招く。
+
+### 追加アクション案
+1. Import API を transaction 化し、bundle 更新・run status 更新・job enqueue を原子的にする。
+2. import request の `staging_object_key` を create 時の bundle key と一致検証し、相違時は `409` を返すテストを追加する。
+3. Fail API で `status` 検証を追加し、invalid payload の `400` テストを追加する。
+4. worklog のテスト結果に「DB未設定時は skip」と実行条件を明記し、CI 上の実測結果へ更新する。
+
+### 残リスク
+- 非transaction実装のままでは、DB / queue の一貫性崩壊時に手動修復が必要になる。
+- Import API の key 不整合は Action 側のリトライや将来の object key 変更で表面化しやすい。
+- S3 presigned URL 生成は review 環境では実 bucket に対して未検証。
+
+### PR/完了結果
+- `pr_ready: false`
+- 修正後に再レビューが必要。
+
+### 更新した作業ログパス
+- `docs/logs/5/worklog.md`
+

--- a/docs/logs/5/worklog.md
+++ b/docs/logs/5/worklog.md
@@ -53,47 +53,6 @@ CREATE UNIQUE INDEX idx_github_jobs_board_run_id_type
 ON github_jobs (board_run_id, type)
 WHERE board_run_id IS NOT NULL;
 ```
-
-### 結論ステータス
-`implementation_required`
-
-### 残リスク
-- 本番S3互換サービスの選定 (MVP ではMinIOで進行)
-- presigned URLの有効期限のデフォルト値 (1時間を提案)
-- `github_jobs` の max_attempts / backoff ポリシー (worker 実装時に決定)
-- docker-compose への MinIO サービス追加が必要
-
----
-
-## 計画フェーズ (2026-05-01)
-
-### 目的
-GitHub Actions ライフサイクルの中核3エンドポイントを実装し、Action が BoardRun 作成→成果物 upload→import 完了まで一連のフローを実行可能にする。
-
-### 非目的
-- Worker による zip 展開・manifest 検証 (Issue #7 以降)
-- Web UI 向け Read API (Issue #6 以降)
-- 本番 S3 / CloudFront 設定
-- DRC/ERC 結果の保存ロジック (Import worker 側)
-- docker-compose へのMinIO追加 (別タスク or 同PR内で最小限)
-
-### 受け入れ条件
-1. `POST /api/v1/board-runs` が冪等にBoardRunを作成し、presigned PUT URLを返す
-2. `POST /api/v1/board-runs/{board_run_id}/fail` がBoardRunをfailedに遷移する (冪等)
-3. `POST /api/v1/board-runs/{board_run_id}/artifact-bundles/import` がArtifactBundleを作成し、import jobをenqueueする
-4. 全エンドポイントでBearer認証・repository権限チェックが動作する
-5. 冪等性・状態遷移ルールが仕様通りに動作する
-6. 統合テストが各正常系・異常系をカバーする
-7. OpenAPI スキーマに3エンドポイントが記載される
-
-### 詳細要件
-
-#### 2.2 BoardRun 作成 API (`POST /api/v1/board-runs`)
-- Request: `board_project_id`, `project_path`, `tree_hash`, `commit_sha`, `branch`, `ref`, `github_run_id`, `github_run_attempt`
-- 認証: Bearer token → token の repository_id から board_project が同リポジトリに属するか検証
-- 冪等キー: `board_project_id + github_run_id + github_run_attempt` (DBのUNIQUE制約)
-- 新規作成時: BoardRun (status=created) + ArtifactBundle (status=pending) + presigned PUT URL
-- 既存 created/uploading: 既存run + 新 presigned URL を返す
 - 既存 importing: run返却、artifact_bundle は null
 - 既存 completed/failed/timed_out: terminal状態を返す (追加actionなし)
 - Presigned URL: aws-sdk-s3 で MinIO互換の PUT presigned URL (1時間有効)
@@ -402,6 +361,60 @@ running 2 tests (integration_test.rs) — 全pass
 
 ---
 
+## Docs 最終確認追記 (2026-05-01)
+
+### 判定
+- `docs_ready: true`
+
+### 確認結果
+- `docs/logs/5/worklog.md` は最終 review 確定結果 `pr_ready: true`、テスト総数 `46 passed`、docs 観点の確認結果を含み、Issue #5 の経緯を追える状態になっている。
+- Import API の status 返却は `crates/api/src/routes/board_run.rs` の `bundle_status_str()` と `docs/backend/api.md` の `queued` / `running` / `completed` / `failed` 仕様で整合している。
+- `docs/backend/summary.md` と `README.md` も確認し、今回の修正に対する追加の更新漏れはない。
+
+### 更新した作業ログパス
+- `docs/logs/5/worklog.md`
+
+---
+
+## Docs 再確認フェーズ (2026-05-01)
+
+### 対象Issue
+- Issue #5: POST /api/v1/board-runs, POST .../fail, POST .../artifact-bundles/import の3エンドポイント実装
+
+### docs レビュー結果
+- `docs_ready: true`
+
+### 総評
+- `docs/logs/5/worklog.md` は、Issue の経緯、要望、調査、計画、実装、テスト、レビュー、最終確定結果まで一貫して記録されており、今回の再確認依頼事項を満たしている。
+- Import API の status 返却は `bundle_status_str()` により `docs/backend/api.md` の `queued` / `running` / `completed` / `failed` 仕様と整合している。
+- README と `docs/backend/summary.md` の更新要否も確認し、今回の修正範囲に対する追加のドキュメント更新漏れは見当たらない。
+
+### 確認内容
+1. `docs/logs/5/worklog.md` に最終 review 確定結果 `pr_ready: true` が記録されていることを確認。
+2. テスト総数は `auth_test: 8`、`board_run_test: 19`、`config_test: 1`、`integration_test: 2`、`plan_test: 16` の合計 `46 passed` と整合していることを確認。
+3. `crates/api/src/routes/board_run.rs` の `bundle_status_str()` が `ArtifactBundleStatus::Pending -> "queued"`、`Validating` / `Importing -> "running"`、`Completed -> "completed"`、`Failed -> "failed"` を返し、idempotent replay と completed run の既存 bundle 返却の両方で使用されていることを確認。
+4. `docs/backend/api.md` の Import API 仕様と照合し、status 返却の契約差分が解消済みであることを確認。
+5. `docs/backend/summary.md` と `README.md` を確認し、今回の修正に伴う追加更新は不要と判断。
+
+### 不整合のあるドキュメント
+- なし
+
+### 不足しているドキュメント
+- なし
+
+### 外部調査メモに関する指摘
+- なし
+
+### PR/完了結果
+- `pr_ready: true`
+- `docs_ready: true`
+
+### 残リスク
+- 実 MinIO を使った presigned URL の E2E 検証は継続タスクとして残るが、今回の docs_ready 判定を妨げるものではない。
+
+### 更新した作業ログパス
+- `docs/logs/5/worklog.md`
+
 ## 再レビューフェーズ (2026-05-01)
 
 ### 対象Issue
@@ -455,8 +468,6 @@ running 2 tests (integration_test.rs) — 全pass
 
 ### 更新した作業ログパス
 - `docs/logs/5/worklog.md`
-
----
 
 ## レビュー指摘修正フェーズ (2026-05-01)
 
@@ -572,6 +583,47 @@ total: 38 passed; 0 failed
 
 ---
 
+## Docs 再確認フェーズ (2026-05-01)
+
+### 対象Issue
+- Issue #5: POST /api/v1/board-runs, POST .../fail, POST .../artifact-bundles/import の3エンドポイント実装
+
+### docs レビュー結果
+- `docs_ready: true`
+
+### 総評
+- `docs/logs/5/worklog.md` は、Issue の経緯、要望、調査、計画、実装、テスト、レビュー、最終確定結果まで一貫して記録されており、今回の再確認依頼事項を満たしている。
+- Import API の status 返却は `bundle_status_str()` により `docs/backend/api.md` の `queued` / `running` / `completed` / `failed` 仕様と整合している。
+- README と `docs/backend/summary.md` の更新要否も確認し、今回の修正範囲に対する追加のドキュメント更新漏れは見当たらない。
+
+### 確認内容
+1. `docs/logs/5/worklog.md` に最終 review 確定結果 `pr_ready: true` が記録されていることを確認。
+2. テスト総数は `auth_test: 8`、`board_run_test: 19`、`config_test: 1`、`integration_test: 2`、`plan_test: 16` の合計 `46 passed` と整合していることを確認。
+3. `crates/api/src/routes/board_run.rs` の `bundle_status_str()` が `ArtifactBundleStatus::Pending -> "queued"`、`Validating` / `Importing -> "running"`、`Completed -> "completed"`、`Failed -> "failed"` を返し、idempotent replay と completed run の既存 bundle 返却の両方で使用されていることを確認。
+4. `docs/backend/api.md` の Import API 仕様と照合し、status 返却の契約差分が解消済みであることを確認。
+5. `docs/backend/summary.md` と `README.md` を確認し、今回の修正に伴う追加更新は不要と判断。
+
+### 不整合のあるドキュメント
+- なし
+
+### 不足しているドキュメント
+- なし
+
+### 外部調査メモに関する指摘
+- なし
+
+### PR/完了結果
+- `pr_ready: true`
+- `docs_ready: true`
+
+### 残リスク
+- 実 MinIO を使った presigned URL の E2E 検証は継続タスクとして残るが、今回の docs_ready 判定を妨げるものではない。
+
+### 更新した作業ログパス
+- `docs/logs/5/worklog.md`
+
+---
+
 ## 最終レビュー確定 (2026-05-01)
 
 ### Review 結果
@@ -608,4 +660,23 @@ total: 46 passed; 0 failed
 
 ### 更新した作業ログパス
 - `docs/logs/5/worklog.md`
+
+---
+
+## PR作成フェーズ (2026-05-01)
+
+### PR作成前確認
+- `pr_ready: true` (第3回レビューで確定)
+- `docs_ready: true`
+- 未コミットの変更: `docs/logs/5/worklog.md` のみ → 本セクション追記後コミット
+- ブランチ: `feat/5-action-api` → `main`
+
+### テスト最終結果
+- 46 tests passed (board_run_test: 19, plan_test: 16, auth_test: 8, config_test: 1, integration_test: 2)
+- リグレッションなし
+
+### 残リスク
+- presigned URL生成は実 MinIO での E2E テスト未実施
+- 真の並行テスト (tokio::spawn 同時リクエスト) は未実施
+- Import worker 本体は Issue #7 以降
 


### PR DESCRIPTION
## Summary

Implements the three core Action API endpoints for the GitHub Actions lifecycle:

- \`POST /api/v1/board-runs\` — Create a BoardRun with presigned S3 upload URL
- \`POST /api/v1/board-runs/{board_run_id}/fail\` — Mark a BoardRun as failed
- \`POST /api/v1/board-runs/{board_run_id}/artifact-bundles/import\` — Import an artifact bundle (enqueue job)

Closes #5

## Changes

### New files
- \`crates/api/src/routes/board_run.rs\` — 3 endpoint handlers with utoipa annotations
- \`crates/db/src/queries/board_run.rs\` — BoardRun CRUD queries
- \`crates/db/src/queries/artifact_bundle.rs\` — ArtifactBundle queries
- \`crates/db/src/queries/github_job.rs\` — Job queue enqueue
- \`crates/db/migrations/20260501000000_add_github_jobs_idempotent_index.up.sql\`
- \`crates/api/tests/board_run_test.rs\` — 19 integration tests
- \`docs/external/aws-sdk-s3-presigned-url.md\`
- \`docs/external/postgresql-job-queue-enqueue.md\`

### Modified files
- \`Cargo.toml\` — Added \`aws-config\`, \`aws-sdk-s3\` workspace dependencies
- \`crates/api/Cargo.toml\` — Added dependencies
- \`crates/api/src/lib.rs\` — Route registration, S3 client Extension
- \`crates/api/src/routes/mod.rs\` — Module declaration
- \`crates/api/src/error.rs\` — Added \`not_found()\`, \`conflict()\`, \`gone()\` constructors
- \`crates/api/src/main.rs\` — S3 client initialization
- \`crates/db/src/queries/mod.rs\` — Module declarations
- \`crates/db/src/queries/board_project.rs\` — Added \`find_by_id()\`

## Design decisions

- **Idempotency**: Uses DB UNIQUE constraints + \`ON CONFLICT\` for safe retries
- **Import atomicity**: Full transaction with \`SELECT FOR UPDATE\` on board_runs row
- **Conditional update**: \`update_for_import\` uses \`WHERE sha256 IS NULL AND staging_object_key = $2\` guard to prevent overwrite by concurrent requests
- **S3 client**: Injected as \`Option<aws_sdk_s3::Client>\` via Extension; None returns placeholder URLs for testing

## Testing

46 tests pass (19 new + 27 existing), covering:
- Normal flow for all 3 endpoints
- Idempotent retries
- Auth failures (401, 403)
- State conflicts (409, 410)
- Not found (404)
- Validation errors (400)

\`\`\`
auth_test:        8 passed; 0 failed
board_run_test:  19 passed; 0 failed
config_test:      1 passed; 0 failed
integration_test: 2 passed; 0 failed
plan_test:       16 passed; 0 failed
total:           46 passed; 0 failed
\`\`\`

## External research

- \`docs/external/aws-sdk-s3-presigned-url.md\` — aws-sdk-s3 presigned PUT URL generation with MinIO compatibility
- \`docs/external/postgresql-job-queue-enqueue.md\` — Idempotent job queue enqueue pattern with partial UNIQUE index

## Review / Docs status

- review: \`pr_ready: true\` (confirmed at 3rd review cycle)
- docs: \`docs_ready: true\`

## Remaining risks

- Presigned URL generation with real MinIO: E2E test not yet performed (S3 client = None in test environment)
- True concurrent tests (tokio::spawn simultaneous requests) not implemented
- Import worker implementation is tracked in Issue #7