### PR TITLE
test(#22): create_run_result_comment ハンドラの統合テスト追加

### DIFF
--- a/crates/worker/tests/run_result_comment_test.rs
+++ b/crates/worker/tests/run_result_comment_test.rs
@@ -398,9 +398,28 @@ async fn test_run_result_comment_success() {
         handler_result_debug(&result)
     );
 
-    // Verify create_comment was called
-    let captured = client.captured_comment_body.lock().unwrap();
-    assert!(captured.is_some(), "create_comment should have been called");
+    // Verify create_comment was called and body contains required elements (spec 12.2)
+    {
+        let captured = client.captured_comment_body.lock().unwrap();
+        let body = captured
+            .as_ref()
+            .expect("create_comment should have been called");
+        assert!(
+            body.contains("<!-- boardflow:comment_type=run_result -->"),
+            "Missing comment_type marker"
+        );
+        assert!(
+            body.contains(&format!("<!-- boardflow:board_run_id={current_run_id} -->")),
+            "Missing board_run_id marker"
+        );
+        assert!(body.contains("## BoardFlow Run Result"), "Missing header");
+        assert!(body.contains("Commit: `def5678`"), "Missing commit SHA");
+        assert!(body.contains("Run: https://"), "Missing Run URL");
+        assert!(body.contains("Diff: https://"), "Missing Diff URL");
+        assert!(body.contains("| Check | Result |"), "Missing table header");
+        assert!(body.contains("ERC"), "Missing ERC in table");
+        assert!(body.contains("DRC"), "Missing DRC in table");
+    }
 
     cleanup_test_data(&pool, repo_id, bp_id).await;
 }
@@ -433,11 +452,13 @@ async fn test_run_result_comment_skip_first_run() {
     );
 
     // Verify create_comment was NOT called
-    let captured = client.captured_comment_body.lock().unwrap();
-    assert!(
-        captured.is_none(),
-        "create_comment should NOT have been called for first run"
-    );
+    {
+        let captured = client.captured_comment_body.lock().unwrap();
+        assert!(
+            captured.is_none(),
+            "create_comment should NOT have been called for first run"
+        );
+    }
 
     cleanup_test_data(&pool, repo_id, bp_id).await;
 }
@@ -471,11 +492,13 @@ async fn test_run_result_comment_skip_no_change() {
     );
 
     // Verify create_comment was NOT called
-    let captured = client.captured_comment_body.lock().unwrap();
-    assert!(
-        captured.is_none(),
-        "create_comment should NOT have been called when no change"
-    );
+    {
+        let captured = client.captured_comment_body.lock().unwrap();
+        assert!(
+            captured.is_none(),
+            "create_comment should NOT have been called when no change"
+        );
+    }
 
     cleanup_test_data(&pool, repo_id, bp_id).await;
 }
