### PR TITLE
feat(#28): GitHub App Webhook受信エンドポイント実装

### DIFF
--- a/crates/api/src/config.rs
+++ b/crates/api/src/config.rs
@@ -44,6 +44,7 @@ pub struct AppConfig {
     pub artifact_secret: Option<String>,
     pub app_domain: String,
     pub artifact_base_url: String,
+    pub github_webhook_secret: Option<String>,
 }
 
 impl AppConfig {
@@ -79,6 +80,7 @@ impl AppConfig {
                 .unwrap_or_else(|_| "http://localhost:3000".to_string()),
             artifact_base_url: std::env::var("BOARDFLOW_ARTIFACT_BASE_URL")
                 .unwrap_or_else(|_| "http://localhost:8080".to_string()),
+            github_webhook_secret: std::env::var("GITHUB_WEBHOOK_SECRET").ok(),
         })
     }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -19,7 +19,7 @@ use github_access::{DynGithubAccessChecker, RealGithubAccessChecker};
 use routes::auth::OAuthConfig;
 
 pub fn create_app(pool: PgPool, s3_client: Option<aws_sdk_s3::Client>) -> Router {
-    create_app_with_config(pool, s3_client, None, None, None, None, None, None)
+    create_app_with_config(pool, s3_client, None, None, None, None, None, None, None)
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -32,6 +32,7 @@ pub fn create_app_with_config(
     final_bucket: Option<String>,
     app_domain: Option<String>,
     artifact_base_url: Option<String>,
+    webhook_secret: Option<String>,
 ) -> Router {
     let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
         .routes(routes!(routes::health::healthz))
@@ -98,6 +99,12 @@ pub fn create_app_with_config(
             "/proxy/artifacts/{artifact_id}",
             axum::routing::get(routes::proxy::get_artifact),
         )
+        .route(
+            "/api/v1/github/webhook",
+            axum::routing::post(routes::webhook::github_webhook),
+        )
+        .layer(Extension(pool.clone()))
+        .layer(Extension(WebhookSecret(webhook_secret)))
         .layer(Extension(s3_client))
         .layer(Extension(oauth))
         .layer(Extension(ArtifactSecret(secret)))
@@ -113,6 +120,9 @@ pub fn create_app_with_config(
 
 #[derive(Clone)]
 pub struct ArtifactSecret(pub Vec<u8>);
+
+#[derive(Clone)]
+pub struct WebhookSecret(pub Option<String>);
 
 #[derive(Clone)]
 pub struct FinalBucket(pub String);

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -35,7 +35,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         None
     };
 
-    let app = boardflow_api::create_app(pool, s3_client);
+    let app = boardflow_api::create_app_with_config(
+        pool,
+        s3_client,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        config.github_webhook_secret,
+    );
 
     let addr = format!("{}:{}", config.api_host, config.api_port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -5,3 +5,4 @@ pub mod health;
 pub mod plan;
 pub mod proxy;
 pub mod read;
+pub mod webhook;

--- a/crates/api/src/routes/webhook.rs
+++ b/crates/api/src/routes/webhook.rs
@@ -99,7 +99,16 @@ pub async fn github_webhook(
         .and_then(|v| v.to_str().ok())
         .unwrap_or("");
 
-    tracing::info!(event = event, "received webhook event");
+    let delivery_id = headers
+        .get("X-GitHub-Delivery")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("unknown");
+
+    tracing::info!(
+        event = event,
+        delivery_id = delivery_id,
+        "received webhook event"
+    );
 
     match event {
         "ping" => StatusCode::OK,
@@ -208,9 +217,12 @@ async fn handle_installation_repositories_event(pool: &PgPool, body: &[u8]) -> S
         }
         "removed" => {
             for repo in &event.repositories_removed {
-                if let Err(err) =
-                    boardflow_db::queries::repository::clear_installation_for_repo(pool, repo.id)
-                        .await
+                if let Err(err) = boardflow_db::queries::repository::clear_installation_for_repo(
+                    pool,
+                    repo.id,
+                    event.installation.id,
+                )
+                .await
                 {
                     tracing::error!(
                         error = %err,

--- a/crates/api/src/routes/webhook.rs
+++ b/crates/api/src/routes/webhook.rs
@@ -1,0 +1,372 @@
+use axum::Extension;
+use axum::body::Bytes;
+use axum::http::{HeaderMap, StatusCode};
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use sha2::Sha256;
+use sqlx::PgPool;
+
+use crate::WebhookSecret;
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn verify_signature(secret: &[u8], body: &[u8], signature_header: &str) -> bool {
+    let hex_signature = match signature_header.strip_prefix("sha256=") {
+        Some(hex) => hex,
+        None => return false,
+    };
+
+    let expected = match hex::decode(hex_signature) {
+        Ok(bytes) => bytes,
+        Err(_) => return false,
+    };
+
+    let mut mac = match HmacSha256::new_from_slice(secret) {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+    mac.update(body);
+    mac.verify_slice(&expected).is_ok()
+}
+
+// --- Payload types ---
+
+#[derive(Debug, Deserialize)]
+struct WebhookRepository {
+    id: i64,
+    #[allow(dead_code)]
+    name: String,
+    full_name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct WebhookInstallation {
+    id: i64,
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallationEvent {
+    action: String,
+    installation: WebhookInstallation,
+    #[serde(default)]
+    repositories: Vec<WebhookRepository>,
+}
+
+#[derive(Debug, Deserialize)]
+struct InstallationRepositoriesEvent {
+    action: String,
+    installation: WebhookInstallation,
+    #[serde(default)]
+    repositories_added: Vec<WebhookRepository>,
+    #[serde(default)]
+    repositories_removed: Vec<WebhookRepository>,
+}
+
+// --- Handler ---
+
+pub async fn github_webhook(
+    Extension(pool): Extension<PgPool>,
+    Extension(webhook_secret): Extension<WebhookSecret>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
+    let secret = match &webhook_secret.0 {
+        Some(s) => s.clone(),
+        None => {
+            tracing::error!("webhook secret is not configured");
+            return StatusCode::INTERNAL_SERVER_ERROR;
+        }
+    };
+
+    let signature = match headers
+        .get("X-Hub-Signature-256")
+        .and_then(|v| v.to_str().ok())
+    {
+        Some(sig) => sig.to_string(),
+        None => {
+            tracing::warn!("missing X-Hub-Signature-256 header");
+            return StatusCode::UNAUTHORIZED;
+        }
+    };
+
+    if !verify_signature(secret.as_bytes(), &body, &signature) {
+        tracing::warn!("invalid webhook signature");
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    let event = headers
+        .get("X-GitHub-Event")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    tracing::info!(event = event, "received webhook event");
+
+    match event {
+        "ping" => StatusCode::OK,
+        "installation" => handle_installation_event(&pool, &body).await,
+        "installation_repositories" => handle_installation_repositories_event(&pool, &body).await,
+        _ => {
+            tracing::debug!(event = event, "ignoring unhandled webhook event");
+            StatusCode::OK
+        }
+    }
+}
+
+async fn handle_installation_event(pool: &PgPool, body: &[u8]) -> StatusCode {
+    let event: InstallationEvent = match serde_json::from_slice(body) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to parse installation event");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    match event.action.as_str() {
+        "created" => {
+            for repo in &event.repositories {
+                if let Some((owner, name)) = repo.full_name.split_once('/') {
+                    if let Err(err) = boardflow_db::queries::repository::upsert(
+                        pool,
+                        repo.id,
+                        owner,
+                        name,
+                        event.installation.id,
+                    )
+                    .await
+                    {
+                        tracing::error!(
+                            error = %err,
+                            repo_id = repo.id,
+                            full_name = %repo.full_name,
+                            "failed to upsert repository"
+                        );
+                        return StatusCode::INTERNAL_SERVER_ERROR;
+                    }
+                } else {
+                    tracing::warn!(
+                        full_name = %repo.full_name,
+                        "invalid full_name format, expected owner/name"
+                    );
+                }
+            }
+            StatusCode::OK
+        }
+        "deleted" => {
+            if let Err(err) =
+                boardflow_db::queries::repository::clear_installation(pool, event.installation.id)
+                    .await
+            {
+                tracing::error!(
+                    error = %err,
+                    installation_id = event.installation.id,
+                    "failed to clear installation"
+                );
+                return StatusCode::INTERNAL_SERVER_ERROR;
+            }
+            StatusCode::OK
+        }
+        _ => {
+            tracing::debug!(action = %event.action, "ignoring installation action");
+            StatusCode::OK
+        }
+    }
+}
+
+async fn handle_installation_repositories_event(pool: &PgPool, body: &[u8]) -> StatusCode {
+    let event: InstallationRepositoriesEvent = match serde_json::from_slice(body) {
+        Ok(e) => e,
+        Err(err) => {
+            tracing::error!(error = %err, "failed to parse installation_repositories event");
+            return StatusCode::BAD_REQUEST;
+        }
+    };
+
+    match event.action.as_str() {
+        "added" => {
+            for repo in &event.repositories_added {
+                if let Some((owner, name)) = repo.full_name.split_once('/') {
+                    if let Err(err) = boardflow_db::queries::repository::upsert(
+                        pool,
+                        repo.id,
+                        owner,
+                        name,
+                        event.installation.id,
+                    )
+                    .await
+                    {
+                        tracing::error!(
+                            error = %err,
+                            repo_id = repo.id,
+                            full_name = %repo.full_name,
+                            "failed to upsert repository"
+                        );
+                        return StatusCode::INTERNAL_SERVER_ERROR;
+                    }
+                }
+            }
+            StatusCode::OK
+        }
+        "removed" => {
+            for repo in &event.repositories_removed {
+                if let Err(err) =
+                    boardflow_db::queries::repository::clear_installation_for_repo(pool, repo.id)
+                        .await
+                {
+                    tracing::error!(
+                        error = %err,
+                        repo_id = repo.id,
+                        "failed to clear installation for repository"
+                    );
+                    return StatusCode::INTERNAL_SERVER_ERROR;
+                }
+            }
+            StatusCode::OK
+        }
+        _ => {
+            tracing::debug!(
+                action = %event.action,
+                "ignoring installation_repositories action"
+            );
+            StatusCode::OK
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- verify_signature tests ---
+
+    #[test]
+    fn test_verify_signature_valid() {
+        // GitHub official test values
+        let secret = b"It's a Secret to Everybody";
+        let payload = b"Hello, World!";
+        let signature = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
+        assert!(verify_signature(secret, payload, signature));
+    }
+
+    #[test]
+    fn test_verify_signature_invalid() {
+        let secret = b"It's a Secret to Everybody";
+        let payload = b"Hello, World!";
+        let signature = "sha256=0000000000000000000000000000000000000000000000000000000000000000";
+        assert!(!verify_signature(secret, payload, signature));
+    }
+
+    #[test]
+    fn test_verify_signature_missing_prefix() {
+        let secret = b"It's a Secret to Everybody";
+        let payload = b"Hello, World!";
+        let signature = "757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
+        assert!(!verify_signature(secret, payload, signature));
+    }
+
+    #[test]
+    fn test_verify_signature_invalid_hex() {
+        let secret = b"It's a Secret to Everybody";
+        let payload = b"Hello, World!";
+        let signature = "sha256=not-valid-hex";
+        assert!(!verify_signature(secret, payload, signature));
+    }
+
+    #[test]
+    fn test_verify_signature_wrong_secret() {
+        let secret = b"wrong-secret";
+        let payload = b"Hello, World!";
+        let signature = "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
+        assert!(!verify_signature(secret, payload, signature));
+    }
+
+    #[test]
+    fn test_verify_signature_empty_body() {
+        let secret = b"test-secret";
+        let payload = b"";
+        // Compute expected signature for empty body with "test-secret"
+        let mut mac = HmacSha256::new_from_slice(secret).unwrap();
+        mac.update(payload);
+        let result = mac.finalize().into_bytes();
+        let signature = format!("sha256={}", hex::encode(result));
+        assert!(verify_signature(secret, payload, signature.as_str()));
+    }
+
+    // --- Payload deserialization tests ---
+
+    #[test]
+    fn test_deserialize_installation_event_created() {
+        let json = r#"{
+            "action": "created",
+            "installation": { "id": 12345 },
+            "repositories": [
+                { "id": 100, "name": "repo1", "full_name": "owner/repo1" },
+                { "id": 200, "name": "repo2", "full_name": "owner/repo2" }
+            ]
+        }"#;
+        let event: InstallationEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.action, "created");
+        assert_eq!(event.installation.id, 12345);
+        assert_eq!(event.repositories.len(), 2);
+        assert_eq!(event.repositories[0].id, 100);
+        assert_eq!(event.repositories[0].full_name, "owner/repo1");
+    }
+
+    #[test]
+    fn test_deserialize_installation_event_deleted_no_repos() {
+        let json = r#"{
+            "action": "deleted",
+            "installation": { "id": 99999 }
+        }"#;
+        let event: InstallationEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.action, "deleted");
+        assert_eq!(event.installation.id, 99999);
+        assert!(event.repositories.is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_installation_repositories_event_added() {
+        let json = r#"{
+            "action": "added",
+            "installation": { "id": 12345 },
+            "repositories_added": [
+                { "id": 300, "name": "repo3", "full_name": "org/repo3" }
+            ],
+            "repositories_removed": []
+        }"#;
+        let event: InstallationRepositoriesEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.action, "added");
+        assert_eq!(event.repositories_added.len(), 1);
+        assert_eq!(event.repositories_added[0].full_name, "org/repo3");
+        assert!(event.repositories_removed.is_empty());
+    }
+
+    #[test]
+    fn test_deserialize_installation_repositories_event_removed() {
+        let json = r#"{
+            "action": "removed",
+            "installation": { "id": 12345 },
+            "repositories_added": [],
+            "repositories_removed": [
+                { "id": 400, "name": "repo4", "full_name": "org/repo4" }
+            ]
+        }"#;
+        let event: InstallationRepositoriesEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.action, "removed");
+        assert!(event.repositories_added.is_empty());
+        assert_eq!(event.repositories_removed.len(), 1);
+        assert_eq!(event.repositories_removed[0].id, 400);
+    }
+
+    #[test]
+    fn test_deserialize_installation_event_ignores_extra_fields() {
+        let json = r#"{
+            "action": "created",
+            "installation": { "id": 1, "account": { "login": "user" } },
+            "repositories": [],
+            "sender": { "login": "user" }
+        }"#;
+        let event: InstallationEvent = serde_json::from_str(json).unwrap();
+        assert_eq!(event.action, "created");
+        assert_eq!(event.installation.id, 1);
+    }
+}

--- a/crates/api/tests/api_token_test.rs
+++ b/crates/api/tests/api_token_test.rs
@@ -30,12 +30,32 @@ async fn setup_pool() -> Option<PgPool> {
 
 fn create_test_app(pool: PgPool) -> axum::Router {
     let checker: DynGithubAccessChecker = Arc::new(AllowAllGithubAccessChecker);
-    create_app_with_config(pool, None, None, None, Some(checker), None, None, None)
+    create_app_with_config(
+        pool,
+        None,
+        None,
+        None,
+        Some(checker),
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 fn create_deny_app(pool: PgPool) -> axum::Router {
     let checker: DynGithubAccessChecker = Arc::new(DenyAllGithubAccessChecker);
-    create_app_with_config(pool, None, None, None, Some(checker), None, None, None)
+    create_app_with_config(
+        pool,
+        None,
+        None,
+        None,
+        Some(checker),
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 fn rand_i64() -> i64 {

--- a/crates/api/tests/proxy_test.rs
+++ b/crates/api/tests/proxy_test.rs
@@ -55,6 +55,7 @@ fn create_proxy_test_app(pool: PgPool) -> axum::Router {
         Some("test-bucket".to_string()),
         Some("https://app.boardflow.example.com".to_string()),
         None,
+        None,
     )
 }
 

--- a/crates/api/tests/read_api_test.rs
+++ b/crates/api/tests/read_api_test.rs
@@ -32,12 +32,32 @@ async fn setup_pool() -> Option<PgPool> {
 
 fn create_test_app(pool: PgPool) -> axum::Router {
     let checker: DynGithubAccessChecker = Arc::new(AllowAllGithubAccessChecker);
-    create_app_with_config(pool, None, None, None, Some(checker), None, None, None)
+    create_app_with_config(
+        pool,
+        None,
+        None,
+        None,
+        Some(checker),
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 fn create_deny_app(pool: PgPool) -> axum::Router {
     let checker: DynGithubAccessChecker = Arc::new(DenyAllGithubAccessChecker);
-    create_app_with_config(pool, None, None, None, Some(checker), None, None, None)
+    create_app_with_config(
+        pool,
+        None,
+        None,
+        None,
+        Some(checker),
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 fn rand_i64() -> i64 {
@@ -1272,6 +1292,7 @@ async fn test_get_viewer_sources_returns_absolute_url_with_custom_base() {
         None,
         None,
         Some("https://artifacts.boardflow.example.com".to_string()),
+        None,
     );
 
     let response = app
@@ -1695,12 +1716,32 @@ async fn test_list_repositories_allow_all_pagination_cursor() {
 
 fn create_rate_limited_app(pool: PgPool) -> axum::Router {
     let checker: DynGithubAccessChecker = Arc::new(RateLimitedGithubAccessChecker);
-    create_app_with_config(pool, None, None, None, Some(checker), None, None, None)
+    create_app_with_config(
+        pool,
+        None,
+        None,
+        None,
+        Some(checker),
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 fn create_upstream_error_app(pool: PgPool) -> axum::Router {
     let checker: DynGithubAccessChecker = Arc::new(UpstreamErrorGithubAccessChecker);
-    create_app_with_config(pool, None, None, None, Some(checker), None, None, None)
+    create_app_with_config(
+        pool,
+        None,
+        None,
+        None,
+        Some(checker),
+        None,
+        None,
+        None,
+        None,
+    )
 }
 
 #[tokio::test]

--- a/crates/api/tests/webhook_test.rs
+++ b/crates/api/tests/webhook_test.rs
@@ -1,0 +1,391 @@
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use hmac::{Hmac, Mac};
+use serial_test::serial;
+use sha2::Sha256;
+use sqlx::PgPool;
+use tower::ServiceExt;
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn compute_signature(secret: &str, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(body);
+    let result = mac.finalize().into_bytes();
+    format!("sha256={}", hex::encode(result))
+}
+
+const WEBHOOK_SECRET: &str = "test-webhook-secret";
+
+async fn setup_pool() -> Option<PgPool> {
+    unsafe { std::env::set_var("BOARDFLOW_ARTIFACT_SECRET", "test-secret-for-tests") };
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("Skipping test: DATABASE_URL not set");
+            return None;
+        }
+    };
+    let pool = PgPool::connect(&database_url).await.unwrap();
+    sqlx::migrate!("../db/migrations").run(&pool).await.unwrap();
+    Some(pool)
+}
+
+fn create_test_app(pool: PgPool) -> axum::Router {
+    boardflow_api::create_app_with_config(
+        pool,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        Some(WEBHOOK_SECRET.to_string()),
+    )
+}
+
+fn rand_i64() -> i64 {
+    use rand::Rng;
+    rand::thread_rng().gen_range(1..i64::MAX)
+}
+
+// --- Test: ping event returns 200 ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_ping() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let app = create_test_app(pool);
+    let body = br#"{"zen":"Keep it logically awesome."}"#;
+    let signature = compute_signature(WEBHOOK_SECRET, body);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "ping")
+                .header("X-Hub-Signature-256", &signature)
+                .body(Body::from(body.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+// --- Test: invalid signature returns 401 ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_invalid_signature() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let app = create_test_app(pool);
+    let body = br#"{"zen":"test"}"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "ping")
+                .header(
+                    "X-Hub-Signature-256",
+                    "sha256=0000000000000000000000000000000000000000000000000000000000000000",
+                )
+                .body(Body::from(body.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+// --- Test: missing signature returns 401 ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_missing_signature() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let app = create_test_app(pool);
+    let body = br#"{"zen":"test"}"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "ping")
+                .body(Body::from(body.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+// --- Test: installation created upserts repositories ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_installation_created() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+
+    let installation_id = rand_i64();
+    let repo_id_1 = rand_i64();
+    let repo_id_2 = rand_i64();
+
+    let body = serde_json::json!({
+        "action": "created",
+        "installation": { "id": installation_id },
+        "repositories": [
+            { "id": repo_id_1, "name": "repo-alpha", "full_name": "test-org/repo-alpha" },
+            { "id": repo_id_2, "name": "repo-beta", "full_name": "test-org/repo-beta" }
+        ]
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let signature = compute_signature(WEBHOOK_SECRET, &body_bytes);
+
+    let app = create_test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "installation")
+                .header("X-Hub-Signature-256", &signature)
+                .body(Body::from(body_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify repos were created
+    let r1 = boardflow_db::queries::repository::find_by_github_id(&pool, repo_id_1)
+        .await
+        .unwrap();
+    assert!(r1.is_some(), "repo-alpha should exist");
+    let r1 = r1.unwrap();
+    assert_eq!(r1.owner, "test-org");
+    assert_eq!(r1.name, "repo-alpha");
+    assert_eq!(r1.installation_id, installation_id);
+
+    let r2 = boardflow_db::queries::repository::find_by_github_id(&pool, repo_id_2)
+        .await
+        .unwrap();
+    assert!(r2.is_some(), "repo-beta should exist");
+    let r2 = r2.unwrap();
+    assert_eq!(r2.owner, "test-org");
+    assert_eq!(r2.name, "repo-beta");
+    assert_eq!(r2.installation_id, installation_id);
+}
+
+// --- Test: installation deleted clears installation_id ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_installation_deleted() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+
+    let installation_id = rand_i64();
+    let repo_id = rand_i64();
+
+    // Pre-insert a repo with this installation_id
+    boardflow_db::queries::repository::upsert(
+        &pool,
+        repo_id,
+        "del-org",
+        "del-repo",
+        installation_id,
+    )
+    .await
+    .unwrap();
+
+    let body = serde_json::json!({
+        "action": "deleted",
+        "installation": { "id": installation_id }
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let signature = compute_signature(WEBHOOK_SECRET, &body_bytes);
+
+    let app = create_test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "installation")
+                .header("X-Hub-Signature-256", &signature)
+                .body(Body::from(body_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Verify installation_id was cleared to 0
+    let repo = boardflow_db::queries::repository::find_by_github_id(&pool, repo_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        repo.installation_id, 0,
+        "installation_id should be cleared to 0"
+    );
+}
+
+// --- Test: installation_repositories added upserts repos ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_repos_added() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+
+    let installation_id = rand_i64();
+    let repo_id = rand_i64();
+
+    let body = serde_json::json!({
+        "action": "added",
+        "installation": { "id": installation_id },
+        "repositories_added": [
+            { "id": repo_id, "name": "new-repo", "full_name": "add-org/new-repo" }
+        ],
+        "repositories_removed": []
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let signature = compute_signature(WEBHOOK_SECRET, &body_bytes);
+
+    let app = create_test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "installation_repositories")
+                .header("X-Hub-Signature-256", &signature)
+                .body(Body::from(body_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let repo = boardflow_db::queries::repository::find_by_github_id(&pool, repo_id)
+        .await
+        .unwrap();
+    assert!(repo.is_some(), "new-repo should exist");
+    let repo = repo.unwrap();
+    assert_eq!(repo.owner, "add-org");
+    assert_eq!(repo.name, "new-repo");
+    assert_eq!(repo.installation_id, installation_id);
+}
+
+// --- Test: installation_repositories removed clears installation_id ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_repos_removed() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+
+    let installation_id = rand_i64();
+    let repo_id = rand_i64();
+
+    // Pre-insert the repo
+    boardflow_db::queries::repository::upsert(&pool, repo_id, "rm-org", "rm-repo", installation_id)
+        .await
+        .unwrap();
+
+    let body = serde_json::json!({
+        "action": "removed",
+        "installation": { "id": installation_id },
+        "repositories_added": [],
+        "repositories_removed": [
+            { "id": repo_id, "name": "rm-repo", "full_name": "rm-org/rm-repo" }
+        ]
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let signature = compute_signature(WEBHOOK_SECRET, &body_bytes);
+
+    let app = create_test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "installation_repositories")
+                .header("X-Hub-Signature-256", &signature)
+                .body(Body::from(body_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let repo = boardflow_db::queries::repository::find_by_github_id(&pool, repo_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        repo.installation_id, 0,
+        "installation_id should be cleared to 0"
+    );
+}
+
+// --- Test: unknown event returns 200 ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_unknown_event() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let app = create_test_app(pool);
+    let body = br#"{"action":"something"}"#;
+    let signature = compute_signature(WEBHOOK_SECRET, body);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "push")
+                .header("X-Hub-Signature-256", &signature)
+                .body(Body::from(body.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/crates/api/tests/webhook_test.rs
+++ b/crates/api/tests/webhook_test.rs
@@ -361,6 +361,100 @@ async fn test_webhook_repos_removed() {
     );
 }
 
+// --- Test: webhook secret not configured returns 500 ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_no_secret_configured() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    // webhook_secret を None で作成
+    let app =
+        boardflow_api::create_app_with_config(pool, None, None, None, None, None, None, None, None);
+    let body = br#"{"zen":"test"}"#;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "ping")
+                .header("X-Hub-Signature-256", "sha256=dummy")
+                .body(Body::from(body.to_vec()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+}
+
+// --- Test: removed event from different installation does not clear ---
+
+#[tokio::test]
+#[serial]
+async fn test_webhook_repos_removed_different_installation() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+
+    let current_installation_id = rand_i64();
+    let different_installation_id = rand_i64();
+    let repo_id = rand_i64();
+
+    // repo を current_installation_id で登録
+    boardflow_db::queries::repository::upsert(
+        &pool,
+        repo_id,
+        "kept-org",
+        "kept-repo",
+        current_installation_id,
+    )
+    .await
+    .unwrap();
+
+    // different_installation_id からの removed event
+    let body = serde_json::json!({
+        "action": "removed",
+        "installation": { "id": different_installation_id },
+        "repositories_added": [],
+        "repositories_removed": [
+            { "id": repo_id, "name": "kept-repo", "full_name": "kept-org/kept-repo" }
+        ]
+    });
+    let body_bytes = serde_json::to_vec(&body).unwrap();
+    let signature = compute_signature(WEBHOOK_SECRET, &body_bytes);
+
+    let app = create_test_app(pool.clone());
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/v1/github/webhook")
+                .header("Content-Type", "application/json")
+                .header("X-GitHub-Event", "installation_repositories")
+                .header("X-Hub-Signature-256", &signature)
+                .body(Body::from(body_bytes))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // installation_id は変更されていないことを確認
+    let repo = boardflow_db::queries::repository::find_by_github_id(&pool, repo_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        repo.installation_id, current_installation_id,
+        "installation_id should NOT be cleared by different installation's removal"
+    );
+}
+
 // --- Test: unknown event returns 200 ---
 
 #[tokio::test]

--- a/crates/db/src/queries/repository.rs
+++ b/crates/db/src/queries/repository.rs
@@ -159,12 +159,14 @@ pub async fn clear_installation(
 pub async fn clear_installation_for_repo(
     executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
     github_repository_id: i64,
+    installation_id: i64,
 ) -> Result<Option<Repository>, sqlx::Error> {
     sqlx::query_as::<_, Repository>(
         "UPDATE repositories SET installation_id = 0, updated_at = NOW() \
-         WHERE github_repository_id = $1 RETURNING *",
+         WHERE github_repository_id = $1 AND installation_id = $2 RETURNING *",
     )
     .bind(github_repository_id)
+    .bind(installation_id)
     .fetch_optional(executor)
     .await
 }

--- a/crates/db/src/queries/repository.rs
+++ b/crates/db/src/queries/repository.rs
@@ -142,3 +142,29 @@ pub async fn upsert(
     .fetch_one(executor)
     .await
 }
+
+pub async fn clear_installation(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    installation_id: i64,
+) -> Result<Vec<Repository>, sqlx::Error> {
+    sqlx::query_as::<_, Repository>(
+        "UPDATE repositories SET installation_id = 0, updated_at = NOW() \
+         WHERE installation_id = $1 RETURNING *",
+    )
+    .bind(installation_id)
+    .fetch_all(executor)
+    .await
+}
+
+pub async fn clear_installation_for_repo(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    github_repository_id: i64,
+) -> Result<Option<Repository>, sqlx::Error> {
+    sqlx::query_as::<_, Repository>(
+        "UPDATE repositories SET installation_id = 0, updated_at = NOW() \
+         WHERE github_repository_id = $1 RETURNING *",
+    )
+    .bind(github_repository_id)
+    .fetch_optional(executor)
+    .await
+}

--- a/docs/external/github-webhook-signature.md
+++ b/docs/external/github-webhook-signature.md
@@ -1,0 +1,383 @@
+# GitHub App Webhook 署名検証・Payload構造・Axum実装パターン調査
+
+## 要約
+
+GitHub App Webhook の受信エンドポイント実装（Issue #28）に必要な外部知識を調査した。
+署名検証は HMAC-SHA256 で `X-Hub-Signature-256` ヘッダを使う。BoardFlow の api crate には既に `hmac`, `sha2`, `hex` が依存に含まれており、新規 crate 追加なしで実装可能。
+Axum では `HeaderMap` と `Bytes` を handler 引数に並べることで raw body と headers を同時に取得できる。
+
+## 確認した情報
+
+### 1. 署名検証アルゴリズム
+
+**GitHub公式要件（https://docs.github.com/en/webhooks/using-webhooks/securing-your-webhooks）:**
+
+1. GitHub App 設定で webhook secret を登録する
+2. GitHub は各 delivery で `X-Hub-Signature-256` ヘッダを付与する
+3. 値の形式: `sha256=<HMAC-SHA256 hex digest>`
+4. HMAC key = webhook secret, message = raw request body (UTF-8)
+5. 比較は定数時間比較（timing-safe）で行う必要がある
+6. `X-Hub-Signature` (SHA-1) はレガシーであり、`X-Hub-Signature-256` を推奨
+
+**検証テスト値（GitHub公式）:**
+
+```
+secret:    "It's a Secret to Everybody"
+payload:   "Hello, World!"
+signature: sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17
+```
+
+**Rustでの実装コード例:**
+
+```rust
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
+
+fn verify_signature(secret: &[u8], body: &[u8], signature_header: &str) -> bool {
+    // "sha256=..." からプレフィックスを除去
+    let hex_signature = match signature_header.strip_prefix("sha256=") {
+        Some(hex) => hex,
+        None => return false,
+    };
+
+    // 期待されるsignatureをデコード
+    let expected = match hex::decode(hex_signature) {
+        Ok(bytes) => bytes,
+        Err(_) => return false,
+    };
+
+    // HMAC-SHA256を計算
+    let mut mac = HmacSha256::new_from_slice(secret)
+        .expect("HMAC accepts any key length");
+    mac.update(body);
+    let computed = mac.finalize().into_bytes();
+
+    // 定数時間比較（timing attack防止）
+    computed.as_slice().ct_eq(&expected).into()
+}
+```
+
+**定数時間比較について:**
+
+- `subtle` crate の `ConstantTimeEq` を使う方法が Rust では一般的
+- `hmac` crate の `mac.verify_slice()` も内部で定数時間比較を行う
+- BoardFlow では `hmac` crate が既に依存にあるので `mac.verify_slice()` を使うのがシンプル
+
+```rust
+// hmac crate の verify_slice を使う場合（推奨）
+fn verify_signature(secret: &[u8], body: &[u8], signature_header: &str) -> bool {
+    let hex_signature = match signature_header.strip_prefix("sha256=") {
+        Some(hex) => hex,
+        None => return false,
+    };
+
+    let expected = match hex::decode(hex_signature) {
+        Ok(bytes) => bytes,
+        Err(_) => return false,
+    };
+
+    let mut mac = HmacSha256::new_from_slice(secret)
+        .expect("HMAC accepts any key length");
+    mac.update(body);
+
+    mac.verify_slice(&expected).is_ok()
+}
+```
+
+### 2. Webhook Delivery ヘッダ
+
+GitHub は各 webhook delivery に以下のヘッダを含める:
+
+| ヘッダ | 説明 | BoardFlow での用途 |
+|---|---|---|
+| `X-GitHub-Event` | イベント名 (`installation`, `installation_repositories`, `ping` など) | イベントのルーティング |
+| `X-GitHub-Delivery` | GUID (delivery ごとに一意) | 冪等性チェック、ログ追跡 |
+| `X-Hub-Signature-256` | `sha256=<HMAC hex>` | 署名検証 |
+| `X-GitHub-Hook-ID` | Webhook ID | ログ |
+| `X-GitHub-Hook-Installation-Target-Type` | `integration` (GitHub App の場合) | 識別補助 |
+| `X-GitHub-Hook-Installation-Target-ID` | App ID | 識別補助 |
+| `User-Agent` | `GitHub-Hookshot/...` | ログ |
+
+### 3. Webhook Event Payload 構造
+
+#### 3.1 `installation` イベント
+
+GitHub App がインストール/アンインストールされたときに発生。全 GitHub App が自動受信。
+
+**action: `created`** (App がインストールされた)
+
+```json
+{
+  "action": "created",
+  "installation": {
+    "id": 12345678,
+    "account": {
+      "login": "ForteFibre",
+      "id": 987654,
+      "type": "Organization"
+    },
+    "app_id": 123456,
+    "target_type": "Organization",
+    "permissions": {
+      "issues": "write",
+      "contents": "read",
+      "metadata": "read"
+    },
+    "events": ["installation", "installation_repositories", "push"],
+    "created_at": "2026-05-01T00:00:00Z",
+    "updated_at": "2026-05-01T00:00:00Z"
+  },
+  "repositories": [
+    {
+      "id": 111222333,
+      "node_id": "R_abc123",
+      "name": "hardware",
+      "full_name": "ForteFibre/hardware",
+      "private": false
+    }
+  ],
+  "sender": {
+    "login": "user",
+    "id": 1
+  }
+}
+```
+
+**action: `deleted`** (App がアンインストールされた)
+
+```json
+{
+  "action": "deleted",
+  "installation": {
+    "id": 12345678,
+    "account": { "login": "ForteFibre", "id": 987654 }
+  },
+  "repositories": [
+    {
+      "id": 111222333,
+      "node_id": "R_abc123",
+      "name": "hardware",
+      "full_name": "ForteFibre/hardware",
+      "private": false
+    }
+  ],
+  "sender": { "login": "user", "id": 1 }
+}
+```
+
+**BoardFlow での処理:**
+- `created`: `repositories` テーブルに `installation_id` を紐づけて upsert
+- `deleted`: 該当 `installation_id` に関連する repository の連携状態を解除（削除ではない）
+
+#### 3.2 `installation_repositories` イベント
+
+GitHub App がアクセスできるリポジトリが追加/削除されたときに発生。
+
+**action: `added`**
+
+```json
+{
+  "action": "added",
+  "installation": {
+    "id": 12345678,
+    "account": { "login": "ForteFibre", "id": 987654 }
+  },
+  "repository_selection": "selected",
+  "repositories_added": [
+    {
+      "id": 444555666,
+      "node_id": "R_def456",
+      "name": "new-board",
+      "full_name": "ForteFibre/new-board",
+      "private": true
+    }
+  ],
+  "repositories_removed": [],
+  "sender": { "login": "user", "id": 1 }
+}
+```
+
+**action: `removed`**
+
+```json
+{
+  "action": "removed",
+  "installation": {
+    "id": 12345678,
+    "account": { "login": "ForteFibre", "id": 987654 }
+  },
+  "repository_selection": "selected",
+  "repositories_added": [],
+  "repositories_removed": [
+    {
+      "id": 444555666,
+      "node_id": "R_def456",
+      "name": "new-board",
+      "full_name": "ForteFibre/new-board",
+      "private": true
+    }
+  ],
+  "sender": { "login": "user", "id": 1 }
+}
+```
+
+**BoardFlow での処理:**
+- `added`: `repositories` テーブルに `installation_id` 付きで upsert
+- `removed`: 該当リポジトリの連携状態を解除（BoardProject や BoardRun は残す）
+
+#### 3.3 `ping` イベント
+
+Webhook 設定時に GitHub が送信する確認イベント。
+
+```json
+{
+  "zen": "Responsive is better than fast.",
+  "hook_id": 292430182,
+  "hook": { ... },
+  "sender": { "login": "user", "id": 1 }
+}
+```
+
+**BoardFlow での処理:** 200 OK を返すだけでよい。
+
+### 4. Axum での Raw Body + Headers 同時取得パターン
+
+Axum では extractor を handler の引数に複数並べることで、headers と raw body を同時に取得できる。
+**重要: `Bytes` は body を消費するため、extractors の最後に置く必要がある。**
+
+```rust
+use axum::{
+    body::Bytes,
+    http::{HeaderMap, StatusCode},
+    routing::post,
+    Router,
+};
+
+async fn webhook_handler(
+    headers: HeaderMap,
+    body: Bytes,
+) -> StatusCode {
+    // 1. X-Hub-Signature-256 を取得
+    let signature = match headers.get("x-hub-signature-256") {
+        Some(sig) => match sig.to_str() {
+            Ok(s) => s,
+            Err(_) => return StatusCode::BAD_REQUEST,
+        },
+        None => return StatusCode::UNAUTHORIZED,
+    };
+
+    // 2. 署名検証
+    let webhook_secret = b"your-webhook-secret"; // 環境変数から取得
+    if !verify_signature(webhook_secret, &body, signature) {
+        return StatusCode::UNAUTHORIZED;
+    }
+
+    // 3. X-GitHub-Event でルーティング
+    let event = headers
+        .get("x-github-event")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    match event {
+        "installation" => handle_installation(&body).await,
+        "installation_repositories" => handle_installation_repositories(&body).await,
+        "ping" => StatusCode::OK,
+        _ => {
+            tracing::debug!(event, "unhandled webhook event");
+            StatusCode::OK
+        }
+    }
+}
+
+// ルーター登録
+fn webhook_router() -> Router {
+    Router::new().route("/api/v1/github/webhook", post(webhook_handler))
+}
+```
+
+**Axum extractor の順序規則:**
+- `HeaderMap` は body を消費しないので先に置ける
+- `Bytes` は body を消費するため最後
+- `Json<T>` も body を消費するため `Bytes` とは併用不可（raw body を先に取って手動パース）
+
+### 5. 必要な Rust crate
+
+| crate | 用途 | BoardFlow での状態 |
+|---|---|---|
+| `hmac` | HMAC 計算 | **既に api crate 依存に含まれている** |
+| `sha2` | SHA-256 | **既に api crate 依存に含まれている** |
+| `hex` | hex encode/decode | **既に api crate 依存に含まれている** |
+| `axum` | HTTP framework | **既に api crate 依存に含まれている** |
+| `serde` / `serde_json` | JSON パース | **既に api crate 依存に含まれている** |
+
+追加 crate は不要。`subtle` crate は `hmac` の `verify_slice` を使えば不要。
+
+### 6. レスポンス方針
+
+GitHub は webhook delivery のレスポンスとして:
+- **10秒以内に応答** することを推奨
+- ステータスコード `2xx` を成功とみなす
+- `4xx` / `5xx` はリトライ対象
+
+BoardFlow では:
+- 署名検証失敗: `401 Unauthorized`
+- 処理成功: `200 OK`（レスポンスボディは空か `{"received": true}` でよい）
+- DB 処理は同期的に行う（installation 同期は軽量な upsert のみ）
+- 重い処理が必要な場合は job enqueue して即座に 200 を返す
+
+### 7. 冪等性
+
+- `X-GitHub-Delivery` ヘッダの GUID で delivery を一意に識別できる
+- MVP では DB に delivery ID を保存する冪等性チェックは必須ではない
+- installation/repository の upsert 自体が冪等な操作
+
+### 8. セキュリティ考慮事項
+
+- webhook secret は環境変数で管理し、コードにハードコードしない
+- 署名検証は **必ず raw body に対して行う**（JSON パース後のシリアライズではなく、受信したバイト列そのもの）
+- 定数時間比較を使い、timing attack を防ぐ
+- `X-Hub-Signature-256` が存在しない場合は署名検証をスキップするのではなく、リクエストを拒否する
+
+## BoardFlow への示唆
+
+1. **エンドポイント**: `POST /api/v1/github/webhook` を api crate に追加
+2. **設定**: `AppConfig` に `github_webhook_secret: Option<String>` を追加
+3. **署名検証**: `hmac` + `sha2` + `hex` で実装（新規 crate 不要）
+4. **イベント処理**:
+   - `installation` created → repositories テーブルに installation_id 付きで upsert
+   - `installation` deleted → 該当 installation の repository 連携状態を解除
+   - `installation_repositories` added → repositories テーブルに upsert
+   - `installation_repositories` removed → 該当 repository の連携状態を解除
+   - `ping` → 200 OK
+5. **Axum パターン**: `HeaderMap` + `Bytes` で raw body と headers を同時取得
+6. **Payload 型**: serde の `#[serde(tag = "action")]` で action ごとにデシリアライズ可能
+
+## 採用/不採用判断
+
+- **HMAC-SHA256署名検証**: 採用（GitHub公式要件、既存crate活用）
+- **`Bytes` + `HeaderMap` パターン**: 採用（Axum標準機能、追加依存なし）
+- **Payload型の自前定義**: 採用（octocrab の webhook 型は使わず、必要なフィールドのみ定義）
+- **delivery ID による冪等性テーブル**: MVP不採用（upsert で十分）
+
+## 制約と pitfall
+
+1. **body は一度しか読めない**: Axum で `Bytes` を使うと body を消費するため、署名検証と JSON パースで同じ `Bytes` を使い回す必要がある
+2. **proxy/load balancer による body 変更**: リバースプロキシがボディを変更すると署名が不一致になる。nginx等でボディを変更しない設定が必要
+3. **GitHub は 10秒以内の応答を期待**: DB upsert 程度なら問題ないが、重い処理は非同期化する
+4. **`X-Hub-Signature` (SHA-1) は無視**: SHA-256 のみ使用する
+5. **webhook secret のローテーション**: GitHub App 設定画面から secret を変更すると、古い secret での署名検証が失敗する。MVP では単一 secret で運用
+
+## 未解決の疑問
+
+- なし（MVP に必要な情報は十分に揃っている）
+
+## 参照URL
+
+- https://docs.github.com/en/webhooks/using-webhooks/securing-your-webhooks
+- https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation
+- https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation_repositories
+- https://docs.github.com/en/webhooks/using-webhooks/best-practices-for-using-webhooks
+- https://docs.github.com/en/apps/creating-github-apps/about-creating-github-apps/about-creating-github-apps

--- a/docs/logs/28/worklog.md
+++ b/docs/logs/28/worklog.md
@@ -324,3 +324,121 @@ pub struct WebhookSecret(pub Option<String>);
 ### 更新した作業ログパス
 
 `docs/logs/28/worklog.md`
+
+---
+
+## レビューフェーズ (2026-05-02)
+
+### Issueまでの経緯
+
+- 対象は Issue #28 のみ。
+- 実装、research、spec、backend summary、統合テスト、関連 worker ハンドラを突き合わせてレビューした。
+
+### 調査結果
+
+- `docs/spec.md` / `docs/backend/summary.md` が求める GitHub App webhook 受信、署名検証、repository 同期の大枠は実装されている。
+- 署名検証は raw body に対する HMAC-SHA256 + `verify_slice()` で、research と GitHub Docs の推奨に整合している。
+- `installation_repositories.removed` の DB 更新が `github_repository_id` のみで実行されており、event payload の `installation.id` で絞っていない。
+- 受け入れ条件 10 (`GITHUB_WEBHOOK_SECRET` 未設定時に 500) に対応する統合テストは存在しない。
+- `GITHUB_WEBHOOK_SECRET` の運用設定が README / docs 配下の恒久ドキュメントに反映されていない。
+
+### 実装内容レビュー結果
+
+- `pr_ready: false`
+
+#### 重大指摘
+
+1. **major**: `installation_repositories removed` が installation を条件にせず repository 単位で解除しており、順不同 delivery や再配送で現行の連携状態を誤って消し得る。
+    - 呼び出し側: `crates/api/src/routes/webhook.rs` で removal payload の `installation.id` を受け取っているにもかかわらず、[crates/api/src/routes/webhook.rs](crates/api/src/routes/webhook.rs#L210) から [crates/api/src/routes/webhook.rs](crates/api/src/routes/webhook.rs#L212) では `clear_installation_for_repo(pool, repo.id)` しか渡していない。
+    - クエリ側: [crates/db/src/queries/repository.rs](crates/db/src/queries/repository.rs#L159) から [crates/db/src/queries/repository.rs](crates/db/src/queries/repository.rs#L165) は `WHERE github_repository_id = $1` だけで `installation_id` を見ていない。
+    - GitHub webhook は再配送や順不同到着を考慮すべきなので、少なくとも `github_repository_id` と `installation_id` の両方で条件付ける必要がある。
+
+#### 必須修正
+
+1. `clear_installation_for_repo` を `github_repository_id + installation_id` 条件に変更し、handler 側から event の `installation.id` を渡す。
+2. 上記に対応する統合テストを追加し、別 installation に再紐付け済みの repository に対して古い removal event が来ても `installation_id` を消さないことを検証する。
+3. 受け入れ条件 10 に対応する統合テストを追加し、`WebhookSecret(None)` 構成で [crates/api/tests/webhook_test.rs](crates/api/tests/webhook_test.rs) に 500 応答を確認するケースを入れる。
+
+#### 任意改善
+
+1. `X-GitHub-Delivery` をログに含めると、再配送や障害解析時の追跡がしやすくなる。
+2. 連携解除済み repository (`installation_id = 0`) を後続 worker が扱うと GitHub API 呼び出しで 0 を installation_id として使うため、将来的にはジョブ側で明示的に無効状態を扱うガードがあると安全。
+
+### テスト結果
+
+- 実行確認: `cargo test -p boardflow-api --test webhook_test` → 8件 pass
+- 実行確認: `cargo test -p boardflow-api webhook::tests` → 11件 pass
+- 既存の `create_app_with_config` 呼び出しは追加引数込みでコンパイル上は整合していることを確認した。
+
+### テスト不足
+
+- [crates/api/tests/webhook_test.rs](crates/api/tests/webhook_test.rs) には `GITHUB_WEBHOOK_SECRET` 未設定時 500 のケースがない。
+- removal event の installation 不一致時に状態を保持する回帰テストがない。
+
+### ドキュメント確認
+
+- `docs/spec.md` / `docs/backend/summary.md` / `docs/external/github-webhook-signature.md` とは概ね整合。
+- ただし `GITHUB_WEBHOOK_SECRET` の設定方法が README などの恒久ドキュメントに見当たらず、運用者向け導線が不足している。
+
+### plan / research / docs との不整合
+
+- 計画上の受け入れ条件 10 は実装されているが、テスト実績とテストファイル構成が追いついていない。
+- research では delivery の信頼性と raw body 検証を重視しており、署名検証は一致している。一方で removal の条件が installation 非依存なのは、順不同 delivery を考慮する設計として弱い。
+
+### PR/完了結果
+
+- PR 作成可否: `pr_ready: false`
+- 理由: 連携解除クエリの条件不足が実データ破壊に繋がり得るため。
+
+### 残リスク
+
+- installation deleted / removed 後に既存の GitHub job が残っていた場合の downstream 挙動は本 Issue のテスト範囲外。
+
+### 更新した作業ログパス
+
+`docs/logs/28/worklog.md`
+
+---
+
+## レビュー指摘修正フェーズ (2026-05-02)
+
+### 修正内容
+
+レビューで指摘された必須修正3件 + 任意改善1件をすべて対応した。
+
+#### 1. (major) `clear_installation_for_repo` の installation 条件追加
+
+- **`crates/db/src/queries/repository.rs`**: `clear_installation_for_repo` に `installation_id: i64` 引数を追加し、WHERE 条件を `github_repository_id = $1 AND installation_id = $2` に変更。再配送や installation 移動時に現行の installation を誤ってクリアしなくなった。
+- **`crates/api/src/routes/webhook.rs`**: `handle_installation_repositories_event` の `removed` 処理で `event.installation.id` を第3引数として渡すように変更。
+
+#### 2. (major) secret 未設定時 500 の統合テスト追加
+
+- **`crates/api/tests/webhook_test.rs`**: `test_webhook_no_secret_configured` を追加。`webhook_secret = None` で app を構成し、500 が返ることを検証。
+
+#### 3. (major) installation 不一致の removed event 回帰テスト追加
+
+- **`crates/api/tests/webhook_test.rs`**: `test_webhook_repos_removed_different_installation` を追加。repo が installation_id=A で登録済みの状態で installation_id=B からの removed event が来ても installation_id が変わらないことを検証。
+
+#### 4. (suggestion) X-GitHub-Delivery ログ出力
+
+- **`crates/api/src/routes/webhook.rs`**: `github_webhook` handler で `X-GitHub-Delivery` ヘッダを取得し、`tracing::info!` に `delivery_id` フィールドとして含めるよう変更。
+
+### テスト結果
+
+- `cargo check --workspace`: OK
+- `cargo test -p boardflow-api --lib`: 15 passed
+- `cargo test -p boardflow-api --test webhook_test`: 10 passed (新規2件含む)
+- `cargo clippy --workspace --all-targets -- -D warnings`: OK
+- `cargo fmt --all -- --check`: OK
+
+### 更新ドキュメント
+
+- `docs/logs/28/worklog.md` (本ファイル)
+
+### 残リスク
+
+- installation deleted / removed 後に既存の GitHub job が残っていた場合の downstream 挙動は本 Issue のテスト範囲外。
+
+### 更新した作業ログパス (修正後)
+
+`docs/logs/28/worklog.md`

--- a/docs/logs/28/worklog.md
+++ b/docs/logs/28/worklog.md
@@ -442,3 +442,138 @@ pub struct WebhookSecret(pub Option<String>);
 ### 更新した作業ログパス (修正後)
 
 `docs/logs/28/worklog.md`
+
+---
+
+## 再レビューフェーズ (2026-05-02)
+
+### Issueまでの経緯
+
+- 対象は Issue #28 のみ。
+- 前回レビューで `pr_ready: false` とした major 3件の修正有無を再確認した。
+- ユーザー申告の修正点に加え、Issue本文、spec、research、現行実装、統合テストを突き合わせた。
+
+### ユーザー要望
+
+- 前回 major 3件が正しく解消されているか再レビューする。
+- 特に以下を確認する。
+    1. `clear_installation_for_repo` の SQL WHERE 句に `installation_id` が追加されていること
+    2. handler 側で `event.installation.id` を渡していること
+    3. 新規テスト2件がリグレッション防止として十分であること
+
+### 調査結果
+
+- Issue本文は `gh issue view 28 --json number,title,body` で確認した。
+- [crates/db/src/queries/repository.rs](crates/db/src/queries/repository.rs#L159) の `clear_installation_for_repo` は `github_repository_id = $1 AND installation_id = $2` 条件に変更済み。
+- [crates/api/src/routes/webhook.rs](crates/api/src/routes/webhook.rs#L220) の `removed` 処理は `clear_installation_for_repo(pool, repo.id, event.installation.id)` を呼ぶように変更済み。
+- [crates/api/tests/webhook_test.rs](crates/api/tests/webhook_test.rs#L368) の `test_webhook_no_secret_configured` が `webhook_secret = None` 構成で 500 を検証している。
+- [crates/api/tests/webhook_test.rs](crates/api/tests/webhook_test.rs#L398) の `test_webhook_repos_removed_different_installation` が installation 不一致時に `installation_id` を保持することを検証している。
+- [crates/api/src/routes/webhook.rs](crates/api/src/routes/webhook.rs#L109) で `X-GitHub-Delivery` が `delivery_id` としてログ出力に含まれている。
+- GitHub Docs のベストプラクティス上も、redelivery があり得ること、`X-GitHub-Delivery` で delivery を追跡すること、event/action を見て処理することは妥当。
+
+### 計画
+
+- major 3件の修正箇所を直接確認する。
+- Webhook 統合テストを実行して新規2件を含む回帰防止を検証する。
+- research / docs / spec と照合して、ブロッカーが残っていないか判定する。
+
+### 実装内容
+
+- `clear_installation_for_repo` は installation 条件付き更新に修正されており、前回指摘の誤解除リスクは解消された。
+- handler 側は removal payload の `installation.id` を DB クエリに渡しており、SQL 修正と接続されている。
+- 追加された2件の統合テストはいずれも前回の欠落点を直接カバーしている。
+
+### テスト結果
+
+- 実行確認: `cargo test -p boardflow-api --test webhook_test` → 10 passed
+- 新規追加の `test_webhook_no_secret_configured` / `test_webhook_repos_removed_different_installation` を含めて成功した。
+
+### レビュー結果
+
+- `pr_ready: true`
+- 前回の major 3件はすべて修正済みで、現時点で PR を止める指摘はない。
+- 新規テスト2件は、受け入れ条件 10 と removal event の installation 不一致回帰の両方を直接押さえており、今回の修正範囲に対して十分。
+
+### ドキュメント確認
+
+- [docs/spec.md](docs/spec.md#L1606) と [docs/backend/summary.md](docs/backend/summary.md#L1) の GitHub App webhook 方針とは整合している。
+- `GITHUB_WEBHOOK_SECRET` の恒久ドキュメント導線は引き続き薄いが、前回 major の再レビュー観点としては非ブロッカーと判断した。
+
+### PR/完了結果
+
+- PR 作成可否: `pr_ready: true`
+
+### 残リスク
+
+- Issue本文は `POST /api/v1/webhooks/github` と書かれている一方、実装とテストは `POST /api/v1/github/webhook` に統一されている。現行 docs / research / テストとは整合しているため今回はブロッカーにしないが、外部利用者向けの案内は将来的に一本化した方がよい。
+
+### 更新した作業ログパス
+
+`docs/logs/28/worklog.md`
+
+---
+
+## ドキュメント確認フェーズ (2026-05-02)
+
+### Issueまでの経緯
+
+- 対象は Issue #28 のみ。
+- docs review として Issue本文、research成果物、実装概要、関連ドキュメント、現行実装、既存 worklog を突き合わせた。
+
+### ユーザー要望
+
+- `docs/spec.md`、`docs/backend/summary.md`、`docs/external/github-webhook-signature.md`、`docs/logs/28/worklog.md` の整合性を確認する。
+- `GITHUB_WEBHOOK_SECRET` の運用ドキュメント追記要否を判断する。
+
+### 調査結果
+
+- [docs/spec.md](docs/spec.md#L1606) は GitHub App 連携方針と webhook 受信の存在を定義しており、今回の実装内容と矛盾しない。
+- [docs/backend/summary.md](docs/backend/summary.md#L290) の「GitHub webhook signature verification test」は、[crates/api/src/routes/webhook.rs](crates/api/src/routes/webhook.rs#L217) のユニットテスト群と [crates/api/tests/webhook_test.rs](crates/api/tests/webhook_test.rs#L1) の統合テスト群でカバーされている。
+- [docs/external/github-webhook-signature.md](docs/external/github-webhook-signature.md#L297) の実装方針は、[crates/api/src/routes/webhook.rs](crates/api/src/routes/webhook.rs#L56)、[crates/api/src/lib.rs](crates/api/src/lib.rs#L92)、[crates/db/src/queries/repository.rs](crates/db/src/queries/repository.rs#L151) と一致している。
+- [docs/logs/28/worklog.md](docs/logs/28/worklog.md#L1) には経緯、調査、計画、実装、テスト、レビュー結果、再レビュー結果が揃っており、今回の確認結果を追記すれば時系列の完全性も満たせる。
+- `GITHUB_WEBHOOK_SECRET` は [crates/api/src/config.rs](crates/api/src/config.rs#L39) と [crates/api/src/main.rs](crates/api/src/main.rs#L41) で実装に反映されているが、[README.md](README.md) と `docs/` 配下の恒久ドキュメントには設定手順が見当たらない。
+- Issue本文は `POST /api/v1/webhooks/github`、実装と research は `POST /api/v1/github/webhook` であり、Issue本文とのみ表記揺れが残っている。
+
+### 計画
+
+- ブロッカーになる不整合があるかを docs 観点で判定する。
+- 必須修正と任意改善を分離して worklog に記録する。
+
+### 実装内容
+
+- コード変更は行わず、docs review 結果のみ整理した。
+
+### テスト結果
+
+- 既存の実装ログに記載された webhook テスト結果を確認し、docs/backend/summary.md のテスト方針に対する裏付けとして妥当と判断した。
+
+### レビュー結果
+
+- `docs_ready: true`
+- PR を docs 観点で止める必須修正はない。
+
+### ドキュメント確認
+
+- 整合しているドキュメント:
+    - [docs/spec.md](docs/spec.md#L1606)
+    - [docs/backend/summary.md](docs/backend/summary.md#L290)
+    - [docs/external/github-webhook-signature.md](docs/external/github-webhook-signature.md#L346)
+    - [docs/logs/28/worklog.md](docs/logs/28/worklog.md#L1)
+- 不整合のあるドキュメント:
+    - GitHub Issue #28 本文のエンドポイント表記が `POST /api/v1/webhooks/github` のままで、実装・research と一致していない。
+- 不足しているドキュメント:
+    - `GITHUB_WEBHOOK_SECRET` をどこで設定するかの運用メモが [README.md](README.md) または関連 docs にない。
+
+### PR/完了結果
+
+- docs 観点の PR 作成可否: `docs_ready: true`
+- 追記推奨はあるが、いずれも非ブロッカー。
+
+### 残リスク
+
+- PR本文で webhook endpoint を説明する際、Issue本文の旧表記をそのまま転載すると混乱が再発する。
+- 本番導入時に `GITHUB_WEBHOOK_SECRET` の設定先が README 等にないため、運用者が環境変数を見落とす可能性がある。
+
+### 更新した作業ログパス
+
+`docs/logs/28/worklog.md`

--- a/docs/logs/28/worklog.md
+++ b/docs/logs/28/worklog.md
@@ -577,3 +577,34 @@ pub struct WebhookSecret(pub Option<String>);
 ### 更新した作業ログパス
 
 `docs/logs/28/worklog.md`
+
+---
+
+## PR作成フェーズ (2026-05-02)
+
+### PR/完了結果
+
+- PR 作成: **完了**
+- PR URL: https://github.com/f0reachARR/boardflow/pull/51
+- タイトル: `feat(#28): GitHub App Webhook受信エンドポイント実装`
+- ベースブランチ: `main` ← `feat/28-github-webhook-endpoint`
+
+### 確認事項
+
+- `pr_ready: true`（再レビューフェーズで確認済み）
+- `docs_ready: true`（ドキュメント確認フェーズで確認済み）
+- 未コミット変更なし（`docs/logs/25/` のみ untracked で無関係）
+- ユニットテスト 15 件 / 統合テスト 10 件 すべて pass
+- `cargo clippy --workspace --all-targets -- -D warnings`: OK
+- `cargo fmt --all -- --check`: OK
+
+### 残リスク
+
+- Issue 本文のエンドポイント表記 (`POST /api/v1/webhooks/github`) と実装 (`POST /api/v1/github/webhook`) に表記揺れあり。将来一本化推奨。
+- `GITHUB_WEBHOOK_SECRET` の設定手順が README / 恒久ドキュメントに未記載。本番導入時に別途追記推奨。
+- installation deleted / removed 後に既存の GitHub job が残っていた場合の downstream 挙動は本 Issue のテスト範囲外。
+
+### 更新した作業ログパス
+
+`docs/logs/28/worklog.md`
+

--- a/docs/logs/28/worklog.md
+++ b/docs/logs/28/worklog.md
@@ -1,0 +1,326 @@
+# Issue #28 作業ログ: GitHub App Webhook受信エンドポイント実装
+
+## Issue概要
+
+GitHub App からの Webhook を受信するエンドポイントを実装する。
+installation 関連のイベント（installation created/deleted、repositories added/removed）を処理し、repository 情報を DB 同期する。webhook 署名の検証も行う。
+
+## Issueまでの経緯
+
+- Issue #19（GitHub App クライアント）がマージ済み。`crates/github/` に octocrab ベースのクライアントが実装されている。
+- `docs/spec.md` および `docs/backend/summary.md` で GitHub App webhook は MVP から含めると明記。
+- `docs/backend/summary.md` のテスト方針に「GitHub webhook signature verification test」が含まれている。
+- api crate には既に `hmac`, `sha2`, `hex` が依存に含まれている。
+
+## ユーザー要望
+
+docs 以下の仕様に基づいてアプリケーションを一通り実装する。
+
+## 調査結果
+
+### 2026-05-02: 外部調査完了 (research agent)
+
+以下の外部トピックを調査し、`docs/external/github-webhook-signature.md` に記録した。
+
+#### 1. GitHub App Webhook 署名検証
+- HMAC-SHA256 アルゴリズムで `X-Hub-Signature-256` ヘッダを検証
+- Rust では `hmac` + `sha2` + `hex` crate（全て api crate に既存）で実装可能
+- `hmac` crate の `verify_slice()` で定数時間比較が組み込み済み
+- 追加 crate 不要
+
+#### 2. Webhook Payload 構造
+- `installation` イベント: action = created / deleted
+  - `installation.id`, `repositories[].id`, `repositories[].full_name` 等を含む
+- `installation_repositories` イベント: action = added / removed
+  - `repositories_added[]`, `repositories_removed[]` で差分を受信
+- `ping` イベント: webhook 設定確認用、200 OK 返却のみ
+
+#### 3. ベストプラクティス
+- 10秒以内に応答する
+- `X-GitHub-Delivery` で冪等性を確保可能（MVPでは upsert で十分）
+- raw body に対して署名検証を行う（JSON パース後のデータではなく）
+
+#### 4. Axum での実装パターン
+- `HeaderMap` + `Bytes` を handler 引数に並べる
+- `Bytes` は body を消費するため最後に配置
+- 署名検証後に同じ `Bytes` から `serde_json::from_slice` でパース
+
+### 参照URL
+- https://docs.github.com/en/webhooks/using-webhooks/securing-your-webhooks
+- https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation
+- https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation_repositories
+- https://docs.github.com/en/webhooks/using-webhooks/best-practices-for-using-webhooks
+
+## 結論ステータス
+
+**`implementation_required`**
+
+調査は完了し、実装に必要な情報はすべて揃っている。以下が後続実装で必要:
+
+1. `AppConfig` に `github_webhook_secret` を追加
+2. `POST /api/v1/github/webhook` エンドポイントを api crate に追加
+3. 署名検証関数の実装（`hmac` + `sha2` + `hex`）
+4. Webhook payload の serde 型定義
+5. installation/repository の DB 同期ロジック（upsert）
+6. 署名検証のユニットテスト
+7. webhook handler の統合テスト
+
+## 残リスク
+
+- なし（MVPに必要な外部情報は十分）
+
+---
+
+## 計画フェーズ (2026-05-02)
+
+### 実装要否: `implementation_required`
+
+### 目的
+
+GitHub App からの Webhook を受信・検証し、installation/repository の状態を DB に同期するエンドポイントを実装する。これにより、GitHub App がインストール/アンインストールされたときやリポジトリが追加/削除されたときに、BoardFlow の repositories テーブルが自動的に更新される。
+
+### 非目的
+
+- push イベントの処理（Webhookではなく Action API 経由で処理）
+- Webhook delivery ID による冪等性チェック（upsert で十分）
+- Redis / Queue への enqueue（同期処理で十分な軽量 upsert のみ）
+- installation テーブルの作成（MVP では repositories テーブルの installation_id で管理）
+- OpenAPI ドキュメント登録（webhook は外部からの呼び出しであり、utoipa ルート登録不要）
+
+### 受け入れ条件
+
+1. `POST /api/v1/github/webhook` でリクエストを受信できる
+2. `X-Hub-Signature-256` ヘッダによる HMAC-SHA256 署名検証が行われる
+3. 署名不正時は 401 を返す
+4. `ping` イベントで 200 を返す
+5. `installation` created で repositories テーブルに upsert される
+6. `installation` deleted で該当 installation_id のリポジトリの installation_id が 0 にクリアされる
+7. `installation_repositories` added で repositories テーブルに upsert される
+8. `installation_repositories` removed で該当リポジトリの installation_id が 0 にクリアされる
+9. 未対応イベントは 200 を返して無視する
+10. `GITHUB_WEBHOOK_SECRET` 未設定時は webhook エンドポイントが 500 を返す（署名検証不可のため）
+11. 署名検証のユニットテストがある
+12. webhook handler の統合テスト（DB あり）がある
+
+### 詳細要件
+
+#### 1. AppConfig 変更
+
+`AppConfig` に `github_webhook_secret: Option<String>` を追加。環境変数 `GITHUB_WEBHOOK_SECRET` から読み込む。
+
+#### 2. 署名検証関数
+
+```rust
+// crates/api/src/routes/webhook.rs 内
+fn verify_signature(secret: &[u8], body: &[u8], signature_header: &str) -> bool
+```
+
+- `sha256=` プレフィックスを除去
+- `hex::decode` で期待値をバイト列に変換
+- `Hmac<Sha256>` で HMAC を計算
+- `mac.verify_slice()` で定数時間比較
+
+#### 3. Webhook Payload serde 型
+
+```rust
+// crates/api/src/routes/webhook.rs 内（ファイルローカル）
+
+#[derive(Deserialize)]
+struct WebhookRepository {
+    id: i64,
+    name: String,
+    full_name: String,
+}
+
+#[derive(Deserialize)]
+struct WebhookInstallation {
+    id: i64,
+}
+
+#[derive(Deserialize)]
+struct InstallationEvent {
+    action: String,
+    installation: WebhookInstallation,
+    #[serde(default)]
+    repositories: Vec<WebhookRepository>,
+}
+
+#[derive(Deserialize)]
+struct InstallationRepositoriesEvent {
+    action: String,
+    installation: WebhookInstallation,
+    #[serde(default)]
+    repositories_added: Vec<WebhookRepository>,
+    #[serde(default)]
+    repositories_removed: Vec<WebhookRepository>,
+}
+```
+
+#### 4. Handler 関数
+
+```rust
+// crates/api/src/routes/webhook.rs
+
+pub async fn github_webhook(
+    State(pool): State<PgPool>,
+    Extension(webhook_secret): Extension<WebhookSecret>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Result<StatusCode, AppError>
+```
+
+処理フロー:
+1. `webhook_secret.0` が None なら 500 Internal Error
+2. `X-Hub-Signature-256` ヘッダを取得。なければ 401
+3. `verify_signature()` で検証。失敗なら 401
+4. `X-GitHub-Event` ヘッダでイベント種別を判定
+5. イベントに応じた処理:
+   - `ping` → 200 OK
+   - `installation` → `handle_installation_event()`
+   - `installation_repositories` → `handle_installation_repositories_event()`
+   - その他 → 200 OK（ログ出力のみ）
+
+#### 5. イベントハンドラ
+
+**handle_installation_event:**
+- `created`: `repositories` 配列の各リポジトリを `full_name` から owner/name を分割して upsert
+- `deleted`: 該当 `installation_id` のリポジトリの `installation_id` を 0 にクリア
+
+**handle_installation_repositories_event:**
+- `added`: `repositories_added` の各リポジトリを upsert
+- `removed`: `repositories_removed` の各リポジトリの `installation_id` を 0 にクリア
+
+#### 6. DB クエリ追加
+
+`crates/db/src/queries/repository.rs` に以下を追加:
+
+```rust
+pub async fn clear_installation(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    installation_id: i64,
+) -> Result<Vec<Repository>, sqlx::Error>
+// UPDATE repositories SET installation_id = 0, updated_at = NOW()
+// WHERE installation_id = $1 RETURNING *
+
+pub async fn clear_installation_for_repo(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    github_repository_id: i64,
+) -> Result<Option<Repository>, sqlx::Error>
+// UPDATE repositories SET installation_id = 0, updated_at = NOW()
+// WHERE github_repository_id = $1 RETURNING *
+```
+
+#### 7. Extension 型
+
+```rust
+// crates/api/src/lib.rs に追加
+#[derive(Clone)]
+pub struct WebhookSecret(pub Option<String>);
+```
+
+#### 8. ルーター登録
+
+`create_app_with_config` に:
+- 引数 `webhook_secret: Option<String>` を追加
+- `WebhookSecret` Extension を layer に追加
+- `.route("/api/v1/github/webhook", post(routes::webhook::github_webhook))` を追加
+  - OpenAPI ルーターではなく、通常の `.route()` で登録（utoipa 不要）
+
+### 影響範囲
+
+| ファイル | 変更内容 |
+|---|---|
+| `crates/api/src/config.rs` | `github_webhook_secret` フィールド追加 |
+| `crates/api/src/lib.rs` | `WebhookSecret` 型追加、`create_app_with_config` 引数追加、route 登録、Extension layer 追加 |
+| `crates/api/src/routes/mod.rs` | `pub mod webhook;` 追加 |
+| `crates/api/src/routes/webhook.rs` | **新規作成** — handler、署名検証、payload 型 |
+| `crates/api/src/main.rs` | `AppConfig` から `webhook_secret` を `create_app_with_config` に渡す |
+| `crates/db/src/queries/repository.rs` | `clear_installation`、`clear_installation_for_repo` 追加 |
+| `crates/api/tests/webhook_test.rs` | **新規作成** — 統合テスト |
+
+### 設計方針
+
+1. **署名検証は raw body に対して行う**: `Bytes` extractor で取得した生バイト列に対して HMAC 検証し、その後 `serde_json::from_slice` でパースする
+2. **OpenAPI 登録しない**: Webhook は GitHub からの着信であり、BoardFlow の公開 API ドキュメントに載せる必要がない。通常の `Router::route()` で登録する
+3. **同期処理**: DB upsert は軽量なので、queue 経由にせず handler 内で同期的に完了する
+4. **installation 解除は論理削除**: `installation_id = 0` でクリアし、repository レコード自体は残す（BoardProject や BoardRun の参照整合性を保つ）
+5. **create_app_with_config の引数追加**: 既存パターンに合わせて Option<String> で webhook_secret を渡す。テストではテスト用 secret を指定する
+
+### 実装順序（TDD前提）
+
+#### Step 1: 署名検証ユニットテスト & 実装
+1. `crates/api/src/routes/webhook.rs` を作成
+2. `verify_signature()` 関数を実装
+3. GitHub 公式テスト値でユニットテスト（`#[cfg(test)]` モジュール内）:
+   - secret: `"It's a Secret to Everybody"`, payload: `"Hello, World!"`
+   - 正しい署名 → true
+   - 不正な署名 → false
+   - プレフィックスなし → false
+   - 不正な hex → false
+
+#### Step 2: Payload serde 型
+1. `InstallationEvent`, `InstallationRepositoriesEvent` 等の型を定義
+2. 調査結果の JSON サンプルでデシリアライズのユニットテスト
+
+#### Step 3: DB クエリ追加
+1. `clear_installation` を `crates/db/src/queries/repository.rs` に追加
+2. `clear_installation_for_repo` を同ファイルに追加
+
+#### Step 4: AppConfig & Extension 変更
+1. `AppConfig.github_webhook_secret` 追加
+2. `WebhookSecret` 型を `lib.rs` に追加
+3. `create_app_with_config` の引数と layer 追加
+4. `main.rs` で config から渡す
+
+#### Step 5: Handler 実装
+1. `github_webhook` handler を実装
+2. `handle_installation_event`, `handle_installation_repositories_event` を実装
+3. route 登録
+
+#### Step 6: 統合テスト
+1. `crates/api/tests/webhook_test.rs` を作成
+2. テストケース:
+   - **test_webhook_ping**: ping イベントで 200 が返る
+   - **test_webhook_invalid_signature**: 不正な署名で 401 が返る
+   - **test_webhook_missing_signature**: 署名ヘッダなしで 401 が返る
+   - **test_webhook_installation_created**: installation created で repositories が upsert される
+   - **test_webhook_installation_deleted**: installation deleted で installation_id が 0 にクリアされる
+   - **test_webhook_repos_added**: installation_repositories added で upsert される
+   - **test_webhook_repos_removed**: installation_repositories removed で installation_id が 0 にクリアされる
+   - **test_webhook_unknown_event**: 未知イベントで 200 が返る
+
+統合テストの構成:
+- `#[serial]` 付き
+- `setup_pool()` で DB 接続・マイグレーション
+- `create_app_with_config` でテスト用 webhook_secret を設定
+- HMAC-SHA256 でテスト用署名を計算
+- `tower::ServiceExt::oneshot` でリクエスト送信
+- DB 状態を `sqlx::query_as` で検証
+
+### テスト観点
+
+| テスト | 種別 | ファイル |
+|---|---|---|
+| verify_signature 正常系 | ユニット | `webhook.rs` 内 `#[cfg(test)]` |
+| verify_signature 異常系（不正署名、prefix なし、不正 hex） | ユニット | 同上 |
+| payload デシリアライズ | ユニット | 同上 |
+| ping イベント | 統合 | `webhook_test.rs` |
+| 署名検証失敗 | 統合 | 同上 |
+| installation created → DB upsert | 統合 | 同上 |
+| installation deleted → installation_id クリア | 統合 | 同上 |
+| installation_repositories added → DB upsert | 統合 | 同上 |
+| installation_repositories removed → installation_id クリア | 統合 | 同上 |
+| 未知イベント → 200 | 統合 | 同上 |
+
+### ドキュメント更新対象
+
+- `docs/logs/28/worklog.md` — 本作業ログ（実装完了時にも追記）
+- `docs/backend/api.md` への追記は不要（webhook は外部からの着信であり、BoardFlow の公開 API 仕様ではない）
+
+### 未解決の疑問
+
+なし。仕様・外部調査とも十分な情報がある。
+
+### 更新した作業ログパス
+
+`docs/logs/28/worklog.md`


### PR DESCRIPTION
## 概要

Closes #28

GitHub App からの Webhook を受信するエンドポイント `POST /api/v1/github/webhook` を実装する。HMAC-SHA256 署名検証、installation/repository の DB 同期、ユニットテスト・統合テストを含む。

---

## 要件

- \`POST /api/v1/github/webhook\` で GitHub App Webhook を受信
- \`X-Hub-Signature-256\` ヘッダによる HMAC-SHA256 署名検証（失敗時 401）
- \`ping\` イベント → 200 OK
- \`installation\` created → repositories テーブルに upsert
- \`installation\` deleted → 該当 installation_id のリポジトリの \`installation_id\` を 0 にクリア
- \`installation_repositories\` added → upsert
- \`installation_repositories\` removed → 該当 repository の \`installation_id\` を 0 にクリア（**installation_id 条件付き**で誤解除防止）
- \`GITHUB_WEBHOOK_SECRET\` 未設定時 → 500
- 未対応イベント → 200（ログのみ）

---

## 調査結果

\`docs/external/github-webhook-signature.md\` に以下を記録済み:
- GitHub HMAC-SHA256 署名検証仕様（\`X-Hub-Signature-256\`、\`sha256=\` プレフィックス）
- Axum での raw body 検証パターン（\`Bytes\` extractor を最後に配置）
- \`hmac\` + \`sha2\` + \`hex\` crate は api crate に既存のため追加 crate 不要
- Webhook ベストプラクティス（10秒以内応答、冪等性、再配送考慮）

---

## 実装概要

### 新規ファイル
- \`crates/api/src/routes/webhook.rs\` — handler、署名検証 (\`verify_signature\`)、payload 型 (\`InstallationEvent\`, \`InstallationRepositoriesEvent\`)、ユニットテスト 15 件
- \`crates/api/tests/webhook_test.rs\` — 統合テスト 10 件
- \`docs/external/github-webhook-signature.md\` — 外部調査ドキュメント

### 変更ファイル
- \`crates/api/src/config.rs\` — \`github_webhook_secret: Option<String>\` フィールド追加
- \`crates/api/src/lib.rs\` — \`WebhookSecret\` 型追加、\`create_app_with_config\` 引数追加、webhook route / layer 登録
- \`crates/api/src/routes/mod.rs\` — \`pub mod webhook;\` 追加
- \`crates/api/src/main.rs\` — config から webhook_secret を渡す
- \`crates/db/src/queries/repository.rs\` — \`clear_installation()\`, \`clear_installation_for_repo(github_repository_id, installation_id)\` 追加

### 設計判断
- raw body に対して署名検証後に JSON パース（Bytes extractor を最後に配置）
- OpenAPI 登録なし（webhook は GitHub からの外部着信）
- installation 解除は論理削除（\`installation_id = 0\`、repository レコード自体は残す）
- \`clear_installation_for_repo\` は \`github_repository_id AND installation_id\` の両条件でクリアし、別 installation に再紐付け済みの repository を誤ってクリアしない

---

## テスト結果

### ユニットテスト（\`cargo test -p boardflow-api --lib\`）
- 15 passed（署名検証 + payload デシリアライズ）

### 統合テスト（\`cargo test -p boardflow-api --test webhook_test\`）
- 10 passed
  - \`test_webhook_ping\`
  - \`test_webhook_invalid_signature\`
  - \`test_webhook_missing_signature\`
  - \`test_webhook_installation_created\`
  - \`test_webhook_installation_deleted\`
  - \`test_webhook_repos_added\`
  - \`test_webhook_repos_removed\`
  - \`test_webhook_unknown_event\`
  - \`test_webhook_no_secret_configured\`（受け入れ条件 10 対応）
  - \`test_webhook_repos_removed_different_installation\`（installation 不一致の誤解除防止）

### 静的解析
- \`cargo clippy --workspace --all-targets -- -D warnings\`: OK
- \`cargo fmt --all -- --check\`: OK

---

## 更新ドキュメント

- \`docs/external/github-webhook-signature.md\` — 新規作成（外部調査記録）
- \`docs/logs/28/worklog.md\` — 経緯・調査・計画・実装・レビュー・再レビュー・docs 確認を時系列で記録

---

## 外部調査メモ

- [GitHub Docs: Securing your webhooks](https://docs.github.com/en/webhooks/using-webhooks/securing-your-webhooks)
- [GitHub Docs: installation event payload](https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation)
- [GitHub Docs: Best practices for using webhooks](https://docs.github.com/en/webhooks/using-webhooks/best-practices-for-using-webhooks)

---

## 残リスク

- Issue 本文のエンドポイント表記 (\`POST /api/v1/webhooks/github\`) と実装 (\`POST /api/v1/github/webhook\`) に表記揺れあり。外部利用者向け案内は将来一本化推奨。
- \`GITHUB_WEBHOOK_SECRET\` の設定手順が README / 恒久ドキュメントに未記載。本番導入時に別途追記推奨。
- installation deleted / removed 後に既存の GitHub job が残っていた場合の downstream 挙動は本 Issue のテスト範囲外。

---

## Review / Docs OK 判定

- **review**: \`pr_ready: true\`（再レビューフェーズ 2026-05-02 — major 3件修正確認済み）
- **docs**: \`docs_ready: true\`（ドキュメント確認フェーズ 2026-05-02 — 非ブロッカー指摘のみ）