@@ -643,6 +666,68 @@ async fn test_run_result_comment_issue_closed_recreate() {
     .await
     .unwrap();
     assert!(job_row.0 >= 1, "create_issue job should be enqueued");
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}
+
+// ─── Test 7b: Issue closed + recreate=true + tree_hash UNCHANGED ────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_issue_closed_tree_hash_unchanged() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, _prev_run_id, current_run_id, installation_id) =
+        setup_with_status_change(&pool).await;
+
+    // Make both runs have the SAME tree_hash so tree_hash_changed returns false
+    sqlx::query("UPDATE board_runs SET tree_hash = 'same_hash' WHERE board_project_id = $1")
+        .bind(bp_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let client = MockGitHubClient::default_success().with_get_issue(Ok(IssueInfo {
+        number: 1,
+        node_id: "MDU6SXNzdWUx".into(),
+        state: IssueState::Closed,
+        html_url: "https://github.com/test-owner/test-repo/issues/1".into(),
+    }));
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(current_run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    // tree_hash unchanged → Completed (no recreation, spec 13.1)
+    assert!(
+        matches!(result, boardflow_worker::handlers::HandlerResult::Completed),
+        "Expected Completed (tree_hash unchanged), got: {}",
+        handler_result_debug(&result)
+    );
+
+    // Verify issue_number was NOT cleared
+    let row: (Option<i32>,) =
+        sqlx::query_as("SELECT issue_number FROM board_projects WHERE id = $1")
+            .bind(bp_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(row.0, Some(1), "issue_number should NOT be cleared");
+
+    // Verify create_issue job was NOT enqueued
+    let job_row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM github_jobs WHERE board_project_id = $1 AND type = 'create_issue'",
+    )
+    .bind(bp_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert_eq!(job_row.0, 0, "create_issue job should NOT be enqueued");
 
     cleanup_test_data(&pool, repo_id, bp_id).await;
 }

--- a/crates/worker/tests/run_result_comment_test.rs
+++ b/crates/worker/tests/run_result_comment_test.rs
@@ -1,0 +1,797 @@
+//! Integration tests for create_run_result_comment handler.
+//!
+//! Requires DATABASE_URL to be set to a PostgreSQL database with migrations applied.
+//! Run with: `cargo test -p boardflow-worker --test run_result_comment_test -- --ignored`
+
+use boardflow_domain::models::github_job::{GithubJob, GithubJobStatus};
+use boardflow_github::{
+    CreatedComment, CreatedIssue, GitHubAppClient, GitHubClientError, IssueInfo, IssueState,
+};
+use chrono::Utc;
+use secrecy::SecretString;
+use serial_test::serial;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+/// Mock GitHub client with configurable results for run result comment tests.
+struct MockGitHubClient {
+    get_issue_result: tokio::sync::Mutex<Option<Result<IssueInfo, GitHubClientError>>>,
+    create_comment_result: tokio::sync::Mutex<Option<Result<CreatedComment, GitHubClientError>>>,
+    captured_comment_body: std::sync::Mutex<Option<String>>,
+}
+
+impl MockGitHubClient {
+    /// Default mock: get_issue returns Open, create_comment returns id=100.
+    fn default_success() -> Self {
+        Self {
+            get_issue_result: tokio::sync::Mutex::new(Some(Ok(IssueInfo {
+                number: 1,
+                node_id: "MDU6SXNzdWUx".into(),
+                state: IssueState::Open,
+                html_url: "https://github.com/test-owner/test-repo/issues/1".into(),
+            }))),
+            create_comment_result: tokio::sync::Mutex::new(Some(Ok(CreatedComment { id: 100 }))),
+            captured_comment_body: std::sync::Mutex::new(None),
+        }
+    }
+
+    fn with_get_issue(mut self, result: Result<IssueInfo, GitHubClientError>) -> Self {
+        self.get_issue_result = tokio::sync::Mutex::new(Some(result));
+        self
+    }
+
+    fn with_create_comment(mut self, result: Result<CreatedComment, GitHubClientError>) -> Self {
+        self.create_comment_result = tokio::sync::Mutex::new(Some(result));
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl GitHubAppClient for MockGitHubClient {
+    async fn get_installation_token(&self, _: u64) -> Result<SecretString, GitHubClientError> {
+        Ok(SecretString::from("mock-token".to_string()))
+    }
+
+    async fn create_issue(
+        &self,
+        _: u64,
+        _: &str,
+        _: &str,
+        _: &str,
+        _: &str,
+    ) -> Result<CreatedIssue, GitHubClientError> {
+        panic!("create_issue should not be called in run result comment tests")
+    }
+
+    async fn get_issue(
+        &self,
+        _: u64,
+        _: &str,
+        _: &str,
+        _: u64,
+    ) -> Result<IssueInfo, GitHubClientError> {
+        match self.get_issue_result.lock().await.take() {
+            Some(r) => r,
+            None => panic!("get_issue called unexpectedly"),
+        }
+    }
+
+    async fn create_comment(
+        &self,
+        _: u64,
+        _: &str,
+        _: &str,
+        _: u64,
+        body: &str,
+    ) -> Result<CreatedComment, GitHubClientError> {
+        *self.captured_comment_body.lock().unwrap() = Some(body.to_string());
+        match self.create_comment_result.lock().await.take() {
+            Some(r) => r,
+            None => panic!("create_comment called unexpectedly"),
+        }
+    }
+
+    async fn update_comment(
+        &self,
+        _: u64,
+        _: &str,
+        _: &str,
+        _: u64,
+        _: &str,
+    ) -> Result<(), GitHubClientError> {
+        panic!("update_comment should not be called in run result comment tests")
+    }
+}
+
+fn make_config() -> boardflow_worker::WorkerConfig {
+    boardflow_worker::WorkerConfig {
+        database_url: String::new(),
+        staging_bucket: "test-staging".into(),
+        artifacts_bucket: "test-artifacts".into(),
+        s3_endpoint: None,
+        s3_access_key: None,
+        s3_secret_key: None,
+        poll_interval_secs: 2,
+        timeout_sweep_interval_secs: 60,
+        github_app_id: None,
+        github_private_key_pem: None,
+        app_base_url: "https://test.boardflow.example.com".into(),
+    }
+}
+
+fn make_job(board_project_id: Option<Uuid>, board_run_id: Option<Uuid>) -> GithubJob {
+    GithubJob {
+        id: Uuid::now_v7(),
+        installation_id: 99999,
+        repository_id: Uuid::now_v7(),
+        board_project_id,
+        board_run_id,
+        r#type: "create_run_result_comment".into(),
+        payload_json: serde_json::json!({}),
+        status: GithubJobStatus::Running,
+        attempts: 1,
+        run_after: Utc::now(),
+        last_error: None,
+        created_at: Utc::now(),
+        updated_at: Utc::now(),
+    }
+}
+
+async fn get_pool() -> Option<PgPool> {
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("Skipping test: DATABASE_URL not set");
+            return None;
+        }
+    };
+    Some(PgPool::connect(&database_url).await.unwrap())
+}
+
+/// Setup with a status change: prev run passed → current run failed.
+/// Returns (repo_id, bp_id, prev_run_id, current_run_id, installation_id).
+async fn setup_with_status_change(pool: &PgPool) -> (Uuid, Uuid, Uuid, Uuid, i64) {
+    let repo_id = Uuid::now_v7();
+    let github_repository_id: i64 = rand::random::<i32>().unsigned_abs() as i64;
+    let installation_id: i64 = 99999;
+
+    sqlx::query(
+        "INSERT INTO repositories (id, github_repository_id, owner, name, installation_id, created_at, updated_at) \
+         VALUES ($1, $2, 'test-owner', 'test-repo', $3, NOW(), NOW())"
+    )
+    .bind(repo_id)
+    .bind(github_repository_id)
+    .bind(installation_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let bp_id = Uuid::now_v7();
+    let project_path = format!("hardware/test_{}/test.kicad_pro", bp_id);
+    sqlx::query(
+        "INSERT INTO board_projects (id, repository_id, project_path, project_dir, display_name, issue_sync_status, recreate_issue_on_update, issue_number, issue_node_id, issue_url, created_at, updated_at) \
+         VALUES ($1, $2, $3, 'hardware/test', 'test_board', 'pending', true, 1, 'MDU6SXNzdWUx', 'https://github.com/test-owner/test-repo/issues/1', NOW(), NOW())"
+    )
+    .bind(bp_id)
+    .bind(repo_id)
+    .bind(&project_path)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Previous run: ERC passed, DRC passed
+    let prev_run_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO board_runs (id, board_project_id, commit_sha, branch, ref, github_run_id, github_run_attempt, tree_hash, status, erc_status, erc_errors, erc_warnings, drc_status, drc_errors, drc_warnings, review_status, diff_status, created_at, completed_at) \
+         VALUES ($1, $2, 'abc1234', 'main', 'refs/heads/main', 1, 1, 'treehash123', 'completed', 'passed', 0, 0, 'passed', 0, 0, 'pending', 'pending', NOW(), NOW())"
+    )
+    .bind(prev_run_id)
+    .bind(bp_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Current run: ERC failed, DRC passed
+    let current_run_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO board_runs (id, board_project_id, commit_sha, branch, ref, github_run_id, github_run_attempt, tree_hash, status, erc_status, erc_errors, erc_warnings, drc_status, drc_errors, drc_warnings, review_status, diff_status, created_at, completed_at) \
+         VALUES ($1, $2, 'def5678', 'main', 'refs/heads/main', 2, 1, 'treehash456', 'completed', 'failed', 2, 0, 'passed', 0, 0, 'pending', 'pending', NOW() + interval '1 second', NOW() + interval '1 second')"
+    )
+    .bind(current_run_id)
+    .bind(bp_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Set latest_completed_run_id
+    sqlx::query("UPDATE board_projects SET latest_completed_run_id = $2 WHERE id = $1")
+        .bind(bp_id)
+        .bind(current_run_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+    (repo_id, bp_id, prev_run_id, current_run_id, installation_id)
+}
+
+/// Setup with a single run only (no previous run). Returns (repo_id, bp_id, run_id, installation_id).
+async fn setup_single_run(pool: &PgPool) -> (Uuid, Uuid, Uuid, i64) {
+    let repo_id = Uuid::now_v7();
+    let github_repository_id: i64 = rand::random::<i32>().unsigned_abs() as i64;
+    let installation_id: i64 = 99999;
+
+    sqlx::query(
+        "INSERT INTO repositories (id, github_repository_id, owner, name, installation_id, created_at, updated_at) \
+         VALUES ($1, $2, 'test-owner', 'test-repo', $3, NOW(), NOW())"
+    )
+    .bind(repo_id)
+    .bind(github_repository_id)
+    .bind(installation_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let bp_id = Uuid::now_v7();
+    let project_path = format!("hardware/test_{}/test.kicad_pro", bp_id);
+    sqlx::query(
+        "INSERT INTO board_projects (id, repository_id, project_path, project_dir, display_name, issue_sync_status, recreate_issue_on_update, issue_number, issue_node_id, issue_url, created_at, updated_at) \
+         VALUES ($1, $2, $3, 'hardware/test', 'test_board', 'pending', true, 1, 'MDU6SXNzdWUx', 'https://github.com/test-owner/test-repo/issues/1', NOW(), NOW())"
+    )
+    .bind(bp_id)
+    .bind(repo_id)
+    .bind(&project_path)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Single run: ERC failed (no previous run to compare)
+    let run_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO board_runs (id, board_project_id, commit_sha, branch, ref, github_run_id, github_run_attempt, tree_hash, status, erc_status, erc_errors, erc_warnings, drc_status, drc_errors, drc_warnings, review_status, diff_status, created_at, completed_at) \
+         VALUES ($1, $2, 'abc1234', 'main', 'refs/heads/main', 1, 1, 'treehash123', 'completed', 'failed', 1, 0, 'passed', 0, 0, 'pending', 'pending', NOW(), NOW())"
+    )
+    .bind(run_id)
+    .bind(bp_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Set latest_completed_run_id
+    sqlx::query("UPDATE board_projects SET latest_completed_run_id = $2 WHERE id = $1")
+        .bind(bp_id)
+        .bind(run_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+    (repo_id, bp_id, run_id, installation_id)
+}
+
+/// Setup with no status change: both runs ERC passed, DRC passed.
+/// Returns (repo_id, bp_id, prev_run_id, current_run_id, installation_id).
+async fn setup_no_change(pool: &PgPool) -> (Uuid, Uuid, Uuid, Uuid, i64) {
+    let repo_id = Uuid::now_v7();
+    let github_repository_id: i64 = rand::random::<i32>().unsigned_abs() as i64;
+    let installation_id: i64 = 99999;
+
+    sqlx::query(
+        "INSERT INTO repositories (id, github_repository_id, owner, name, installation_id, created_at, updated_at) \
+         VALUES ($1, $2, 'test-owner', 'test-repo', $3, NOW(), NOW())"
+    )
+    .bind(repo_id)
+    .bind(github_repository_id)
+    .bind(installation_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    let bp_id = Uuid::now_v7();
+    let project_path = format!("hardware/test_{}/test.kicad_pro", bp_id);
+    sqlx::query(
+        "INSERT INTO board_projects (id, repository_id, project_path, project_dir, display_name, issue_sync_status, recreate_issue_on_update, issue_number, issue_node_id, issue_url, created_at, updated_at) \
+         VALUES ($1, $2, $3, 'hardware/test', 'test_board', 'pending', true, 1, 'MDU6SXNzdWUx', 'https://github.com/test-owner/test-repo/issues/1', NOW(), NOW())"
+    )
+    .bind(bp_id)
+    .bind(repo_id)
+    .bind(&project_path)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Previous run: all passed
+    let prev_run_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO board_runs (id, board_project_id, commit_sha, branch, ref, github_run_id, github_run_attempt, tree_hash, status, erc_status, erc_errors, erc_warnings, drc_status, drc_errors, drc_warnings, review_status, diff_status, created_at, completed_at) \
+         VALUES ($1, $2, 'abc1234', 'main', 'refs/heads/main', 1, 1, 'treehash123', 'completed', 'passed', 0, 0, 'passed', 0, 0, 'pending', 'pending', NOW(), NOW())"
+    )
+    .bind(prev_run_id)
+    .bind(bp_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Current run: all passed (same as previous)
+    let current_run_id = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO board_runs (id, board_project_id, commit_sha, branch, ref, github_run_id, github_run_attempt, tree_hash, status, erc_status, erc_errors, erc_warnings, drc_status, drc_errors, drc_warnings, review_status, diff_status, created_at, completed_at) \
+         VALUES ($1, $2, 'def5678', 'main', 'refs/heads/main', 2, 1, 'treehash456', 'completed', 'passed', 0, 0, 'passed', 0, 0, 'pending', 'pending', NOW() + interval '1 second', NOW() + interval '1 second')"
+    )
+    .bind(current_run_id)
+    .bind(bp_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Set latest_completed_run_id
+    sqlx::query("UPDATE board_projects SET latest_completed_run_id = $2 WHERE id = $1")
+        .bind(bp_id)
+        .bind(current_run_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+    (repo_id, bp_id, prev_run_id, current_run_id, installation_id)
+}
+
+async fn cleanup_test_data(pool: &PgPool, repo_id: Uuid, bp_id: Uuid) {
+    let _ = sqlx::query("DELETE FROM github_jobs WHERE board_project_id = $1")
+        .bind(bp_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM board_project_issue_history WHERE board_project_id = $1")
+        .bind(bp_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM board_runs WHERE board_project_id = $1")
+        .bind(bp_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM board_projects WHERE id = $1")
+        .bind(bp_id)
+        .execute(pool)
+        .await;
+    let _ = sqlx::query("DELETE FROM repositories WHERE id = $1")
+        .bind(repo_id)
+        .execute(pool)
+        .await;
+}
+
+fn handler_result_debug(result: &boardflow_worker::handlers::HandlerResult) -> String {
+    match result {
+        boardflow_worker::handlers::HandlerResult::Completed => "Completed".into(),
+        boardflow_worker::handlers::HandlerResult::Reschedule {
+            reason,
+            backoff_secs,
+        } => {
+            format!("Reschedule({reason}, {backoff_secs}s)")
+        }
+        boardflow_worker::handlers::HandlerResult::Failed { reason } => {
+            format!("Failed({reason})")
+        }
+    }
+}
+
+// ─── Test 1: Success (status change triggers comment) ───────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_success() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, _prev_run_id, current_run_id, installation_id) =
+        setup_with_status_change(&pool).await;
+
+    let client = MockGitHubClient::default_success();
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(current_run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    assert!(
+        matches!(result, boardflow_worker::handlers::HandlerResult::Completed),
+        "Expected Completed, got: {}",
+        handler_result_debug(&result)
+    );
+
+    // Verify create_comment was called
+    let captured = client.captured_comment_body.lock().unwrap();
+    assert!(captured.is_some(), "create_comment should have been called");
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}
+
+// ─── Test 2: Skip first run (no previous run) ──────────────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_skip_first_run() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, run_id, installation_id) = setup_single_run(&pool).await;
+
+    let client = MockGitHubClient::default_success();
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    // First run → should_post_run_result returns false → Completed (skip)
+    assert!(
+        matches!(result, boardflow_worker::handlers::HandlerResult::Completed),
+        "Expected Completed (skip), got: {}",
+        handler_result_debug(&result)
+    );
+
+    // Verify create_comment was NOT called
+    let captured = client.captured_comment_body.lock().unwrap();
+    assert!(
+        captured.is_none(),
+        "create_comment should NOT have been called for first run"
+    );
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}
+
+// ─── Test 3: Skip no change (both passed) ──────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_skip_no_change() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, _prev_run_id, current_run_id, installation_id) =
+        setup_no_change(&pool).await;
+
+    let client = MockGitHubClient::default_success();
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(current_run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    // No status change → should_post_run_result returns false → Completed (skip)
+    assert!(
+        matches!(result, boardflow_worker::handlers::HandlerResult::Completed),
+        "Expected Completed (skip), got: {}",
+        handler_result_debug(&result)
+    );
+
+    // Verify create_comment was NOT called
+    let captured = client.captured_comment_body.lock().unwrap();
+    assert!(
+        captured.is_none(),
+        "create_comment should NOT have been called when no change"
+    );
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}
+
+// ─── Test 4: Missing board_project_id ───────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_missing_board_project_id() {
+    let Some(pool) = get_pool().await else { return };
+
+    let client = MockGitHubClient::default_success();
+    let config = make_config();
+    let job = make_job(None, Some(Uuid::now_v7()));
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    match result {
+        boardflow_worker::handlers::HandlerResult::Failed { reason } => {
+            assert!(
+                reason.contains("board_project_id"),
+                "Expected 'board_project_id' in reason, got: {reason}"
+            );
+        }
+        _ => panic!("Expected Failed, got: {}", handler_result_debug(&result)),
+    }
+}
+
+// ─── Test 5: Missing board_run_id ───────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_missing_board_run_id() {
+    let Some(pool) = get_pool().await else { return };
+
+    let client = MockGitHubClient::default_success();
+    let config = make_config();
+    let job = make_job(Some(Uuid::now_v7()), None);
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    match result {
+        boardflow_worker::handlers::HandlerResult::Failed { reason } => {
+            assert!(
+                reason.contains("board_run_id"),
+                "Expected 'board_run_id' in reason, got: {reason}"
+            );
+        }
+        _ => panic!("Expected Failed, got: {}", handler_result_debug(&result)),
+    }
+}
+
+// ─── Test 6: No issue (issue_number not set) ────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_no_issue() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, _prev_run_id, current_run_id, installation_id) =
+        setup_with_status_change(&pool).await;
+
+    // Clear issue_number to simulate issue not yet created
+    sqlx::query("UPDATE board_projects SET issue_number = NULL, issue_node_id = NULL, issue_url = NULL WHERE id = $1")
+        .bind(bp_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let client = MockGitHubClient::default_success();
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(current_run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    match result {
+        boardflow_worker::handlers::HandlerResult::Reschedule {
+            reason,
+            backoff_secs,
+        } => {
+            assert!(
+                reason.contains("issue not yet created"),
+                "Expected 'issue not yet created' in reason, got: {reason}"
+            );
+            assert_eq!(backoff_secs, 5.0);
+        }
+        _ => panic!(
+            "Expected Reschedule, got: {}",
+            handler_result_debug(&result)
+        ),
+    }
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}
+
+// ─── Test 7: Issue closed + recreate=true + tree_hash changed ───────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_issue_closed_recreate() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, _prev_run_id, current_run_id, installation_id) =
+        setup_with_status_change(&pool).await;
+
+    // get_issue returns Closed
+    let client = MockGitHubClient::default_success().with_get_issue(Ok(IssueInfo {
+        number: 1,
+        node_id: "MDU6SXNzdWUx".into(),
+        state: IssueState::Closed,
+        html_url: "https://github.com/test-owner/test-repo/issues/1".into(),
+    }));
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(current_run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    // Should Reschedule after clearing issue info and enqueuing create_issue
+    match &result {
+        boardflow_worker::handlers::HandlerResult::Reschedule { reason, .. } => {
+            assert!(
+                reason.contains("closed") || reason.contains("closed"),
+                "Expected 'closed' in reason, got: {reason}"
+            );
+        }
+        _ => panic!(
+            "Expected Reschedule, got: {}",
+            handler_result_debug(&result)
+        ),
+    }
+
+    // Verify issue_number was cleared
+    let row: (Option<i32>,) =
+        sqlx::query_as("SELECT issue_number FROM board_projects WHERE id = $1")
+            .bind(bp_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(row.0, None, "issue_number should be cleared");
+
+    // Verify create_issue job was enqueued
+    let job_row: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM github_jobs WHERE board_project_id = $1 AND type = 'create_issue'",
+    )
+    .bind(bp_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(job_row.0 >= 1, "create_issue job should be enqueued");
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}
+
+// ─── Test 8: Issue closed + recreate=false ──────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_issue_closed_no_recreate() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, _prev_run_id, current_run_id, installation_id) =
+        setup_with_status_change(&pool).await;
+
+    // Set recreate_issue_on_update = false
+    sqlx::query("UPDATE board_projects SET recreate_issue_on_update = false WHERE id = $1")
+        .bind(bp_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    let client = MockGitHubClient::default_success().with_get_issue(Ok(IssueInfo {
+        number: 1,
+        node_id: "MDU6SXNzdWUx".into(),
+        state: IssueState::Closed,
+        html_url: "https://github.com/test-owner/test-repo/issues/1".into(),
+    }));
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(current_run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    // recreate_issue_on_update=false → Completed (stop)
+    assert!(
+        matches!(result, boardflow_worker::handlers::HandlerResult::Completed),
+        "Expected Completed, got: {}",
+        handler_result_debug(&result)
+    );
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}
+
+// ─── Test 9: Issue 404 ─────────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_issue_404() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, _prev_run_id, current_run_id, installation_id) =
+        setup_with_status_change(&pool).await;
+
+    let client = MockGitHubClient::default_success()
+        .with_get_issue(Err(GitHubClientError::NotFound("not found".into())));
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(current_run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    // Should Reschedule after clearing issue info
+    match &result {
+        boardflow_worker::handlers::HandlerResult::Reschedule { reason, .. } => {
+            assert!(
+                reason.contains("404"),
+                "Expected '404' in reason, got: {reason}"
+            );
+        }
+        _ => panic!(
+            "Expected Reschedule, got: {}",
+            handler_result_debug(&result)
+        ),
+    }
+
+    // Verify issue_number was cleared
+    let row: (Option<i32>,) =
+        sqlx::query_as("SELECT issue_number FROM board_projects WHERE id = $1")
+            .bind(bp_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+    assert_eq!(row.0, None, "issue_number should be cleared after 404");
+
+    // Verify issue history was created
+    let history_count: (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM board_project_issue_history WHERE board_project_id = $1",
+    )
+    .bind(bp_id)
+    .fetch_one(&pool)
+    .await
+    .unwrap();
+    assert!(history_count.0 >= 1, "Issue history should be recorded");
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}
+
+// ─── Test 10: Rate limited ─────────────────────────────────────────────────
+
+#[tokio::test]
+#[ignore]
+#[serial]
+async fn test_run_result_comment_rate_limited() {
+    let Some(pool) = get_pool().await else { return };
+    let (repo_id, bp_id, _prev_run_id, current_run_id, installation_id) =
+        setup_with_status_change(&pool).await;
+
+    let client = MockGitHubClient::default_success().with_create_comment(Err(
+        GitHubClientError::RateLimited {
+            retry_after_secs: Some(60),
+        },
+    ));
+    let config = make_config();
+    let mut job = make_job(Some(bp_id), Some(current_run_id));
+    job.installation_id = installation_id;
+    job.repository_id = repo_id;
+
+    let result = boardflow_worker::handlers::create_run_result_comment::handle(
+        &pool, &client, &config, &job,
+    )
+    .await;
+
+    match &result {
+        boardflow_worker::handlers::HandlerResult::Reschedule {
+            reason,
+            backoff_secs,
+        } => {
+            assert!(
+                reason.contains("Rate limited"),
+                "Expected 'Rate limited' in reason, got: {reason}"
+            );
+            assert!(
+                *backoff_secs >= 60.0,
+                "Expected backoff_secs >= 60, got: {backoff_secs}"
+            );
+        }
+        _ => panic!(
+            "Expected Reschedule, got: {}",
+            handler_result_debug(&result)
+        ),
+    }
+
+    cleanup_test_data(&pool, repo_id, bp_id).await;
+}

--- a/docs/logs/22/worklog.md
+++ b/docs/logs/22/worklog.md
@@ -1,0 +1,208 @@
+# Issue #22: Worker: Run Resultコメント作成ジョブハンドラ実装 - 作業ログ
+
+## 経緯
+
+- ハンドラ実装 (`create_run_result_comment.rs`, `comment_body.rs`, `dispatcher.rs`, `import.rs`) は完了済み
+- `comment_body.rs` のユニットテスト (`should_post_run_result` 系) も完了済み
+- **統合テスト `crates/worker/tests/run_result_comment_test.rs` が未作成**
+
+## ユーザー要望
+
+- 10件のテストケースをカバーする統合テストファイルを作成する
+- 既存テスト (`dashboard_comment_test.rs`, `create_issue_test.rs`) のパターンに準拠
+
+## 調査結果
+
+### ハンドラのコードパス分析 (`create_run_result_comment.rs`)
+
+1. `board_project_id` 欠損 → `Failed`
+2. `board_run_id` 欠損 → `Failed`
+3. board_project 見つからない → `Failed`
+4. issue_number 未設定 → `Reschedule(5s)`
+5. get_issue で Issue Closed:
+   - `recreate_issue_on_update=false` → `Completed`
+   - `recreate_issue_on_update=true` + tree_hash変更なし → `Completed`
+   - `recreate_issue_on_update=true` + tree_hash変更あり → issue_history挿入, clear_issue_info, enqueue create_issue, `Reschedule(5s)`
+6. get_issue で 404 → clear_issue_info, enqueue create_issue, `Reschedule(5s)`
+7. get_issue でその他エラー → `handle_github_error`
+8. current_run 見つからない → `Failed`
+9. `should_post_run_result` が false → `Completed` (スキップ)
+10. `should_post_run_result` が true → create_comment API呼び出し
+    - 成功 → `Completed`
+    - RateLimited → `Reschedule(retry_after)`
+    - その他エラー → `Reschedule(backoff)`
+
+### should_post_run_result ロジック
+
+- previous run なし (初回) → false (コメントしない)
+- ERC: Passed→Failed or Failed→Passed → true
+- DRC: Passed→Failed or Failed→Passed → true
+- current.erc_errors > prev.erc_errors → true
+- current.drc_errors > prev.drc_errors → true
+- それ以外 → false
+
+### 既存テストのパターン
+
+- `#[tokio::test]`, `#[ignore]`, `#[serial]`
+- `get_pool()` → `Option<PgPool>`
+- `setup_test_data(pool)` → `(repo_id, bp_id, run_id, installation_id)`
+- `setup_with_issue(pool)` → issue_number設定済み
+- `setup_with_two_runs(pool)` → prev_run + current_run
+
+## 実装 (2026-05-02)
+
+### フェーズ: 統合テスト作成
+
+#### 作成ファイル
+- `crates/worker/tests/run_result_comment_test.rs` (新規)
+
+#### テストケース一覧 (10件)
+| # | テスト名 | 検証内容 |
+|---|----------|----------|
+| 1 | `test_run_result_comment_success` | ERC passed→failed で create_comment 呼出、Completed |
+| 2 | `test_run_result_comment_skip_first_run` | 初回run (prev無し) → Completed (スキップ) |
+| 3 | `test_run_result_comment_skip_no_change` | 両run passed → Completed (スキップ) |
+| 4 | `test_run_result_comment_missing_board_project_id` | board_project_id=None → Failed |
+| 5 | `test_run_result_comment_missing_board_run_id` | board_run_id=None → Failed |
+| 6 | `test_run_result_comment_no_issue` | issue_number未設定 → Reschedule(5s) |
+| 7 | `test_run_result_comment_issue_closed_recreate` | Closed+recreate+tree_hash変更 → Reschedule + create_issue enqueued |
+| 8 | `test_run_result_comment_issue_closed_no_recreate` | Closed+recreate=false → Completed |
+| 9 | `test_run_result_comment_issue_404` | 404 → Reschedule + issue_history保存 + issue_number cleared |
+| 10 | `test_run_result_comment_rate_limited` | RateLimited(60s) → Reschedule(backoff>=60) |
+
+#### テスト結果
+- `cargo check` コンパイル成功 (EXIT:0)
+
+#### 次ステップ
+- DATABASE_URL設定済み環境で `cargo test -p boardflow-worker --test run_result_comment_test -- --ignored` 実行
+- 全テスト PASS 確認後、PR作成
+- `cleanup_test_data(pool, repo_id, bp_id)`
+- `handler_result_debug(&result)` → debug出力
+- `MockGitHubClient` with configurable results
+- `make_job(type, bp_id, run_id)` → GithubJob
+- `make_config()` → WorkerConfig
+
+---
+
+## 実装計画
+
+### 目的
+
+`create_run_result_comment` ハンドラの統合テストを作成し、全主要コードパスの正常動作を検証する。
+
+### 非目的
+
+- ハンドラ本体のコード変更
+- `should_post_run_result` のユニットテスト追加 (既存)
+- 他のハンドラのテスト修正
+
+### 受け入れ条件
+
+- `crates/worker/tests/run_result_comment_test.rs` が存在する
+- `cargo test -p boardflow-worker --test run_result_comment_test -- --ignored` で全テストPASS
+- 10件のテストケースすべてがカバーされる
+- `cargo clippy --workspace` が警告なしで通る
+
+### 詳細要件
+
+#### テストケース一覧
+
+| # | テスト名 | セットアップ | 期待結果 |
+|---|----------|-------------|----------|
+| 1 | `test_run_result_comment_success` | 2 runs: prev=passed, cur=failed | Completed + create_comment呼出 |
+| 2 | `test_run_result_comment_skip_first_run` | 1 run only (no prev) | Completed (スキップ) |
+| 3 | `test_run_result_comment_skip_no_change` | 2 runs: both passed | Completed (スキップ) |
+| 4 | `test_run_result_comment_missing_board_project_id` | job.board_project_id=None | Failed |
+| 5 | `test_run_result_comment_missing_board_run_id` | job.board_run_id=None | Failed |
+| 6 | `test_run_result_comment_no_issue` | issue_number=NULL | Reschedule |
+| 7 | `test_run_result_comment_issue_closed_recreate` | issue closed + recreate=true + tree_hash変更 | Reschedule + create_issue enqueued |
+| 8 | `test_run_result_comment_issue_closed_no_recreate` | issue closed + recreate=false | Completed |
+| 9 | `test_run_result_comment_issue_404` | get_issue returns NotFound | Reschedule + issue_number cleared |
+| 10 | `test_run_result_comment_rate_limited` | create_comment returns RateLimited | Reschedule(60s) |
+
+#### テストファイル構造
+
+```
+run_result_comment_test.rs
+├── imports (boardflow_domain, boardflow_github, boardflow_worker, chrono, serial_test, sqlx, uuid)
+├── MockGitHubClient struct
+│   ├── get_issue_result: Mutex<Option<Result<...>>>
+│   ├── create_comment_result: Mutex<Option<Result<...>>>
+│   └── captured_comment_body: Mutex<Option<String>>
+├── impl MockGitHubClient
+│   ├── default_success() → Open issue + create_comment Ok
+│   ├── with_get_issue(result) → builder
+│   └── with_create_comment(result) → builder
+├── impl GitHubAppClient for MockGitHubClient
+├── make_config() → WorkerConfig
+├── make_job(type, bp_id, run_id) → GithubJob
+├── get_pool() → Option<PgPool>
+├── setup_with_two_runs_erc_change(pool)
+│   → repo + bp(issue set) + prev_run(erc=passed) + cur_run(erc=failed)
+│   → returns (repo_id, bp_id, prev_run_id, cur_run_id, installation_id)
+├── setup_with_single_run(pool)
+│   → repo + bp(issue set) + single run (no prev)
+│   → returns (repo_id, bp_id, run_id, installation_id)
+├── setup_with_two_runs_no_change(pool)
+│   → repo + bp(issue set) + prev_run(passed) + cur_run(passed)
+├── cleanup_test_data(pool, repo_id, bp_id)
+├── handler_result_debug(result) → String
+└── 10 test functions
+```
+
+### 影響範囲
+
+- 新規ファイル: `crates/worker/tests/run_result_comment_test.rs`
+- 既存コード変更なし
+
+### 設計方針
+
+- `dashboard_comment_test.rs` のパターンを踏襲
+- MockGitHubClient は create_issue/update_comment を panic にする (このハンドラでは直接呼ばないため)
+- DB セットアップでは `erc_status`/`drc_status`/`erc_errors`/`drc_errors` を明示的に設定
+- `find_previous_completed` が正しく prev_run を返すよう `completed_at` でタイムスタンプ順序を保証
+
+### テスト観点
+
+- ハンドラの全分岐パスがカバーされている
+- `should_post_run_result` の判定結果が統合テストレベルで正しく反映される
+- Issue再作成フローで `issue_number` がクリアされ `create_issue` ジョブが enqueue される
+- Rate limiting時のbackoff値が正しい (retry_after_secs の値が使われる)
+
+### ドキュメント更新対象
+
+- `docs/logs/22/worklog.md` (本ファイル) のみ
+
+### 実装要否
+
+`implementation_required`
+
+### 未解決の疑問
+
+なし — ハンドラ実装と既存テストパターンから全情報が揃っている。
+
+### 実装手順
+
+1. `crates/worker/tests/run_result_comment_test.rs` を作成
+2. MockGitHubClient, ヘルパー関数 (setup系, cleanup, make_job, make_config, handler_result_debug) を実装
+3. テストケース 4, 5 (Missing fields) を実装 — DB不要
+4. テストケース 6 (No issue) を実装
+5. テストケース 2 (Skip first run) を実装
+6. テストケース 3 (Skip no change) を実装
+7. テストケース 1 (Success) を実装
+8. テストケース 7 (Issue closed + recreate) を実装
+9. テストケース 8 (Issue closed + no recreate) を実装
+10. テストケース 9 (Issue 404) を実装
+11. テストケース 10 (Rate limited) を実装
+12. `cargo clippy` + `cargo test` で検証
+13. コミット & プッシュ
+
+---
+
+## 作業ステータス
+
+- [x] 計画策定
+- [ ] 実装
+- [ ] テスト実行確認
+- [ ] レビュー
+- [ ] マージ

--- a/docs/logs/22/worklog.md
+++ b/docs/logs/22/worklog.md
@@ -206,3 +206,121 @@ run_result_comment_test.rs
 - [ ] テスト実行確認
 - [ ] レビュー
 - [ ] マージ
+
+## レビュー (2026-05-02)
+
+### Issueまでの経緯
+
+- Issue #22 の対象は、既存の `create_run_result_comment` ハンドラ実装に対する統合テスト追加と、spec 12.2 / 12.3 / 13.1 / rate limit 対応の観点でのレビュー。
+- レビュー対象として `crates/worker/src/handlers/create_run_result_comment.rs`、`crates/worker/src/comment_body.rs`、`crates/worker/tests/run_result_comment_test.rs`、`crates/worker/src/dispatcher.rs`、`crates/worker/src/handlers/import.rs`、`docs/spec.md` を確認。
+
+### 今回のユーザー要望
+
+- 統合テスト 10 件が仕様を十分に網羅しているかを確認する。
+- テストコードの race condition / cleanup 漏れの有無を確認する。
+- ハンドラ本体が spec 12.2, 12.3, 13.1 と整合しているかを確認する。
+
+### 今回の調査結果
+
+- `create_run_result_comment` ハンドラ本体は、missing IDs、issue 未作成、closed issue、404、rate limit、初回 run スキップ、状態変化時コメント作成の主要分岐を実装している。
+- `should_post_run_result()` のユニットテストは、初回 run スキップ、pass→fail、fail→pass、新規 error 増加、変化なしを個別にカバーしている。
+- 統合テスト 10 件は正常系、初回 skip、変化なし skip、missing IDs、issue 未作成、closed recreate、closed no recreate、404、rate limit を確認している。
+- Web 調査では、GitHub REST API の rate limit 対応は `Retry-After` があればそれに従い、無ければ少なくとも 1 分待機し、継続失敗時は指数バックオフする方針が推奨されていることを確認。
+
+### 実装内容の評価
+
+- ハンドラ本体の仕様整合性は概ね良好。closed issue で `recreate_issue_on_update=false` は停止、`404` は issue 情報クリア + `create_issue` enqueue、rate limit は reschedule となっており、ユーザー提示の観点 2, 3, 4 には沿っている。
+- `dispatcher.rs` には `create_run_result_comment` のルーティングがあり、`import.rs` でも import 完了後に同ジョブが enqueue されるため、ジョブフロー自体は 13.1 と整合している。
+- テストは `serial_test` を使い、`cleanup_test_data()` で作成データを消しており、明白な race condition や cleanup 漏れは見当たらない。
+
+### 今回のテスト結果
+
+- `export DATABASE_URL="postgresql://boardflow:boardflow@localhost:5432/boardflow" && cargo test -p boardflow-worker --test run_result_comment_test -- --ignored` を再実行し、10 件すべて PASS を確認。
+- `cargo clippy -p boardflow-worker --tests -- -D warnings` を再実行し、成功を確認。
+
+### レビュー結果
+
+- PR作成可否: `pr_ready: false`
+
+#### 重大度順の指摘
+
+1. `spec 13.1` の closed issue 分岐にある「`recreate_issue_on_update=true` かつ `tree_hash` 変更ありでのみ再作成する」という条件が、統合テストでは未検証。
+    - `crates/worker/src/handlers/create_run_result_comment.rs` では `tree_hash_changed()` 分岐が実装されているが、`crates/worker/tests/run_result_comment_test.rs` の closed issue 系は changed case と `recreate=false` しかなく、unchanged case がない。
+    - このままだと、closed issue を常に再作成してしまう回帰が入っても今回の 10 テストでは検知できない。
+
+2. `spec 12.2` の本文フォーマットに対する回帰テストが不足している。
+    - 実装側の `run_result_comment()` は marker、Commit、Run URL、Diff URL、ERC/DRC table を生成している。
+    - ただし統合テスト成功ケースは `create_comment` が呼ばれたことしか見ておらず、本文内容を検証していない。
+    - 既存のユニットテスト `test_run_result_comment_contains_markers()` も marker と一部結果表示のみで、Run URL、Diff URL、table header までは確認していない。
+    - ユーザーが明示した 12.2 の確認項目に対して、実装は満たしていてもテスト網羅としては不足している。
+
+### 必須修正
+
+1. `crates/worker/tests/run_result_comment_test.rs` に、Issue closed + `recreate_issue_on_update=true` + `tree_hash` unchanged のケースを追加し、`Completed` かつ `create_issue` 非 enqueue を確認すること。
+2. `crates/worker/tests/run_result_comment_test.rs` の success ケース、または `crates/worker/src/comment_body.rs` のユニットテストで、Run Result 本文に marker、Commit、Run URL、Diff URL、`| Check | Result |` が含まれることを直接検証すること。
+
+### 任意改善
+
+1. `404` と closed recreate のテストで、`board_project_issue_history.reason` が期待値 (`deleted` / `recreated`) になっていることまで確認すると、履歴保存の回帰に強くなる。
+2. success ケースで ERC だけでなく DRC 変化、fail→pass、新規 error 増加を統合テスト側にも 1 ケースずつ足すと、ユニットテストと統合テストの責務分担がより明確になる。
+
+### テスト不足
+
+- closed issue + unchanged tree hash の未検証。
+- Run Result コメント本文の必須要素に対する直接検証の不足。
+- integration レベルでは fail→pass と新規 error 増加の投稿条件は未検証。
+
+### ドキュメント確認
+
+- `docs/spec.md` の 12.2, 12.3, 13.1 を確認。
+- `docs/logs/22/worklog.md` の既存内容には「統合テスト未作成」「次ステップでテスト実行確認」といった過去状態が残っており、今回の実装完了・テスト PASS 状態とは一致していない。
+
+### PR/完了結果
+
+- 現時点では `pr_ready: false`。
+- 理由は、実装の致命的不整合ではなく、ユーザーがレビュー観点として明示した spec 12.2 / 13.1 に対する回帰テストがまだ 2 点不足しているため。
+
+### 残リスク
+
+- closed issue の tree_hash unchanged 分岐が将来壊れても現状テストでは検知できない。
+- コメント本文の URL / table 生成が壊れても現状テストでは検知できない。
+
+---
+
+## ドキュメント確認 (2026-05-02, docs review)
+
+### docs review の調査結果
+
+- `docs/logs/22/worklog.md` 内の過去レビュー節は現行実装に対して stale であり、最新状態をそのまま表していない。
+- 現行の統合テスト `crates/worker/tests/run_result_comment_test.rs` は 10 件ではなく 11 件ある。
+- 追加済みの 11 件目は `test_run_result_comment_issue_closed_tree_hash_unchanged` で、spec 13.1 の「closed issue かつ tree_hash unchanged では再作成しない」を確認している。
+- success ケースではコメント本文に marker、Commit、Run URL、Diff URL、`| Check | Result |` が含まれることを検証しており、spec 12.2 の主要要素に対応している。
+- `docs/spec.md` の 12.2、12.3、13.1 と `docs/backend/summary.md` の Run Result コメント方針・closed issue 方針には、今回の実装と矛盾する記述は見当たらない。
+
+### docs review の対応内容
+
+- ドキュメントレビューとして、Issue #22 の worklog に現行状態の確認結果を追記した。
+- 過去節に残る「10件テスト」「必須修正 2 点」「`pr_ready: false`」は当時のレビュー記録として残るが、現時点の最終判定は本節を優先する。
+
+### docs review 時点のテスト結果
+
+- ユーザー提示の最新結果として、`crates/worker/tests/run_result_comment_test.rs` は 11 tests all passed。
+- `cargo clippy --tests -- -D warnings` は PASS。
+
+### docs review の判定
+
+- `docs_ready: true`
+
+### docs review のドキュメント確認
+
+- 修正が必要だったのは `docs/logs/22/worklog.md` の最新状態反映のみ。
+- `docs/spec.md` の更新は不要。
+- `docs/backend/summary.md` の更新は不要。
+
+### docs review の PR/完了結果
+
+- Issue #22 について、ドキュメント観点では PR 作成可。
+
+### docs review の残リスク
+
+- worklog 内には履歴として stale な過去レビュー節が残るため、読む側は本節を最新判定として参照する必要がある。

--- a/docs/logs/22/worklog.md
+++ b/docs/logs/22/worklog.md
@@ -324,3 +324,26 @@ run_result_comment_test.rs
 ### docs review の残リスク
 
 - worklog 内には履歴として stale な過去レビュー節が残るため、読む側は本節を最新判定として参照する必要がある。
+
+---
+
+## 2回目レビュー後の最終判定 (2026-05-02)
+
+### 最終確認
+
+- `pr_ready: true`（レビュー指摘 2 点を fix コミットで対応済み）
+  - tree_hash unchanged テスト (`test_run_result_comment_issue_closed_tree_hash_unchanged`) 追加済み
+  - success テストでコメント本文の必須要素 (marker, Commit, Run URL, Diff URL, `| Check | Result |`) 検証済み
+- `docs_ready: true`（docs review 確認済み）
+- テスト: 11 tests all passed、`cargo clippy --tests -- -D warnings` PASS
+
+### PR/完了結果
+
+- PR 作成: `feat/22-run-result-comment-handler` → `main`
+- PR タイトル: `test(#22): create_run_result_comment ハンドラの統合テスト追加`
+- Closes #22
+
+### 残リスク
+
+- fail→pass や DRC 変化、新規 error 増加の統合テストケースは任意改善として未追加（ユニットテストで個別検証済み）
+- 404 / closed recreate の `board_project_issue_history.reason` 値の検証は任意改善として未追加


### PR DESCRIPTION
## 要件

Issue #22: Worker の \`create_run_result_comment\` ジョブハンドラに対する統合テストを追加し、spec 12.2 / 12.3 / 13.1 の準拠を検証する。

## 調査結果

- ハンドラ本体 (\`create_run_result_comment.rs\`)、コメント本文生成 (\`comment_body.rs\`)、ディスパッチャ (\`dispatcher.rs\`)、import enqueue (\`import.rs\`) はすべて main にマージ済み (#19, #20, #26 経由)。
- \`should_post_run_result()\` のユニットテストは既存済み。
- 既存統合テストパターン (\`dashboard_comment_test.rs\`, \`create_issue_test.rs\`) に準拠して実装。

## 実装概要

### 追加ファイル

| ファイル | 内容 |
|---|---|
| \`crates/worker/tests/run_result_comment_test.rs\` | 統合テスト 11 件 |
| \`docs/logs/22/worklog.md\` | 作業ログ |

### テストケース一覧 (11 件)

| # | テスト名 | 検証内容 |
|---|----------|----------|
| 1 | \`test_run_result_comment_success\` | ERC passed→failed でコメント作成 + 本文必須要素検証 (marker, Commit, Run URL, Diff URL, table) |
| 2 | \`test_run_result_comment_skip_first_run\` | 初回 run はコメントスキップ (spec 12.3) |
| 3 | \`test_run_result_comment_skip_no_change\` | 状態変化なしはスキップ |
| 4 | \`test_run_result_comment_missing_board_project_id\` | 必須パラメータ欠損 → Failed |
| 5 | \`test_run_result_comment_missing_board_run_id\` | 必須パラメータ欠損 → Failed |
| 6 | \`test_run_result_comment_no_issue\` | Issue 未作成 → Reschedule(5s) |
| 7 | \`test_run_result_comment_issue_closed_recreate\` | Closed + recreate + tree_hash 変更 → 再作成フロー |
| 7b | \`test_run_result_comment_issue_closed_tree_hash_unchanged\` | Closed + recreate + tree_hash 同一 → Completed (再作成しない) |
| 8 | \`test_run_result_comment_issue_closed_no_recreate\` | Closed + recreate=false → Completed |
| 9 | \`test_run_result_comment_issue_404\` | 404 → issue info clear + issue_history 保存 |
| 10 | \`test_run_result_comment_rate_limited\` | RateLimited → Reschedule(backoff >= 60s) |

## テスト結果

\`\`\`
running 11 tests - all passed (0.92s)
cargo clippy --workspace --tests -- -D warnings → PASS
\`\`\`

## 更新ドキュメント

- \`docs/logs/22/worklog.md\` — 作業ログ (調査・計画・実装・レビュー・最終判定)

## 外部調査メモ

- GitHub REST API rate limit: \`Retry-After\` があればその値、なければ最低 60s 待機、継続失敗時は指数バックオフが推奨。ハンドラ実装と整合確認済み。

## 残リスク

- fail→pass / DRC 変化 / 新規 error 増加の統合テストケースは任意改善として未追加（ユニットテストで個別検証済み）。
- 404 / closed recreate での \`board_project_issue_history.reason\` 値の検証は任意改善として未追加。

## review / docs 判定

- **review: \`pr_ready: true\`** — レビュー指摘 2 点（tree_hash unchanged テスト追加、コメント本文検証強化）を fix コミットで対応済み。
- **docs: \`docs_ready: true\`** — spec.md / backend/summary.md の更新不要を確認済み。

Closes #22