### PR TITLE
feat: GitHub APIレスポンスのDBキャッシュとレートリミット対策 (#63)

### DIFF
--- a/crates/api/src/github_access.rs
+++ b/crates/api/src/github_access.rs
@@ -44,6 +44,12 @@ pub trait GithubAccessChecker: Send + Sync {
         &self,
         github_access_token: &str,
     ) -> Result<Option<Vec<i64>>, AccessError>;
+
+    /// Invalidate cached repository data for a given user.
+    /// Default implementation is a no-op (for non-caching implementations).
+    async fn invalidate_repo_cache(&self, _user_id: uuid::Uuid) -> Result<(), AccessError> {
+        Ok(())
+    }
 }
 
 // ─── Production implementation ───────────────────────────────────────────────
@@ -275,23 +281,46 @@ impl GithubAccessChecker for UpstreamErrorGithubAccessChecker {
     }
 }
 
+// ─── Mock: token expired ─────────────────────────────────────────────────────
+
+/// Mock implementation that always returns TokenExpired (for error handling tests).
+pub struct TokenExpiredGithubAccessChecker;
+
+#[async_trait::async_trait]
+impl GithubAccessChecker for TokenExpiredGithubAccessChecker {
+    async fn check_access(&self, _token: &str, _owner: &str, _name: &str) -> AccessResult {
+        AccessResult::Error(AccessError::TokenExpired)
+    }
+
+    async fn list_accessible_repo_ids(
+        &self,
+        _token: &str,
+    ) -> Result<Option<Vec<i64>>, AccessError> {
+        Err(AccessError::TokenExpired)
+    }
+}
+
 pub type DynGithubAccessChecker = Arc<dyn GithubAccessChecker>;
 
 // ─── Cached implementation ───────────────────────────────────────────────────
 
 /// Caching decorator that stores `list_accessible_repo_ids` results in PostgreSQL.
-/// Falls back to stale cache on rate-limit / upstream errors (stale-while-error).
+/// Falls back to stale cache on rate-limit errors (stale-while-error).
 pub struct CachedGithubAccessChecker {
-    inner: RealGithubAccessChecker,
+    inner: Arc<dyn GithubAccessChecker>,
     pool: sqlx::PgPool,
 }
 
 impl CachedGithubAccessChecker {
     pub fn new(pool: sqlx::PgPool) -> Self {
         Self {
-            inner: RealGithubAccessChecker::new(),
+            inner: Arc::new(RealGithubAccessChecker::new()),
             pool,
         }
+    }
+
+    pub fn with_inner(inner: Arc<dyn GithubAccessChecker>, pool: sqlx::PgPool) -> Self {
+        Self { inner, pool }
     }
 
     /// Invalidate all cached data for a given user.
@@ -377,8 +406,8 @@ impl GithubAccessChecker for CachedGithubAccessChecker {
                 }
                 Ok(result)
             }
-            Err(e) => {
-                // 5. On error (rate limit / upstream) – try stale cache
+            Err(ref e @ AccessError::RateLimited) => {
+                // 5. On RateLimited only – try stale cache
                 let stale_duration = chrono::Duration::seconds(STALE_MAX_SECONDS);
                 if let Ok(Some(stale)) = boardflow_db::queries::github_api_cache::get_stale_cache(
                     &self.pool,
@@ -392,13 +421,24 @@ impl GithubAccessChecker for CachedGithubAccessChecker {
                         tracing::warn!(
                             user_id = %user_id,
                             error = %format!("{e:?}"),
-                            "using stale cache for accessible_repo_ids"
+                            "using stale cache for accessible_repo_ids due to rate limiting"
                         );
                         return Ok(Some(ids));
                     }
                 }
+                Err(AccessError::RateLimited)
+            }
+            Err(e) => {
+                // 6. Non-rate-limit errors (TokenExpired, Upstream) – propagate directly
                 Err(e)
             }
         }
+    }
+
+    async fn invalidate_repo_cache(&self, user_id: uuid::Uuid) -> Result<(), AccessError> {
+        boardflow_db::queries::github_api_cache::delete_cache_by_user(&self.pool, user_id)
+            .await
+            .map_err(|e| AccessError::Upstream(format!("db error: {e}")))?;
+        Ok(())
     }
 }

--- a/crates/api/src/github_access.rs
+++ b/crates/api/src/github_access.rs
@@ -276,3 +276,129 @@ impl GithubAccessChecker for UpstreamErrorGithubAccessChecker {
 }
 
 pub type DynGithubAccessChecker = Arc<dyn GithubAccessChecker>;
+
+// ─── Cached implementation ───────────────────────────────────────────────────
+
+/// Caching decorator that stores `list_accessible_repo_ids` results in PostgreSQL.
+/// Falls back to stale cache on rate-limit / upstream errors (stale-while-error).
+pub struct CachedGithubAccessChecker {
+    inner: RealGithubAccessChecker,
+    pool: sqlx::PgPool,
+}
+
+impl CachedGithubAccessChecker {
+    pub fn new(pool: sqlx::PgPool) -> Self {
+        Self {
+            inner: RealGithubAccessChecker::new(),
+            pool,
+        }
+    }
+
+    /// Invalidate all cached data for a given user.
+    pub async fn invalidate_cache(&self, user_id: uuid::Uuid) -> Result<(), sqlx::Error> {
+        boardflow_db::queries::github_api_cache::delete_cache_by_user(&self.pool, user_id).await
+    }
+}
+
+const CACHE_TYPE_REPO_IDS: &str = "accessible_repo_ids";
+const CACHE_TTL_SECONDS: i64 = 600; // 10 minutes
+const STALE_MAX_SECONDS: i64 = 3600; // 1 hour
+
+#[async_trait::async_trait]
+impl GithubAccessChecker for CachedGithubAccessChecker {
+    async fn check_access(
+        &self,
+        github_access_token: &str,
+        owner: &str,
+        name: &str,
+    ) -> AccessResult {
+        self.inner
+            .check_access(github_access_token, owner, name)
+            .await
+    }
+
+    async fn list_accessible_repo_ids(
+        &self,
+        github_access_token: &str,
+    ) -> Result<Option<Vec<i64>>, AccessError> {
+        // 1. Resolve user_id from token
+        let user = boardflow_db::queries::user::find_by_github_access_token(
+            &self.pool,
+            github_access_token,
+        )
+        .await
+        .map_err(|e| AccessError::Upstream(format!("db error: {e}")))?;
+
+        let user = match user {
+            Some(u) => u,
+            None => {
+                // Unknown token – pass through to inner without caching
+                return self
+                    .inner
+                    .list_accessible_repo_ids(github_access_token)
+                    .await;
+            }
+        };
+
+        let user_id = user.id;
+
+        // 2. Try valid cache
+        if let Ok(Some(cached)) = boardflow_db::queries::github_api_cache::get_valid_cache(
+            &self.pool,
+            user_id,
+            CACHE_TYPE_REPO_IDS,
+        )
+        .await
+        {
+            if let Ok(ids) = serde_json::from_value::<Vec<i64>>(cached) {
+                return Ok(Some(ids));
+            }
+        }
+
+        // 3. Cache miss – call inner
+        match self
+            .inner
+            .list_accessible_repo_ids(github_access_token)
+            .await
+        {
+            Ok(result) => {
+                // 4. On success, upsert cache
+                if let Some(ref ids) = result {
+                    let value = serde_json::to_value(ids)
+                        .unwrap_or_else(|_| serde_json::Value::Array(vec![]));
+                    let _ = boardflow_db::queries::github_api_cache::upsert_cache(
+                        &self.pool,
+                        user_id,
+                        CACHE_TYPE_REPO_IDS,
+                        &value,
+                        CACHE_TTL_SECONDS,
+                    )
+                    .await;
+                }
+                Ok(result)
+            }
+            Err(e) => {
+                // 5. On error (rate limit / upstream) – try stale cache
+                let stale_duration = chrono::Duration::seconds(STALE_MAX_SECONDS);
+                if let Ok(Some(stale)) = boardflow_db::queries::github_api_cache::get_stale_cache(
+                    &self.pool,
+                    user_id,
+                    CACHE_TYPE_REPO_IDS,
+                    stale_duration,
+                )
+                .await
+                {
+                    if let Ok(ids) = serde_json::from_value::<Vec<i64>>(stale) {
+                        tracing::warn!(
+                            user_id = %user_id,
+                            error = %format!("{e:?}"),
+                            "using stale cache for accessible_repo_ids"
+                        );
+                        return Ok(Some(ids));
+                    }
+                }
+                Err(e)
+            }
+        }
+    }
+}

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -15,7 +15,7 @@ use utoipa::{Modify, OpenApi};
 use utoipa_axum::router::OpenApiRouter;
 use utoipa_axum::routes;
 
-use github_access::{DynGithubAccessChecker, RealGithubAccessChecker};
+use github_access::{CachedGithubAccessChecker, DynGithubAccessChecker};
 use routes::auth::OAuthConfig;
 
 use boardflow_config::{optional_env, optional_env_or};
@@ -76,7 +76,7 @@ pub fn create_app_with_config(
     });
 
     let checker: DynGithubAccessChecker =
-        access_checker.unwrap_or_else(|| Arc::new(RealGithubAccessChecker::new()));
+        access_checker.unwrap_or_else(|| Arc::new(CachedGithubAccessChecker::new(pool.clone())));
 
     let bucket = FinalBucket(
         final_bucket.unwrap_or_else(|| optional_env_or("MINIO_BUCKET_FINAL", "boardflow-final")),

--- a/crates/api/tests/github_cache_test.rs
+++ b/crates/api/tests/github_cache_test.rs
@@ -1,0 +1,407 @@
+use serial_test::serial;
+
+use boardflow_api::github_access::{CachedGithubAccessChecker, GithubAccessChecker};
+use sqlx::PgPool;
+use uuid::Uuid;
+
+async fn setup_pool() -> Option<PgPool> {
+    unsafe { std::env::set_var("BOARDFLOW_ARTIFACT_SECRET", "test-secret-for-tests") };
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("Skipping test: DATABASE_URL not set");
+            return None;
+        }
+    };
+    let pool = PgPool::connect(&database_url).await.unwrap();
+    sqlx::migrate!("../db/migrations").run(&pool).await.unwrap();
+    Some(pool)
+}
+
+fn rand_i64() -> i64 {
+    let uuid = Uuid::now_v7();
+    let bytes = uuid.as_bytes();
+    i64::from_be_bytes(bytes[0..8].try_into().unwrap()).abs()
+}
+
+async fn create_test_user_with_token(pool: &PgPool, token: &str) -> Uuid {
+    let id = Uuid::now_v7();
+    let github_user_id = rand_i64();
+    sqlx::query(
+        "INSERT INTO users (id, github_user_id, github_login, github_avatar_url, github_access_token, created_at, updated_at) \
+         VALUES ($1, $2, 'cacheuser', 'https://avatar.example.com/test', $3, NOW(), NOW())",
+    )
+    .bind(id)
+    .bind(github_user_id)
+    .bind(token)
+    .execute(pool)
+    .await
+    .unwrap();
+    id
+}
+
+// ─── DB query tests ──────────────────────────────────────────────────────────
+
+/// Test: upsert_cache inserts a new cache entry and get_valid_cache retrieves it
+#[tokio::test]
+#[serial]
+async fn test_upsert_and_get_valid_cache() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let user_id = create_test_user_with_token(&pool, "gho_cache_test_1").await;
+
+    let value = serde_json::json!([1, 2, 3]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "test_type",
+        &value,
+        600, // 10 min TTL
+    )
+    .await
+    .unwrap();
+
+    let cached =
+        boardflow_db::queries::github_api_cache::get_valid_cache(&pool, user_id, "test_type")
+            .await
+            .unwrap();
+    assert_eq!(cached, Some(value));
+}
+
+/// Test: get_valid_cache returns None for expired cache
+#[tokio::test]
+#[serial]
+async fn test_get_valid_cache_returns_none_when_expired() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let user_id = create_test_user_with_token(&pool, "gho_cache_test_2").await;
+
+    // Insert with negative TTL (already expired)
+    sqlx::query(
+        "INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at) \
+         VALUES ($1, 'expired_type', '[4,5,6]'::jsonb, NOW() - INTERVAL '1 minute', NOW(), NOW())",
+    )
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let cached =
+        boardflow_db::queries::github_api_cache::get_valid_cache(&pool, user_id, "expired_type")
+            .await
+            .unwrap();
+    assert_eq!(cached, None);
+}
+
+/// Test: get_stale_cache returns recently-expired cache within max_stale_duration
+#[tokio::test]
+#[serial]
+async fn test_get_stale_cache_returns_recently_expired() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let user_id = create_test_user_with_token(&pool, "gho_cache_test_3").await;
+
+    // Insert expired 5 minutes ago
+    sqlx::query(
+        "INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at) \
+         VALUES ($1, 'stale_type', '[7,8,9]'::jsonb, NOW() - INTERVAL '5 minutes', NOW(), NOW()) \
+         ON CONFLICT (user_id, cache_type) DO UPDATE SET value_json = EXCLUDED.value_json, expires_at = EXCLUDED.expires_at",
+    )
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Stale window of 1 hour should include this entry
+    let stale = boardflow_db::queries::github_api_cache::get_stale_cache(
+        &pool,
+        user_id,
+        "stale_type",
+        chrono::Duration::hours(1),
+    )
+    .await
+    .unwrap();
+    assert_eq!(stale, Some(serde_json::json!([7, 8, 9])));
+}
+
+/// Test: get_stale_cache returns None for cache expired beyond max_stale_duration
+#[tokio::test]
+#[serial]
+async fn test_get_stale_cache_returns_none_for_very_old_cache() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let user_id = create_test_user_with_token(&pool, "gho_cache_test_4").await;
+
+    // Insert expired 2 hours ago
+    sqlx::query(
+        "INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at) \
+         VALUES ($1, 'old_type', '[10]'::jsonb, NOW() - INTERVAL '2 hours', NOW(), NOW()) \
+         ON CONFLICT (user_id, cache_type) DO UPDATE SET value_json = EXCLUDED.value_json, expires_at = EXCLUDED.expires_at",
+    )
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Stale window of 1 hour should NOT include this
+    let stale = boardflow_db::queries::github_api_cache::get_stale_cache(
+        &pool,
+        user_id,
+        "old_type",
+        chrono::Duration::hours(1),
+    )
+    .await
+    .unwrap();
+    assert_eq!(stale, None);
+}
+
+/// Test: upsert_cache updates existing entry (ON CONFLICT DO UPDATE)
+#[tokio::test]
+#[serial]
+async fn test_upsert_cache_updates_existing() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let user_id = create_test_user_with_token(&pool, "gho_cache_test_5").await;
+
+    let value1 = serde_json::json!([100, 200]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "upsert_type",
+        &value1,
+        600,
+    )
+    .await
+    .unwrap();
+
+    let value2 = serde_json::json!([300, 400, 500]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "upsert_type",
+        &value2,
+        600,
+    )
+    .await
+    .unwrap();
+
+    let cached =
+        boardflow_db::queries::github_api_cache::get_valid_cache(&pool, user_id, "upsert_type")
+            .await
+            .unwrap();
+    assert_eq!(cached, Some(value2));
+}
+
+/// Test: delete_cache removes specific cache entry
+#[tokio::test]
+#[serial]
+async fn test_delete_cache_removes_specific_entry() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let user_id = create_test_user_with_token(&pool, "gho_cache_test_6").await;
+
+    let value = serde_json::json!([1]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "delete_type",
+        &value,
+        600,
+    )
+    .await
+    .unwrap();
+
+    boardflow_db::queries::github_api_cache::delete_cache(&pool, user_id, "delete_type")
+        .await
+        .unwrap();
+
+    let cached =
+        boardflow_db::queries::github_api_cache::get_valid_cache(&pool, user_id, "delete_type")
+            .await
+            .unwrap();
+    assert_eq!(cached, None);
+}
+
+/// Test: delete_cache_by_user removes all cache entries for a user
+#[tokio::test]
+#[serial]
+async fn test_delete_cache_by_user_removes_all() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let user_id = create_test_user_with_token(&pool, "gho_cache_test_7").await;
+
+    let value = serde_json::json!([1]);
+    boardflow_db::queries::github_api_cache::upsert_cache(&pool, user_id, "type_a", &value, 600)
+        .await
+        .unwrap();
+    boardflow_db::queries::github_api_cache::upsert_cache(&pool, user_id, "type_b", &value, 600)
+        .await
+        .unwrap();
+
+    boardflow_db::queries::github_api_cache::delete_cache_by_user(&pool, user_id)
+        .await
+        .unwrap();
+
+    let a = boardflow_db::queries::github_api_cache::get_valid_cache(&pool, user_id, "type_a")
+        .await
+        .unwrap();
+    let b = boardflow_db::queries::github_api_cache::get_valid_cache(&pool, user_id, "type_b")
+        .await
+        .unwrap();
+    assert_eq!(a, None);
+    assert_eq!(b, None);
+}
+
+/// Test: cleanup_expired_cache removes old expired entries
+#[tokio::test]
+#[serial]
+async fn test_cleanup_expired_cache() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let user_id = create_test_user_with_token(&pool, "gho_cache_test_8").await;
+
+    // Insert expired >1 hour ago (should be cleaned)
+    sqlx::query(
+        "INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at) \
+         VALUES ($1, 'cleanup_type', '[1]'::jsonb, NOW() - INTERVAL '2 hours', NOW(), NOW()) \
+         ON CONFLICT (user_id, cache_type) DO UPDATE SET value_json = EXCLUDED.value_json, expires_at = EXCLUDED.expires_at",
+    )
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let deleted = boardflow_db::queries::github_api_cache::cleanup_expired_cache(&pool)
+        .await
+        .unwrap();
+    assert!(deleted >= 1);
+}
+
+// ─── CachedGithubAccessChecker integration tests ─────────────────────────────
+
+/// Test: CachedGithubAccessChecker.invalidate_cache removes all user's cache
+#[tokio::test]
+#[serial]
+async fn test_cached_checker_invalidate_cache() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_cached_checker_test_1";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Seed cache directly
+    let value = serde_json::json!([111, 222]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+        &value,
+        600,
+    )
+    .await
+    .unwrap();
+
+    let checker = CachedGithubAccessChecker::new(pool.clone());
+    checker.invalidate_cache(user_id).await.unwrap();
+
+    let cached = boardflow_db::queries::github_api_cache::get_valid_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+    )
+    .await
+    .unwrap();
+    assert_eq!(cached, None);
+}
+
+/// Test: CachedGithubAccessChecker returns cached data on second call (cache hit)
+#[tokio::test]
+#[serial]
+async fn test_cached_checker_returns_cached_repo_ids() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_cached_checker_test_2";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Pre-seed cache with known IDs
+    let value = serde_json::json!([1001, 1002, 1003]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+        &value,
+        600,
+    )
+    .await
+    .unwrap();
+
+    let checker = CachedGithubAccessChecker::new(pool.clone());
+    let result = checker.list_accessible_repo_ids(token).await.unwrap();
+    assert_eq!(result, Some(vec![1001, 1002, 1003]));
+}
+
+/// Test: CachedGithubAccessChecker for unknown token passes through without caching
+/// (token not in users table → delegates to inner directly)
+#[tokio::test]
+#[serial]
+async fn test_cached_checker_unknown_token_passes_through() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    // This token doesn't exist in users table
+    // The inner (RealGithubAccessChecker) will get a 401 from GitHub
+    let checker = CachedGithubAccessChecker::new(pool.clone());
+    let result = checker
+        .list_accessible_repo_ids("gho_definitely_not_in_db")
+        .await;
+    // Should error (TokenExpired or Upstream) since it's not a real token
+    assert!(result.is_err());
+}
+
+/// Test: CachedGithubAccessChecker uses stale cache on rate-limit error
+/// We simulate this by seeding an expired cache entry and using a token
+/// that will trigger a rate-limit from the inner checker
+#[tokio::test]
+#[serial]
+async fn test_cached_checker_stale_fallback_on_rate_limit() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_cached_checker_test_stale";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Seed an expired (but recent) cache entry - expired 5 minutes ago
+    sqlx::query(
+        "INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at) \
+         VALUES ($1, 'accessible_repo_ids', '[9001, 9002]'::jsonb, NOW() - INTERVAL '5 minutes', NOW(), NOW()) \
+         ON CONFLICT (user_id, cache_type) DO UPDATE SET value_json = EXCLUDED.value_json, expires_at = EXCLUDED.expires_at",
+    )
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // The CachedGithubAccessChecker uses RealGithubAccessChecker internally.
+    // With an invalid token, GitHub will return 401 (TokenExpired), not 429.
+    // For a true stale-while-error test we'd need to mock the inner checker.
+    // Here we verify the cache miss path correctly attempts the stale lookup by
+    // checking the DB state is correct - see the unit test below for full mock.
+    let cached = boardflow_db::queries::github_api_cache::get_stale_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+        chrono::Duration::hours(1),
+    )
+    .await
+    .unwrap();
+    assert_eq!(cached, Some(serde_json::json!([9001, 9002])));
+}

--- a/crates/api/tests/github_cache_test.rs
+++ b/crates/api/tests/github_cache_test.rs
@@ -1,7 +1,11 @@
 use serial_test::serial;
 
-use boardflow_api::github_access::{CachedGithubAccessChecker, GithubAccessChecker};
+use boardflow_api::github_access::{
+    AccessError, AllowAllGithubAccessChecker, CachedGithubAccessChecker, GithubAccessChecker,
+    RateLimitedGithubAccessChecker,
+};
 use sqlx::PgPool;
+use std::sync::Arc;
 use uuid::Uuid;
 
 async fn setup_pool() -> Option<PgPool> {
@@ -25,6 +29,13 @@ fn rand_i64() -> i64 {
 }
 
 async fn create_test_user_with_token(pool: &PgPool, token: &str) -> Uuid {
+    // Clean up any leftover users with this token from previous test runs
+    sqlx::query("DELETE FROM users WHERE github_access_token = $1")
+        .bind(token)
+        .execute(pool)
+        .await
+        .unwrap();
+
     let id = Uuid::now_v7();
     let github_user_id = rand_i64();
     sqlx::query(
@@ -344,7 +355,9 @@ async fn test_cached_checker_returns_cached_repo_ids() {
     .await
     .unwrap();
 
-    let checker = CachedGithubAccessChecker::new(pool.clone());
+    // Use AllowAll as inner – if cache hits, inner is never called
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(AllowAllGithubAccessChecker);
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
     let result = checker.list_accessible_repo_ids(token).await.unwrap();
     assert_eq!(result, Some(vec![1001, 1002, 1003]));
 }
@@ -404,4 +417,160 @@ async fn test_cached_checker_stale_fallback_on_rate_limit() {
     .await
     .unwrap();
     assert_eq!(cached, Some(serde_json::json!([9001, 9002])));
+}
+
+// ─── Mock-inner tests (stale fallback & error propagation) ───────────────────
+
+/// Test: RateLimited from inner triggers stale cache fallback
+#[tokio::test]
+#[serial]
+async fn test_cached_checker_stale_fallback_with_mock_inner_rate_limited() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_mock_rate_limit_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Seed an expired (but recent) cache entry - expired 5 minutes ago
+    sqlx::query(
+        "INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at) \
+         VALUES ($1, 'accessible_repo_ids', '[5001, 5002, 5003]'::jsonb, NOW() - INTERVAL '5 minutes', NOW(), NOW()) \
+         ON CONFLICT (user_id, cache_type) DO UPDATE SET value_json = EXCLUDED.value_json, expires_at = EXCLUDED.expires_at",
+    )
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Use RateLimitedGithubAccessChecker as inner → always returns RateLimited
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(RateLimitedGithubAccessChecker);
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+
+    let result = checker.list_accessible_repo_ids(token).await;
+    // Should return stale cache instead of error
+    assert_eq!(result, Ok(Some(vec![5001, 5002, 5003])));
+}
+
+/// Test: TokenExpired from inner does NOT use stale cache – propagates error
+#[tokio::test]
+#[serial]
+async fn test_cached_checker_token_expired_no_stale_fallback() {
+    use boardflow_api::github_access::TokenExpiredGithubAccessChecker;
+
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_mock_token_expired_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Seed an expired (but recent) cache entry
+    sqlx::query(
+        "INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at) \
+         VALUES ($1, 'accessible_repo_ids', '[6001, 6002]'::jsonb, NOW() - INTERVAL '5 minutes', NOW(), NOW()) \
+         ON CONFLICT (user_id, cache_type) DO UPDATE SET value_json = EXCLUDED.value_json, expires_at = EXCLUDED.expires_at",
+    )
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Use TokenExpiredGithubAccessChecker as inner → always returns TokenExpired
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(TokenExpiredGithubAccessChecker);
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+
+    let result = checker.list_accessible_repo_ids(token).await;
+    // Should propagate TokenExpired error, NOT return stale cache
+    assert_eq!(result, Err(AccessError::TokenExpired));
+}
+
+/// Test: Upstream error from inner does NOT use stale cache – propagates error
+#[tokio::test]
+#[serial]
+async fn test_cached_checker_upstream_error_no_stale_fallback() {
+    use boardflow_api::github_access::UpstreamErrorGithubAccessChecker;
+
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_mock_upstream_error_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Seed an expired (but recent) cache entry
+    sqlx::query(
+        "INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at) \
+         VALUES ($1, 'accessible_repo_ids', '[7001, 7002]'::jsonb, NOW() - INTERVAL '5 minutes', NOW(), NOW()) \
+         ON CONFLICT (user_id, cache_type) DO UPDATE SET value_json = EXCLUDED.value_json, expires_at = EXCLUDED.expires_at",
+    )
+    .bind(user_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Use UpstreamErrorGithubAccessChecker as inner
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(UpstreamErrorGithubAccessChecker);
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+
+    let result = checker.list_accessible_repo_ids(token).await;
+    // Should propagate Upstream error, NOT return stale cache
+    assert!(matches!(result, Err(AccessError::Upstream(_))));
+}
+
+/// Test: invalidate_repo_cache is callable via trait object (DynGithubAccessChecker)
+#[tokio::test]
+#[serial]
+async fn test_invalidate_repo_cache_via_trait() {
+    use boardflow_api::github_access::DynGithubAccessChecker;
+
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_invalidate_trait_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Seed a valid cache entry
+    let value = serde_json::json!([8001, 8002]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+        &value,
+        600,
+    )
+    .await
+    .unwrap();
+
+    // Create checker as DynGithubAccessChecker (trait object)
+    let checker: DynGithubAccessChecker = Arc::new(CachedGithubAccessChecker::new(pool.clone()));
+
+    // Call invalidate_repo_cache via trait
+    checker.invalidate_repo_cache(user_id).await.unwrap();
+
+    // Verify cache was removed
+    let cached = boardflow_db::queries::github_api_cache::get_valid_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+    )
+    .await
+    .unwrap();
+    assert_eq!(cached, None);
+}
+
+/// Test: RateLimited with no stale cache returns RateLimited error
+#[tokio::test]
+#[serial]
+async fn test_cached_checker_rate_limited_no_stale_returns_error() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_rate_limit_no_stale_test";
+    let _user_id = create_test_user_with_token(&pool, token).await;
+
+    // No cache entry seeded → stale fallback has nothing to return
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(RateLimitedGithubAccessChecker);
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+
+    let result = checker.list_accessible_repo_ids(token).await;
+    // Should return RateLimited since no stale cache exists
+    assert_eq!(result, Err(AccessError::RateLimited));
 }

--- a/crates/db/migrations/20260503000000_add_github_api_cache.down.sql
+++ b/crates/db/migrations/20260503000000_add_github_api_cache.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS github_api_cache;

--- a/crates/db/migrations/20260503000000_add_github_api_cache.down.sql
+++ b/crates/db/migrations/20260503000000_add_github_api_cache.down.sql
@@ -1,1 +1,2 @@
+DROP INDEX IF EXISTS idx_users_github_access_token;
 DROP TABLE IF EXISTS github_api_cache;

--- a/crates/db/migrations/20260503000000_add_github_api_cache.up.sql
+++ b/crates/db/migrations/20260503000000_add_github_api_cache.up.sql
@@ -9,3 +9,5 @@ CREATE TABLE github_api_cache (
 );
 
 CREATE INDEX idx_github_api_cache_expires_at ON github_api_cache (expires_at);
+
+CREATE INDEX idx_users_github_access_token ON users (github_access_token) WHERE github_access_token IS NOT NULL;

--- a/crates/db/migrations/20260503000000_add_github_api_cache.up.sql
+++ b/crates/db/migrations/20260503000000_add_github_api_cache.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE github_api_cache (
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    cache_type TEXT NOT NULL,
+    value_json JSONB NOT NULL,
+    expires_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (user_id, cache_type)
+);
+
+CREATE INDEX idx_github_api_cache_expires_at ON github_api_cache (expires_at);

--- a/crates/db/src/queries/github_api_cache.rs
+++ b/crates/db/src/queries/github_api_cache.rs
@@ -1,0 +1,94 @@
+use chrono::{Duration, Utc};
+use serde_json::Value;
+use uuid::Uuid;
+
+pub async fn get_valid_cache(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+) -> Result<Option<Value>, sqlx::Error> {
+    let row = sqlx::query_scalar::<_, Value>(
+        "SELECT value_json FROM github_api_cache WHERE user_id = $1 AND cache_type = $2 AND expires_at > NOW()",
+    )
+    .bind(user_id)
+    .bind(cache_type)
+    .fetch_optional(executor)
+    .await?;
+    Ok(row)
+}
+
+pub async fn get_stale_cache(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+    max_stale_duration: Duration,
+) -> Result<Option<Value>, sqlx::Error> {
+    let cutoff = Utc::now() - max_stale_duration;
+    let row = sqlx::query_scalar::<_, Value>(
+        "SELECT value_json FROM github_api_cache WHERE user_id = $1 AND cache_type = $2 AND expires_at > $3",
+    )
+    .bind(user_id)
+    .bind(cache_type)
+    .bind(cutoff)
+    .fetch_optional(executor)
+    .await?;
+    Ok(row)
+}
+
+pub async fn upsert_cache(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+    value_json: &Value,
+    ttl_seconds: i64,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at)
+           VALUES ($1, $2, $3, NOW() + make_interval(secs => $4), NOW(), NOW())
+           ON CONFLICT (user_id, cache_type) DO UPDATE SET
+             value_json = EXCLUDED.value_json,
+             expires_at = EXCLUDED.expires_at,
+             updated_at = NOW()"#,
+    )
+    .bind(user_id)
+    .bind(cache_type)
+    .bind(value_json)
+    .bind(ttl_seconds as f64)
+    .execute(executor)
+    .await?;
+    Ok(())
+}
+
+pub async fn delete_cache_by_user(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM github_api_cache WHERE user_id = $1")
+        .bind(user_id)
+        .execute(executor)
+        .await?;
+    Ok(())
+}
+
+pub async fn delete_cache(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query("DELETE FROM github_api_cache WHERE user_id = $1 AND cache_type = $2")
+        .bind(user_id)
+        .bind(cache_type)
+        .execute(executor)
+        .await?;
+    Ok(())
+}
+
+pub async fn cleanup_expired_cache(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+) -> Result<u64, sqlx::Error> {
+    let result =
+        sqlx::query("DELETE FROM github_api_cache WHERE expires_at < NOW() - INTERVAL '1 hour'")
+            .execute(executor)
+            .await?;
+    Ok(result.rows_affected())
+}

--- a/crates/db/src/queries/mod.rs
+++ b/crates/db/src/queries/mod.rs
@@ -4,6 +4,7 @@ pub mod artifact_bundle;
 pub mod board_project;
 pub mod board_run;
 pub mod diff;
+pub mod github_api_cache;
 pub mod github_job;
 pub mod repository;
 pub mod run_check;

--- a/crates/db/src/queries/user.rs
+++ b/crates/db/src/queries/user.rs
@@ -21,6 +21,16 @@ pub async fn find_by_github_user_id(
         .await
 }
 
+pub async fn find_by_github_access_token(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    github_access_token: &str,
+) -> Result<Option<User>, sqlx::Error> {
+    sqlx::query_as::<_, User>("SELECT * FROM users WHERE github_access_token = $1")
+        .bind(github_access_token)
+        .fetch_optional(executor)
+        .await
+}
+
 pub async fn upsert(
     executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
     github_user_id: i64,

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -539,6 +539,11 @@ Response (200):
 Web UI read API は GitHub OAuth session を前提にし、backend が repository 権限を確認する。
 存在しない resource と閲覧不可 resource は、情報漏洩を避けるためどちらも `404 not_found` を返してよい。
 
+repository 権限の判定に使う `list_accessible_repo_ids` は、backend 内で PostgreSQL テーブル `github_api_cache` を使ってキャッシュしてよい。
+現在の実装は user ごとに `accessible_repo_ids` を 10 分 TTL で保持し、GitHub API が `RateLimited` を返した場合のみ、期限切れ後 1 時間以内の stale cache を read API の継続提供に使う。
+`TokenExpired` とその他の upstream error では stale cache を使わず、そのまま認証エラーまたは server error を返す。
+明示的 invalidation 用のフックはあるが、この時点では read API のキャッシュ失効は TTL ベースを基本とし、Webhook 連動の invalidation は未接続である。
+
 ### 3.1 Repository 一覧
 
 ```http

--- a/docs/backend/summary.md
+++ b/docs/backend/summary.md
@@ -84,6 +84,10 @@ crates/jobs
 - GitHub job の冪等性を DB 制約で守りやすい
 - manifest や file hashes を JSONB で柔軟に扱える
 
+read API の GitHub repository 可視性判定には補助テーブル `github_api_cache` を使う。
+ここには user ごとの `accessible_repo_ids` を JSONB で保持し、TTL 10 分の DB キャッシュとして扱う。
+GitHub API が rate limit に到達した場合のみ、期限切れ後 1 時間以内の stale cache を read API のフォールバックに使う。
+
 MVP で特に重要な識別:
 
 - BoardProject の同一性は `github_repository_id + project_path`
@@ -213,6 +217,9 @@ MVP では GitHub 中心の構成にする。
 - GitHub App webhook は MVP から含める
 - installation 情報同期と権限確認を backend の責務にする
 - Web UI の閲覧可否は GitHub 権限と揃える
+
+Web UI の repository 可視性判定は `CachedGithubAccessChecker` で行い、内部で GitHub API 呼び出しを DB キャッシュする。
+明示的 invalidation 用の `invalidate_repo_cache` フックは追加済みだが、現時点の本番運用では TTL による自然失効が主であり、`installation_repositories` webhook からの invalidation 呼び出しは今後の作業範囲とする。
 
 GitHub App installation が解除済み、権限不足、または repository 不一致の場合、plan API は build/skip decision ではなく認可エラーを返す。
 Plan API の per-project `decision: error` は、SaaS側で受け取った project payload の不正などproject単位のvalidation失敗に限定する。

--- a/docs/external/github-api-rate-limit-cache.md
+++ b/docs/external/github-api-rate-limit-cache.md
@@ -1,0 +1,224 @@
+# GitHub APIレートリミットとDBキャッシュ設計
+
+## 要約
+
+BoardFlow Issue #63 に関連し、GitHub REST API のレートリミット仕様、429/403 レスポンスのハンドリングベストプラクティス、PostgreSQL でのキャッシュテーブル設計、sqlx での JSONB upsert パターンをまとめる。
+
+## 確認した情報
+
+### 1. GitHub API Rate Limiting 仕様
+
+#### Primary Rate Limit
+
+| 認証方式 | 制限 |
+|---|---|
+| 未認証 | 60 req/h（IPベース） |
+| ユーザーアクセストークン（OAuth App / GitHub App） | **5,000 req/h**（ユーザー単位で共有） |
+| GitHub Enterprise Cloud ユーザートークン | 15,000 req/h |
+| GitHub App インストールトークン | 最低 5,000 req/h（リポジトリ数・ユーザー数に応じてスケール、上限 12,500 req/h） |
+
+- **ユーザーアクセストークンのレートリミットは、同じユーザーに紐づく全てのアプリ・PATで共有される**
+- BoardFlow は OAuth App 経由の user access token を使用 → **5,000 req/h per user** が上限
+- `list_accessible_repo_ids` は `/user/repos?per_page=100` を全ページ取得するため、リポジトリが 500 件あると 5 API コール消費
+
+#### Secondary Rate Limit
+
+- GET リクエスト: 1ポイント/req
+- 同時並行リクエスト数の制限（具体的な数値は非公開）
+- **予告なく変更される可能性あり**
+- 違反すると一時的にブロック（最小1分待機）
+
+#### レスポンスヘッダ
+
+| ヘッダ | 説明 |
+|---|---|
+| `x-ratelimit-limit` | 1時間あたりの最大リクエスト数 |
+| `x-ratelimit-remaining` | 現在のウィンドウ内の残りリクエスト数 |
+| `x-ratelimit-used` | 使用済みリクエスト数 |
+| `x-ratelimit-reset` | ウィンドウリセット時刻（UTC epoch秒） |
+| `retry-after` | リトライまでの秒数（secondary rate limit時のみ、常に返されるとは限らない） |
+
+### 2. 429/403 レスポンスハンドリング
+
+GitHub は primary rate limit 超過時に **403 または 429** を返す。判定方法:
+
+1. **`retry-after` ヘッダがあれば**: 指定秒数だけ待ってリトライ
+2. **`x-ratelimit-remaining` が 0 であれば**: `x-ratelimit-reset` の時刻まで待つ
+3. **上記いずれもない場合（secondary rate limit）**: **最低1分待機**、失敗が続く場合は指数バックオフ
+
+**重要**: GitHub は secondary rate limit で必ずしも `retry-after` ヘッダを返さない（GitHub公式ドキュメントおよび GitHub Issue #1805 で確認）。
+
+#### BoardFlow の現状
+
+`RealGithubAccessChecker` は既に `403` + `x-ratelimit-remaining=0` と `retry-after` ヘッダの組み合わせで `RateLimited` を判定している。**429 ステータスコードも判定済み**。ただし:
+- リトライロジックは未実装（即座に `AccessError::RateLimited` を返す）
+- `x-ratelimit-remaining` / `x-ratelimit-reset` の値を保存していない
+
+### 3. PostgreSQL キャッシュテーブル設計
+
+#### UNLOGGED テーブル vs 通常テーブル
+
+| 特性 | UNLOGGED | 通常 |
+|---|---|---|
+| WALなし → 高速書き込み | ✅ | ❌ |
+| クラッシュ復旧後にデータ消失 | ✅（テーブルは空になる） | ❌ |
+| レプリケーション不可 | ✅ | ❌ |
+| キャッシュ用途 | 適している | 安全だが遅め |
+
+**BoardFlow への推奨**: キャッシュデータはクラッシュ後に再取得すれば良いため **UNLOGGED テーブルが適切**。ただし、将来の Read Replica 構成を考慮するなら通常テーブルも選択肢。現状のシングルインスタンス構成では UNLOGGED で十分。
+
+#### テーブル設計案
+
+```sql
+CREATE TABLE github_api_cache (
+    cache_key   TEXT PRIMARY KEY,      -- 例: "user_repos:{github_user_id}"
+    value_json  JSONB NOT NULL,        -- キャッシュデータ本体
+    expires_at  TIMESTAMPTZ NOT NULL,  -- TTL expiry
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_github_api_cache_expires_at ON github_api_cache (expires_at);
+```
+
+代替案: ユーザー単位でキャッシュキーを設計する場合
+
+```sql
+CREATE TABLE github_api_cache (
+    user_id     UUID NOT NULL REFERENCES users(id),
+    cache_type  TEXT NOT NULL,           -- 例: "accessible_repo_ids"
+    value_json  JSONB NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, cache_type)
+);
+
+CREATE INDEX idx_github_api_cache_expires_at ON github_api_cache (expires_at);
+```
+
+#### TTL と invalidation 戦略
+
+- **TTL**: 5〜15分が妥当（権限変更の即時反映は不要だが、極端に古いデータは避けたい）
+- **明示的 invalidation**: Webhook（`installation_repositories` イベント）受信時にキャッシュ削除
+- **期限切れ行の掃除**: `DELETE FROM github_api_cache WHERE expires_at < NOW()` を定期実行（ジョブキューまたは起動時）
+
+### 4. sqlx での JSONB + Upsert パターン
+
+BoardFlow は既に以下のパターンを使用中:
+- `serde_json::Value` を JSONB カラムに bind する
+- `ON CONFLICT ... DO UPDATE ... RETURNING` パターン（user.rs, repository.rs, github_job.rs）
+
+キャッシュ upsert の例:
+
+```rust
+pub async fn upsert_cache(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+    value: &serde_json::Value,
+    expires_at: chrono::DateTime<chrono::Utc>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        r#"INSERT INTO github_api_cache (user_id, cache_type, value_json, expires_at, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, NOW(), NOW())
+           ON CONFLICT (user_id, cache_type) DO UPDATE SET
+             value_json = EXCLUDED.value_json,
+             expires_at = EXCLUDED.expires_at,
+             updated_at = NOW()"#,
+    )
+    .bind(user_id)
+    .bind(cache_type)
+    .bind(value)
+    .bind(expires_at)
+    .execute(executor)
+    .await?;
+    Ok(())
+}
+
+pub async fn get_cache(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+) -> Result<Option<serde_json::Value>, sqlx::Error> {
+    let row = sqlx::query_scalar::<_, serde_json::Value>(
+        "SELECT value_json FROM github_api_cache WHERE user_id = $1 AND cache_type = $2 AND expires_at > NOW()"
+    )
+    .bind(user_id)
+    .bind(cache_type)
+    .fetch_optional(executor)
+    .await?;
+    Ok(row)
+}
+```
+
+sqlx 0.8 は `serde_json::Value` を PostgreSQL JSONB に直接 bind できる（postgres feature に含まれる）。追加の feature flag は不要。
+
+## BoardFlow への示唆
+
+### 推奨アーキテクチャ: CachedGithubAccessChecker (Decorator パターン)
+
+```
+GithubAccessChecker trait
+  ├── RealGithubAccessChecker          (直接 GitHub API 呼び出し)
+  ├── CachedGithubAccessChecker        (DB キャッシュ + fallback to inner)
+  │     └── inner: RealGithubAccessChecker
+  ├── AllowAllGithubAccessChecker      (テスト用)
+  └── ...
+```
+
+- `CachedGithubAccessChecker` は `GithubAccessChecker` を実装し、内部に `RealGithubAccessChecker` + `PgPool` を持つ
+- `list_accessible_repo_ids` でまず DB キャッシュを確認、有効なら返す
+- キャッシュミスまたは期限切れ → GitHub API 呼び出し → 結果を DB に upsert
+- **429/RateLimited 時のフォールバック**: API がレートリミットエラーを返した場合、期限切れキャッシュがあればそれを返す（stale-while-error パターン）
+- `check_access` は個別リポジトリの権限チェックなのでキャッシュ不要（リスト取得に比べて低頻度）
+
+### TTL 推奨値
+
+| キャッシュ対象 | TTL |
+|---|---|
+| `list_accessible_repo_ids` | 5〜10分 |
+| stale-while-error フォールバック | 期限切れ後も最大1時間保持 |
+
+### Invalidation
+
+- 明示的: `installation_repositories` Webhook で対象ユーザーのキャッシュを DELETE
+- 暗黙的: TTL 超過で自動失効
+- 手動: 管理 API やキャッシュクリアエンドポイント（将来的に）
+
+## 採用/不採用判断
+
+| 項目 | 判断 |
+|---|---|
+| DB キャッシュ（PostgreSQL） | **採用** — 既存インフラで追加サービス不要 |
+| UNLOGGED テーブル | **不採用** — キャッシュの persistence は不要だが、将来のレプリカ構成対応と sqlx マイグレーション管理の簡便さを考慮し通常テーブルで問題ない |
+| Redis/Memcached | **不採用** — オーバーキル、運用負荷増 |
+| Decorator パターン (CachedGithubAccessChecker) | **採用** — トレイト設計が既にこれを想定 |
+| stale-while-error | **採用** — レートリミット時の耐障害性向上 |
+| インメモリキャッシュ併用 | **不採用（現時点）** — マルチインスタンス不整合リスク、DB キャッシュで十分な性能 |
+
+## 制約と pitfall
+
+1. **ユーザートークンのレートリミットは共有**: BoardFlow 以外のアプリ・PAT も同じ 5,000 req/h バジェットを消費する → キャッシュは必須
+2. **UNLOGGED テーブルはレプリケーション不可**: 将来 Read Replica を導入する場合、通常テーブルに変更する必要あり
+3. **secondary rate limit は `retry-after` を返さない場合がある**: 固定の 1分待機 + 指数バックオフの実装が必要
+4. **キャッシュの陳腐化**: ユーザーが GitHub 側でリポジトリ権限を変更しても、TTL が切れるまで古い情報が返る
+5. **`list_accessible_repo_ids` の全ページ取得**: リポジトリ数が多いユーザーでは複数ページの API コールが発生 → キャッシュの恩恵が大きい
+6. **github_user_id vs user_id**: キャッシュキーは BoardFlow の `user_id` (UUID) を使うべき（users テーブルとの FK 整合性）
+
+## 未解決の疑問
+
+1. `check_access` （個別リポジトリの権限チェック）もキャッシュすべきか？ → 現時点では不要（低頻度）だが、将来的に検討
+2. `installation_repositories` Webhook の受信とキャッシュ invalidation の実装タイミング → 別 Issue で対応可能
+3. キャッシュの TTL 値は設定ファイルで外部化すべきか → 初回実装はハードコードで十分、後で Config crate に移動
+
+## 参照URL
+
+- [GitHub REST API Rate Limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
+- [Rate limits for OAuth Apps](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/rate-limits-for-oauth-apps)
+- [Troubleshooting REST API - Rate limit errors](https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api#rate-limit-errors)
+- [GitHub Issue: Retry-After header not always sent (#1805)](https://github.com/hub4j/github-api/issues/1805)
+- [PostgreSQL as a Cache (Martin Heinz)](https://martinheinz.dev/blog/105)
+- [Storing sessions/cache in PostgreSQL](https://tech-couch.com/post/storing-sessions-or-cache-data-in-postgresql)
+- [sqlx::types::Json docs](https://docs.rs/sqlx/latest/sqlx/types/struct.Json.html)
+- [SQLx PostgreSQL Upsert パターン（BoardFlow既存調査メモ）](../external/sqlx-postgresql-upsert.md)

--- a/docs/logs/63/worklog.md
+++ b/docs/logs/63/worklog.md
@@ -551,3 +551,160 @@ let checker: DynGithubAccessChecker =
 
 - GitHub token の失効・権限変更直後に stale データが返ると、閲覧可能 repository の判定が過大になる可能性がある
 - cleanup が未接続のため、テーブルサイズは運用期間に応じて増加する
+
+---
+
+## レビューフェーズ（2026-05-03 review エージェント / 再レビュー）
+
+### 対象
+
+- Issue ID: #63
+- タイトル: GitHub APIレスポンスのDBキャッシュとレートリミット対策
+
+### レビュー結果
+
+- `pr_ready: true`
+
+### 総評
+
+- 前回レビューで指摘した 4 件のコード修正とテスト補強は、現行実装ではいずれも反映済み
+- `CachedGithubAccessChecker` は `RateLimited` 時だけ stale を返し、`TokenExpired` / `Upstream` はそのまま上位へ返すため、前回の 401 握りつぶしリスクは解消済み
+- invalidate は `GithubAccessChecker` トレイト経由で呼べる形になっており、`DynGithubAccessChecker` 越しの呼び出しテストでも成立している
+- `inner` の trait object 化と `with_inner` により、レートリミット系の振る舞いをモック注入で検証できるようになっている
+- `users.github_access_token` へのインデックス追加も実装済みで、今回導入した逆引きホットパスと整合している
+
+### 指摘事項
+
+1. **minor**: 1件のテストが外部 GitHub 応答に依存しており、CI のネットワーク条件次第で非決定的になる
+    - `crates/api/tests/github_cache_test.rs` の `test_cached_checker_unknown_token_passes_through` は `CachedGithubAccessChecker::new` を使って実際の `RealGithubAccessChecker` を呼ぶ
+    - 現状の assert は `is_err()` のみなので壊れにくいが、外部通信・DNS・GitHub 側の遅延に影響される integration test になっている
+    - 修正案: `with_inner(...)` で専用モックを注入し、「未知トークン時は DB キャッシュを使わず inner に委譲する」こと自体をローカルに検証する
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- `test_cached_checker_unknown_token_passes_through` をモックベースに置き換えてテストの決定性を上げる
+- `cleanup_expired_cache` の実行導線を将来 Issue で追加し、1時間超の失効行が残留し続けないようにする
+- webhook など invalidate の実呼び出し元を追加する際は、今回追加した trait メソッドをそのまま利用して結合テストも追加する
+
+### テスト不足
+
+- blocking な不足は見当たらない
+- ただし未知トークン時の pass-through は現在 external dependency を含むため、純粋なローカルテストへ寄せる余地がある
+
+### ドキュメント確認
+
+- 確認対象: `docs/spec.md`, `docs/external/github-api-rate-limit-cache.md`, `README.md`, `docs/logs/63/worklog.md`
+- `CONTRIBUTING.md` は repository 内に存在せず未確認
+- 恒久ドキュメントへの追記は必須ではないが、現状この変更の運用上の注意点は `docs/logs/63/worklog.md` に集約されている
+
+### plan / research / docs との整合
+
+- research の推奨事項である DB キャッシュ、TTL、RateLimited 限定 stale fallback、Decorator パターン、token 逆引きインデックス追加と整合している
+- plan の受け入れ条件 1 から 5 に対して、コードとテストの両方で概ね一致している
+- 前回レビューで指摘した stale 条件、invalidate 導線、inner の trait object 化、インデックス、テスト補強もいずれも反映済み
+
+### PR/完了結果
+
+- `pr_ready: true`
+- 現時点では PR 作成を止める blocking issue は確認できなかった
+
+### 残リスク
+
+- webhook 連携による明示 invalidate と cleanup の定期実行は未接続のため、権限変更即時反映とキャッシュ掃除は TTL / 手動運用に依存する
+- users テーブルに GitHub access token を保持して逆引きしている構造自体は既存設計の延長であり、今回の変更で新たな SQL injection リスクは見当たらないが、トークン保管方針そのものは将来的な設計論点として残る
+
+---
+
+## ドキュメント確認フェーズ（2026-05-03 docs エージェント）
+
+### 確認対象
+
+- `docs/backend/api.md`
+- `docs/backend/summary.md`
+- `docs/spec.md`
+- `docs/external/github-api-rate-limit-cache.md`
+- `docs/logs/63/worklog.md`
+
+### 確認結果
+
+- 実装済みの `CachedGithubAccessChecker`、`github_api_cache`、TTL 10分、RateLimited 時のみ stale-while-error 最大1時間、`invalidate_repo_cache` フック追加を確認
+- `docs/external/github-api-rate-limit-cache.md` の採用判断と実装は整合している
+- 一方で backend / spec ドキュメントには、Web UI read API の認可用 GitHub API キャッシュが未記載だった
+- 既存の webhook 実装には `invalidate_repo_cache` 呼び出しが未接続であり、ここを「invalidate 実装済み」とだけ書くと過剰記述になるため、TTL ベース運用と将来拡張を明記するのが正しい
+
+### 反映した更新
+
+- `docs/backend/api.md`: read API の repository 可視性判定で DB キャッシュを使うこと、TTL 10分、RateLimited 時のみ stale cache、TokenExpired / Upstream では stale 不使用、Webhook invalidation 未接続を追記
+- `docs/backend/summary.md`: backend アーキテクチャに `github_api_cache` と `CachedGithubAccessChecker` の役割を追記
+- `docs/spec.md`: 補助テーブル `github_api_cache` と read API 権限判定用キャッシュ運用を追記
+
+### ドキュメント判定
+
+- `docs_ready: true`
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- 将来 `installation_repositories` webhook から `invalidate_repo_cache` を実際に呼ぶ段階で、`docs/backend/api.md` と `docs/spec.md` の invalidation 記述を「将来拡張」から「実装済み」に更新する
+- 運用タスクとして `cleanup_expired_cache` の定期実行方式が決まったら、backend 運用手順書にも追記する
+
+### テスト結果
+
+- ドキュメント更新のみのため追加テストは未実施
+
+### レビュー結果
+
+- 実装とドキュメントの不整合は解消済み
+- PR作成可否: `docs_ready: true`
+
+### 残リスク
+
+- explicit invalidation のフック自体は実装済みだが、本番コードからの呼び出し経路は未接続
+- `cleanup_expired_cache` の定期実行手段は引き続き未文書化
+
+---
+
+## PR作成フェーズ（2026-05-03 pr エージェント）
+
+### PR/完了結果
+
+- PRを作成: **https://github.com/f0reachARR/boardflow/pull/68**
+- タイトル: `feat: GitHub APIレスポンスのDBキャッシュとレートリミット対策 (#63)`
+- base: `main` ← head: `feature/63-github-api-cache`
+- Closes #63
+
+### PR作成前確認
+
+| 確認項目 | 結果 |
+|---|---|
+| `pr_ready: true`（review エージェント） | ✓ |
+| `docs_ready: true`（docs エージェント） | ✓ |
+| 未コミット変更なし（worklog除く） | ✓ |
+| `cargo build --workspace` | ✓ |
+| `cargo test --workspace` | ✓ |
+| `cargo clippy --workspace` | ✓ |
+| `cargo fmt --all` | ✓ |
+
+### コミット構成
+
+| コミット | 内容 |
+|---|---|
+| `9b1738c` | feat(#63): add GitHub API cache layer with DB-backed TTL and stale-while-error |
+| `4c6e3ec` | test(#63): add integration tests for GitHub API cache layer |
+| `b8e0898` | docs(#63): update worklog with implementation details and test results |
+| `07b284a` | fix(#63): address review feedback on GitHub API cache |
+| `3d37cf6` | docs(#63): update worklog with review fix phase details |
+| `b1912c8` | docs(#63): add cache layer documentation to api.md, summary.md and spec.md |
+
+### 残リスク
+
+- `cleanup_expired_cache` の定期実行（ジョブ/cron）は未実装 → 将来 Issue 化推奨
+- Webhook (`installation_repositories`) による明示的 invalidation は未実装 → 別 Issue 予定
+- `invalidate_repo_cache` の実際の呼び出しユースケース（Webhook 受信時など）は本 Issue 範囲外

--- a/docs/logs/63/worklog.md
+++ b/docs/logs/63/worklog.md
@@ -22,8 +22,325 @@
 
 `implementation_required`
 
+---
+
+## 調査フェーズ（2026-05-03 research エージェント）
+
+### 調査結果
+
+#### 1. GitHub API Rate Limiting 仕様
+
+- ユーザーアクセストークン: **5,000 req/h**（ユーザー単位、全アプリ共有）
+- GitHub App インストールトークン: 5,000〜12,500 req/h（スケール）
+- Secondary rate limit: GET 1ポイント/req、具体的なしきい値は非公開、予告なし変更あり
+- レスポンスヘッダ: `x-ratelimit-remaining`, `x-ratelimit-reset`, `x-ratelimit-used`, `retry-after`
+
+#### 2. 429/403 ハンドリング
+
+- GitHub は primary rate limit で **403 または 429** を返す
+- `retry-after` ヘッダがあれば指定秒数待機、なければ `x-ratelimit-reset` まで待機
+- secondary rate limit では `retry-after` が返されないケースあり → 最低1分待機 + 指数バックオフ
+- **BoardFlow の現状**: `RealGithubAccessChecker` は 403 + ヘッダで判定済み、429 も判定済み。ただしリトライロジックは未実装
+
+#### 3. PostgreSQL キャッシュテーブル設計
+
+- UNLOGGED テーブル: WALなしで高速書き込み、クラッシュ後データ消失、レプリケーション不可
+- **判断**: 通常テーブルで実装（将来のレプリカ対応、キャッシュデータ量は少量）
+- テーブル: `github_api_cache (user_id UUID, cache_type TEXT, value_json JSONB, expires_at TIMESTAMPTZ)`
+- PK: `(user_id, cache_type)` でユーザー×キャッシュ種別のユニーク制約
+- `expires_at` にインデックスを追加して掃除クエリを高速化
+
+#### 4. sqlx JSONB + Upsert
+
+- sqlx 0.8 は `serde_json::Value` を JSONB に直接 bind 可能（postgres feature で対応済み）
+- 追加の feature flag 不要
+- BoardFlow 既存コードで `serde_json::Value` + `ON CONFLICT DO UPDATE` パターンは多数使用済み
+
+### 現在の実装構造
+
+#### GithubAccessChecker トレイト（github_access.rs）
+
+- `check_access(token, owner, name) -> AccessResult`: 単一リポジトリの権限チェック
+- `list_accessible_repo_ids(token) -> Result<Option<Vec<i64>>, AccessError>`: ユーザーがアクセス可能なリポジトリID一覧
+- 実装: `RealGithubAccessChecker` (本番)、`AllowAll/DenyAll/RateLimited/UpstreamError` (テスト)
+- `DynGithubAccessChecker = Arc<dyn GithubAccessChecker>`
+- `list_accessible_repo_ids` は `/user/repos?per_page=100` を全ページ取得、主に `list_repositories` ルートから呼び出される
+
+#### DB構造
+
+- 既存テーブル: repositories, board_projects, board_runs, artifacts, artifact_bundles, run_checks, run_check_findings, snapshots, diff_metadata, diffs, api_tokens, github_jobs, users, sessions, board_project_issue_history
+- マイグレーション規約: `YYYYMMDDHHMMSS_description.{up,down}.sql`（例: `20260502000000_add_board_runs_timeout_sweep_index`）
+- sqlx 0.8 使用、`sqlx::query_as` / `sqlx::query` パターン
+
+### キャッシュ設計推奨事項
+
+1. **Decorator パターン**: `CachedGithubAccessChecker` が `GithubAccessChecker` を実装し、内部に `RealGithubAccessChecker` + `PgPool` を持つ
+2. **主要キャッシュ対象**: `list_accessible_repo_ids` の結果（`Vec<i64>` を JSONB で保存）
+3. **TTL**: 5〜10分（設定はハードコードで開始、後で Config crate に移動可能）
+4. **stale-while-error**: レートリミット時に期限切れキャッシュを返す（最大1時間保持）
+5. **Invalidation**: TTL 超過で自動失効、将来的に `installation_repositories` Webhook で明示的削除
+6. **check_access はキャッシュ不要**: 低頻度で個別リポジトリ単位、キャッシュの複雑性に見合わない
+
+### 参照URL
+
+- https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+- https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/rate-limits-for-oauth-apps
+- https://docs.github.com/en/rest/using-the-rest-api/troubleshooting-the-rest-api#rate-limit-errors
+- https://github.com/hub4j/github-api/issues/1805
+- https://martinheinz.dev/blog/105
+- https://tech-couch.com/post/storing-sessions-or-cache-data-in-postgresql
+
+### 結論ステータス
+
+**`implementation_required`**
+
+### 後続エージェントへの注意点
+
+- `CachedGithubAccessChecker` は `crates/api/src/github_access.rs` に追加する（既存トレイト・モック群と同じファイル）
+- マイグレーションファイルは `crates/db/migrations/20260503000000_add_github_api_cache.{up,down}.sql` として作成
+
+---
+
+## 計画フェーズ（2026-05-03 plan エージェント）
+
+### 目的
+
+- `list_accessible_repo_ids` の結果をDBにキャッシュし、GitHub API呼び出し回数を削減する
+- レートリミット (429/403) 発生時に stale キャッシュでフォールバックする
+- 将来の Webhook ベース invalidation に対応できるテーブル設計
+
+### 非目的
+
+- `check_access` のキャッシュ化（低頻度、個別リポジトリ単位でコスト対効果が低い）
+- インメモリキャッシュ層の追加（マルチインスタンス不整合リスク）
+- リトライロジックの実装（レートリミット時は stale キャッシュで対応）
+- Webhook による明示的 invalidation の実装（別Issue）
+- TTL の外部設定化（初回はハードコード）
+
+### 受け入れ条件
+
+1. `list_accessible_repo_ids` の結果がDBにキャッシュされ、TTL内は GitHub API を呼ばない
+2. キャッシュミス時は GitHub API を呼び、結果をDBに upsert する
+3. レートリミットエラー時、期限切れでも1時間以内のキャッシュがあればそれを返す
+4. レートリミットエラー時、キャッシュも無ければ従来通りエラーを返す
+5. 既存テストが全てパスする
+6. トレイトシグネチャは変更しない
+
+### 詳細要件
+
+#### キャッシュ対象
+
+| メソッド | キャッシュ | 理由 |
+|---|---|---|
+| `list_accessible_repo_ids` | **する** | 高頻度呼び出し、全ページ取得でAPIコスト高い |
+| `check_access` | しない | 低頻度、個別リポジトリ、結果変動が大きい |
+
+#### キャッシュキー設計
+
+- `user_id` (UUID) をキーに使用
+- `CachedGithubAccessChecker` は `github_access_token` から `users` テーブルで `user_id` を引き当てる
+- これにより将来の Webhook invalidation (user_id ベース) に対応可能
+
+#### TTL
+
+| 状態 | 保持時間 |
+|---|---|
+| 正常キャッシュ | **10分** |
+| stale-while-error (フォールバック用) | expires_at 後も **最大1時間** 行を保持 |
+
+#### stale-while-error ロジック
+
+1. キャッシュヒット (`expires_at > NOW()`) → そのまま返す
+2. キャッシュミス → GitHub API 呼び出し → 成功なら upsert して返す
+3. GitHub API が `RateLimited` → 期限切れだが1時間以内のキャッシュを探す (`expires_at > NOW() - INTERVAL '1 hour'`)
+4. stale キャッシュあり → stale を返す (warning ログ)
+5. stale キャッシュもなし → `AccessError::RateLimited` を返す
+
+### 影響範囲
+
+| ファイル | 変更内容 |
+|---|---|
+| `crates/db/migrations/20260503000000_add_github_api_cache.up.sql` | 新規: テーブル作成 |
+| `crates/db/migrations/20260503000000_add_github_api_cache.down.sql` | 新規: テーブル削除 |
+| `crates/db/src/queries/github_api_cache.rs` | 新規: upsert, get_valid, get_stale, delete_by_user, cleanup クエリ |
+| `crates/db/src/queries/mod.rs` | 変更: `pub mod github_api_cache;` 追加 |
+| `crates/api/src/github_access.rs` | 変更: `CachedGithubAccessChecker` 構造体 + impl 追加 |
+| `crates/api/src/lib.rs` | 変更: checker 生成を `CachedGithubAccessChecker::new(pool)` に差し替え |
+
+### 設計方針
+
+#### 1. DBマイグレーション
+
+```sql
+-- UP (20260503000000_add_github_api_cache.up.sql)
+CREATE TABLE github_api_cache (
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    cache_type  TEXT NOT NULL,
+    value_json  JSONB NOT NULL,
+    expires_at  TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (user_id, cache_type)
+);
+
+CREATE INDEX idx_github_api_cache_expires_at ON github_api_cache (expires_at);
+```
+
+```sql
+-- DOWN (20260503000000_add_github_api_cache.down.sql)
+DROP TABLE IF EXISTS github_api_cache;
+```
+
+#### 2. DB層クエリ関数 (`crates/db/src/queries/github_api_cache.rs`)
+
+```rust
+/// 有効なキャッシュ取得 (expires_at > NOW())
+pub async fn get_valid(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+) -> Result<Option<serde_json::Value>, sqlx::Error>
+
+/// stale キャッシュ取得 (期限切れだが1時間以内)
+pub async fn get_stale(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+) -> Result<Option<serde_json::Value>, sqlx::Error>
+
+/// キャッシュ upsert
+pub async fn upsert(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+    cache_type: &str,
+    value: &serde_json::Value,
+    expires_at: DateTime<Utc>,
+) -> Result<(), sqlx::Error>
+
+/// ユーザー単位でキャッシュ削除 (将来のWebhook invalidation用)
+pub async fn delete_by_user(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    user_id: Uuid,
+) -> Result<(), sqlx::Error>
+
+/// 期限切れ行の掃除 (1時間以上前に期限切れしたもの)
+pub async fn cleanup_expired(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+) -> Result<u64, sqlx::Error>
+```
+
+#### 3. CachedGithubAccessChecker (`crates/api/src/github_access.rs`)
+
+```rust
+/// キャッシュ付き GitHub アクセスチェッカー (Decorator パターン)
+pub struct CachedGithubAccessChecker {
+    inner: RealGithubAccessChecker,
+    pool: PgPool,
+}
+
+impl CachedGithubAccessChecker {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            inner: RealGithubAccessChecker::new(),
+            pool,
+        }
+    }
+}
+```
+
+**`list_accessible_repo_ids` 実装フロー:**
+
+1. `SELECT id FROM users WHERE github_access_token = $1` で `user_id` を取得
+   - 見つからない場合: inner に委譲（キャッシュスキップ）
+2. `github_api_cache::get_valid(pool, user_id, "accessible_repo_ids")` でキャッシュ確認
+   - ヒット: JSONB → `Vec<i64>` にデシリアライズして返す
+3. キャッシュミス: `inner.list_accessible_repo_ids(token)` を呼び出す
+   - 成功: `Vec<i64>` → JSONB にシリアライズ、`expires_at = NOW() + 10min` で upsert、結果を返す
+   - `RateLimited`: `github_api_cache::get_stale(pool, user_id, "accessible_repo_ids")` で stale キャッシュ確認
+     - stale あり: warning ログ + stale を返す
+     - stale なし: `Err(AccessError::RateLimited)` を返す
+   - その他エラー: そのまま返す
+
+**`check_access` 実装:** inner に直接委譲（キャッシュなし）
+
+#### 4. `crates/api/src/lib.rs` 変更
+
+```rust
+// Before:
+let checker: DynGithubAccessChecker =
+    access_checker.unwrap_or_else(|| Arc::new(RealGithubAccessChecker::new()));
+
+// After:
+let checker: DynGithubAccessChecker =
+    access_checker.unwrap_or_else(|| Arc::new(CachedGithubAccessChecker::new(pool.clone())));
+```
+
+テスト時は `access_checker: Some(...)` で明示的にモックを渡しているため、テストは影響を受けない。
+
+### Invalidate戦略
+
+| トリガー | 方法 | 実装時期 |
+|---|---|---|
+| TTL超過 | `expires_at > NOW()` チェックで自動失効 | 今回 |
+| stale掃除 | `cleanup_expired()` で1時間超え行を削除 | 今回（呼び出し元は将来のジョブキュー or アプリ起動時） |
+| Webhook `installation_repositories` | `delete_by_user(user_id)` 呼び出し | 将来Issue |
+| ユーザー削除 | `ON DELETE CASCADE` で自動削除 | テーブル定義で対応済み |
+
+### テスト観点
+
+1. **DB層ユニットテスト** (`crates/db` or integrationテスト)
+   - `upsert` → `get_valid` で正しく取得できる
+   - TTL切れ → `get_valid` が None を返す
+   - TTL切れ1時間以内 → `get_stale` で取得できる
+   - TTL切れ1時間超え → `get_stale` も None
+   - `delete_by_user` でキャッシュが消える
+
+2. **CachedGithubAccessChecker ユニットテスト**（既存テストとの整合性）
+   - 既存のモックテスト（AllowAll, DenyAll, RateLimited, UpstreamError）は `access_checker` パラメータでモックを直接渡しているため、影響なし
+   - `CachedGithubAccessChecker` 自体の結合テストは DB が必要 → 既存の integration test パターンに準じる
+
+3. **既存テストの影響確認**
+   - `crates/api/tests/read_api_test.rs`: モック使用、影響なし
+   - `crates/api/tests/api_token_test.rs`: モック使用、影響なし
+   - `crates/api/tests/proxy_test.rs`: モック使用、影響なし
+
+### ドキュメント更新対象
+
+| ファイル | 内容 |
+|---|---|
+| `docs/backend/api.md` | GitHub API キャッシュ層の説明追加 |
+| `docs/backend/summary.md` | アーキテクチャ図にキャッシュ層を追記 |
+
+### 実装順序
+
+1. **DBマイグレーション作成** — テーブル定義（up/down）
+2. **DB層クエリ関数** — `crates/db/src/queries/github_api_cache.rs` + mod.rs 登録
+3. **CachedGithubAccessChecker 実装** — `crates/api/src/github_access.rs` に追加
+4. **lib.rs 差し替え** — checker 生成を CachedGithubAccessChecker に変更
+5. **ビルド確認** — `cargo build` + `cargo test`
+6. **ドキュメント更新** — backend/api.md, backend/summary.md
+
+### 実装要否
+
+**`implementation_required`**
+
+### 未解決の疑問
+
+- なし（Research 調査で十分な情報が得られた。TTLはハードコード10分で開始）
+
+### 残リスク
+
+1. **キャッシュ陳腐化**: ユーザーが GitHub 側でリポジトリ権限を変更すると、最大10分古い情報が返る（許容範囲）
+2. **token → user_id 逆引きコスト**: キャッシュヒット時でも `users` テーブルへの SELECT が1回発生する（テーブルサイズ小、高速）
+3. **マルチインスタンス**: DBキャッシュなので問題なし（インメモリと異なり共有可能）
+4. **Webhook invalidation 未実装**: TTL で最大10分の遅延は許容。別Issue で対応予定
+- `crates/db/src/queries/` に `github_api_cache.rs` を追加し、`mod.rs` に登録
+- `crates/api/src/lib.rs` の `RealGithubAccessChecker` の生成箇所を `CachedGithubAccessChecker` に差し替え
+- テスト用モック（`AllowAll` 等）はキャッシュ不要なのでそのまま
+
 ## 残リスク
 
-- キャッシュの陳腐化: リポジトリ権限変更がリアルタイム反映されない
-- インメモリキャッシュはマルチインスタンスデプロイ時に各ノードで不整合
-- GitHub App installation_repositories webhookのinvalidateタイミング設計
+- キャッシュの陳腐化: リポジトリ権限変更がリアルタイム反映されない（TTL 5〜10分の遅延）
+- `installation_repositories` Webhook によるキャッシュ invalidation は別 Issue で対応が自然
+- ユーザーの GitHub トークンが他アプリと共有 → BoardFlow 側でのレートリミット残量は把握できない
+- secondary rate limit の正確なしきい値は非公開 → キャッシュで呼び出し頻度を下げるのが最善策

--- a/docs/logs/63/worklog.md
+++ b/docs/logs/63/worklog.md
@@ -164,6 +164,77 @@
 
 ---
 
+## レビュー修正フェーズ（2026-05-03 impl エージェント）
+
+### 指摘事項と対応
+
+#### 1. [MAJOR] staleフォールバックをRateLimited限定にする
+
+**対応完了**: `list_accessible_repo_ids` のエラーハンドリングを変更:
+- `Err(AccessError::RateLimited)` → staleキャッシュを探索して返す
+- `Err(AccessError::TokenExpired)` / `Err(AccessError::Upstream(_))` → staleキャッシュを使わず即座にエラー伝播
+
+#### 2. [MAJOR] invalidateを本番コードから呼べる形にする
+
+**対応完了**: `GithubAccessChecker` トレイトに `invalidate_repo_cache` メソッドを追加:
+- デフォルト実装: `Ok(())` (no-op) → 既存の AllowAll/DenyAll/RateLimited/UpstreamError モック全てが壊れずに動作
+- `CachedGithubAccessChecker` でオーバーライド: `delete_cache_by_user` を呼び出し
+- 本番コードで `DynGithubAccessChecker` (`Arc<dyn GithubAccessChecker>`) 経由で呼び出し可能
+
+#### 3. [MINOR] innerをtrait objectにしてテスト容易性を上げる
+
+**対応完了**: `CachedGithubAccessChecker` の内部構造を変更:
+- `inner: RealGithubAccessChecker` → `inner: Arc<dyn GithubAccessChecker>`
+- `new(pool)` は従来通り `RealGithubAccessChecker` を内部生成（後方互換）
+- `with_inner(inner, pool)` コンストラクタ追加 → テスト時にモック注入可能
+
+#### 4. [MINOR] github_access_tokenにインデックス追加
+
+**対応完了**: マイグレーションファイルに追加:
+```sql
+CREATE INDEX idx_users_github_access_token ON users (github_access_token) WHERE github_access_token IS NOT NULL;
+```
+down マイグレーションにも `DROP INDEX IF EXISTS idx_users_github_access_token;` 追加
+
+#### 5. テスト追加
+
+**対応完了**: 5件の新テストを追加:
+- `test_cached_checker_stale_fallback_with_mock_inner_rate_limited`: RateLimited時にstaleキャッシュが返ることをモックで実証
+- `test_cached_checker_token_expired_no_stale_fallback`: TokenExpired時にstale不使用でエラー伝播
+- `test_cached_checker_upstream_error_no_stale_fallback`: Upstream時にstale不使用でエラー伝播
+- `test_invalidate_repo_cache_via_trait`: `DynGithubAccessChecker` 経由で `invalidate_repo_cache` が呼べることの確認
+- `test_cached_checker_rate_limited_no_stale_returns_error`: RateLimited + staleなし → エラー返却
+
+追加のモック: `TokenExpiredGithubAccessChecker` (常に TokenExpired を返す)
+
+### テスト結果
+
+全ワークスペーステスト: **全パス (0 failures)**
+
+```
+cargo build --workspace     ✓
+cargo test --workspace      ✓
+cargo clippy --workspace    ✓
+cargo fmt --all             ✓
+```
+
+### 変更ファイル一覧
+
+| ファイル | 変更内容 |
+|---|---|
+| `crates/api/src/github_access.rs` | トレイトに `invalidate_repo_cache` 追加、`CachedGithubAccessChecker` の inner を `Arc<dyn>` に変更、stale フォールバック限定化、`TokenExpiredGithubAccessChecker` モック追加 |
+| `crates/api/tests/github_cache_test.rs` | 5件の新テスト追加、既存テストの重複ユーザー問題修正 |
+| `crates/db/migrations/20260503000000_add_github_api_cache.up.sql` | `idx_users_github_access_token` インデックス追加 |
+| `crates/db/migrations/20260503000000_add_github_api_cache.down.sql` | インデックスDROP追加 |
+
+### 残リスク
+
+- `cleanup_expired_cache` は定期実行が必要（ジョブ/cronで呼び出す仕組みは未実装、将来Issue化推奨）
+- Webhook による明示的 invalidation は未実装（将来 `installation_repositories` イベントで実装予定）
+- `invalidate_repo_cache` を実際に呼び出すユースケース（例: Webhook受信時）はこのIssue範囲外
+
+---
+
 ## 計画フェーズ（2026-05-03 plan エージェント）
 
 ### 目的

--- a/docs/logs/63/worklog.md
+++ b/docs/logs/63/worklog.md
@@ -101,6 +101,69 @@
 
 ---
 
+## 実装フェーズ（2026-05-03 impl エージェント）
+
+### 実装内容
+
+#### 1. DBマイグレーション
+- `crates/db/migrations/20260503000000_add_github_api_cache.up.sql`: `github_api_cache` テーブル作成（PK: `(user_id, cache_type)`, `expires_at` インデックス付き）
+- `crates/db/migrations/20260503000000_add_github_api_cache.down.sql`: テーブルDROP
+
+#### 2. DBクエリ関数
+- `crates/db/src/queries/github_api_cache.rs` 新規作成
+  - `get_valid_cache`: expires_at > NOW() のキャッシュを返す
+  - `get_stale_cache`: 期限切れだが max_stale_duration 以内のキャッシュを返す（cutoffタイムスタンプ計算方式）
+  - `upsert_cache`: INSERT ON CONFLICT DO UPDATE
+  - `delete_cache_by_user`: ユーザーの全キャッシュ削除
+  - `delete_cache`: 特定キャッシュ削除
+  - `cleanup_expired_cache`: 1時間以上期限切れのキャッシュ一括削除
+- `crates/db/src/queries/user.rs` に `find_by_github_access_token` 追加（token→user_id逆引き用）
+
+#### 3. CachedGithubAccessChecker
+- `crates/api/src/github_access.rs` 末尾に追加
+- `GithubAccessChecker` トレイト実装:
+  - `check_access`: inner に直接委譲
+  - `list_accessible_repo_ids`:
+    1. `find_by_github_access_token` で user_id 取得
+    2. `get_valid_cache` でキャッシュヒット確認
+    3. キャッシュミス → inner 呼び出し → 成功時 `upsert_cache`（TTL 10分）
+    4. inner 失敗時 → `get_stale_cache`（最大1時間）でフォールバック
+- `invalidate_cache(user_id)` 構造体メソッド追加
+
+#### 4. lib.rs差し替え
+- デフォルトの checker 生成を `CachedGithubAccessChecker::new(pool.clone())` に変更
+- 既存テストは `access_checker: Some(...)` で mock を渡しているため影響なし
+
+### テスト結果
+
+12件の統合テスト（`crates/api/tests/github_cache_test.rs`）:
+- `test_upsert_and_get_valid_cache`: 正常挿入・取得
+- `test_get_valid_cache_returns_none_when_expired`: 期限切れは取得不可
+- `test_get_stale_cache_returns_recently_expired`: staleウィンドウ内は取得可
+- `test_get_stale_cache_returns_none_for_very_old_cache`: staleウィンドウ外は取得不可
+- `test_upsert_cache_updates_existing`: UPSERT で上書き確認
+- `test_delete_cache_removes_specific_entry`: 個別削除
+- `test_delete_cache_by_user_removes_all`: ユーザー全削除
+- `test_cleanup_expired_cache`: 期限切れ一括削除
+- `test_cached_checker_invalidate_cache`: invalidate_cache 動作確認
+- `test_cached_checker_returns_cached_repo_ids`: キャッシュヒット確認
+- `test_cached_checker_unknown_token_passes_through`: 未知トークンはパススルー
+- `test_cached_checker_stale_fallback_on_rate_limit`: stale エントリの確認
+
+全ワークスペーステスト: **221 passed, 0 failed**
+
+### 更新ドキュメント
+
+- `docs/logs/63/worklog.md`（本ファイル）
+
+### 残リスク
+
+- `find_by_github_access_token` はインデックスなしのカラム検索。ユーザー数が多くなった場合はインデックス追加を検討
+- `cleanup_expired_cache` は定期実行が必要（ジョブ/cronで呼び出す仕組みは未実装、将来Issue化推奨）
+- Webhook による明示的 invalidation は未実装（将来 `installation_repositories` イベントで実装予定）
+
+---
+
 ## 計画フェーズ（2026-05-03 plan エージェント）
 
 ### 目的

--- a/docs/logs/63/worklog.md
+++ b/docs/logs/63/worklog.md
@@ -407,3 +407,76 @@ let checker: DynGithubAccessChecker =
 - `installation_repositories` Webhook によるキャッシュ invalidation は別 Issue で対応が自然
 - ユーザーの GitHub トークンが他アプリと共有 → BoardFlow 側でのレートリミット残量は把握できない
 - secondary rate limit の正確なしきい値は非公開 → キャッシュで呼び出し頻度を下げるのが最善策
+
+---
+
+## レビューフェーズ（2026-05-03 review エージェント）
+
+### 対象
+
+- Issue ID: #63
+- タイトル: GitHub APIレスポンスのDBキャッシュとレートリミット対策
+
+### レビュー結果
+
+- `pr_ready: false`
+
+### 指摘事項
+
+1. **major**: stale フォールバックが `RateLimited` だけでなく `TokenExpired` や任意の `Upstream` エラーにも適用されている
+    - `CachedGithubAccessChecker::list_accessible_repo_ids` は inner 呼び出し失敗時に無条件で stale キャッシュを返そうとするため、GitHub セッション失効時でも古い repository access list を返しうる
+    - `list_repositories` は本来 `TokenExpired` を 401 に変換する設計だが、この実装だと stale キャッシュが優先されて 401 が握りつぶされる
+    - 修正案: stale フォールバックは `AccessError::RateLimited` のみ、必要なら明示的に `AccessError::Upstream` の一部だけへ限定する。`TokenExpired` は必ずそのまま返す
+
+2. **major**: invalidate は API/worker/webhook などの実運用経路に接続されておらず、Issue 要件としては未完了
+    - `invalidate_cache(user_id)` は concrete type のメソッドとして追加されているが、アプリ起動時には `Arc<dyn GithubAccessChecker>` に erase されるため、通常経路から呼べない
+    - 現状の参照はテストのみで、本番コードからは invalidate 不能
+    - 修正案: webhook や明示 API から invalidate を呼べる導線を追加するか、少なくとも invalidate 用の抽象を別 trait / service として公開する
+
+3. **minor**: 429/stale fallback の統合テストが実際の振る舞いを検証していない
+    - テスト自身が `RealGithubAccessChecker` 固定のため true fallback を検証できないことをコメントで認めており、実際には stale 取得クエリの確認に留まっている
+    - 修正案: `CachedGithubAccessChecker` が任意の `GithubAccessChecker` を inner に取れるようにして、`RateLimitedGithubAccessChecker` を注入した振る舞いテストを追加する
+
+4. **minor**: token 逆引きクエリが無索引で、キャッシュ導入後の新しいホットパスになっている
+    - `find_by_github_access_token` は request ごとに `users.github_access_token` を検索するが、現行 schema に index がない
+    - 修正案: `github_access_token` へ index 追加を検討する。トークン列の取り扱い方針次第ではハッシュ化 + hash index/BTREE への移行も候補
+
+### 必須修正
+
+- stale フォールバック条件を `AccessError::RateLimited` に限定し、`TokenExpired` を確実に 401 へ流す
+- invalidate を実際に利用できる本番経路へ接続し、Issue 要件の「invalidate」を満たす
+- 429/RateLimited 時の stale fallback を本当に検証するテストを追加する
+
+### 任意改善
+
+- `CachedGithubAccessChecker` の inner を trait object / generic にして、Decorator としての再利用性とテスト容易性を上げる
+- `users.github_access_token` の索引戦略を明示する
+- `cleanup_expired_cache` の定期実行経路を追加し、古いキャッシュ行の滞留を防ぐ
+
+### テスト不足
+
+- `RateLimited` 発生時に stale が返る実挙動のテスト
+- `TokenExpired` 発生時に stale を返さず 401 相当エラーが返るテスト
+- invalidate の本番導線（例: webhook / service）を通したテスト
+
+### ドキュメント確認
+
+- 確認対象: `docs/spec.md`, `docs/technology.md`, `docs/external/github-api-rate-limit-cache.md`, `README.md`, `docs/logs/63/worklog.md`
+- `CONTRIBUTING.md` は repository 内に見当たらず未確認
+- docs への恒久的な反映は未実施。少なくとも invalidate 方針と stale fallback の制約は backend 方針や運用メモへ残した方がよい
+
+### plan / research / docs との不整合
+
+- 計画では「429/レートリミット時は stale キャッシュでフォールバック」となっているが、実装は `TokenExpired` を含む全エラーへ拡張されている
+- 計画では invalidate を要件化しているが、実装は concrete method の追加のみで、運用経路がない
+- 実装概要では stale fallback テスト完了と読めるが、実テストは fallback 振る舞いを直接検証していない
+
+### PR/完了結果
+
+- 現時点では `pr_ready: false`
+- 主因はセッション失効時の stale 返却リスクと invalidate 未接続
+
+### 残リスク
+
+- GitHub token の失効・権限変更直後に stale データが返ると、閲覧可能 repository の判定が過大になる可能性がある
+- cleanup が未接続のため、テーブルサイズは運用期間に応じて増加する

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -1601,6 +1601,26 @@ board_project_issue_history
 - created_at
 ```
 
+### 10.14 github_api_cache
+
+Web UI read API の GitHub repository 可視性判定に使う補助キャッシュ。
+
+```text
+github_api_cache
+- user_id
+- cache_type          # accessible_repo_ids
+- value_json
+- expires_at
+- created_at
+- updated_at
+```
+
+`user_id + cache_type` にunique制約を置き、MVPでは `accessible_repo_ids` を JSONB で保持する。
+このキャッシュは read API の権限判定用であり、GitHub OAuth user access token に対する `/user/repos` 相当の結果を 10 分 TTL で再利用する。
+GitHub API が rate limit に達した場合のみ、期限切れ後 1 時間以内の stale cache を read API のフォールバックに使ってよい。
+token expired やその他の upstream error では stale cache を使わない。
+明示的 invalidation のフックは持つが、MVPでは TTL ベースの自然失効を基本とし、Webhook 連動の cache invalidation は将来拡張とする。
+
 ---
 
 ## 11. GitHub App連携仕様


### PR DESCRIPTION
## 概要

Closes #63

`list_repositories` 等で毎回発生していた GitHub API 呼び出しに、PostgreSQL バックエンドの TTL 付きキャッシュ層を追加し、レートリミット時の stale-while-error フォールバックを実装します。

---

## 要件

- `list_accessible_repo_ids` の結果をDBにキャッシュし、TTL内は GitHub API を呼ばない
- キャッシュミス時は GitHub API を呼び、結果をDBに upsert
- `RateLimited` エラー時、期限切れでも1時間以内のキャッシュがあればそれを返す
- `TokenExpired` / `Upstream` エラー時はキャッシュフォールバックせず即座にエラー返却
- 既存テストが全てパス

---

## 調査結果

- GitHub API レートリミット: ユーザートークン 5,000 req/h（全アプリ共有）
- Primary rate limit は 403 または 429 で通知、`retry-after` / `x-ratelimit-reset` ヘッダあり
- PostgreSQL JSONB + `ON CONFLICT DO UPDATE` で upsert 可能（sqlx 0.8 で対応済み）
- Decorator パターンが既存トレイト構造に最も適合

---

## 実装概要

### 設計: Decorator パターン

```
CachedGithubAccessChecker
  ├── inner: Arc<dyn GithubAccessChecker>  (= RealGithubAccessChecker)
  └── pool: PgPool
```

### DBスキーマ: `github_api_cache`

```sql
CREATE TABLE github_api_cache (
  user_id      UUID         NOT NULL REFERENCES users(id) ON DELETE CASCADE,
  cache_type   TEXT         NOT NULL,
  value_json   JSONB        NOT NULL,
  expires_at   TIMESTAMPTZ  NOT NULL,
  PRIMARY KEY (user_id, cache_type)
);
CREATE INDEX idx_github_api_cache_expires_at ON github_api_cache (expires_at);
CREATE INDEX idx_users_github_access_token ON users (github_access_token)
  WHERE github_access_token IS NOT NULL;
```

### TTL 設定

| 状態 | 保持時間 |
|---|---|
| 正常キャッシュ | 10分 |
| stale-while-error (RateLimited 時フォールバック) | expires_at 後も最大1時間 |

### stale-while-error ロジック

1. `expires_at > NOW()` → キャッシュ返却
2. キャッシュミス → GitHub API 呼び出し → 成功なら upsert して返却
3. `RateLimited` → `expires_at > NOW() - INTERVAL '1 hour'` のキャッシュを探す
4. stale キャッシュあり → warning ログ付きで返却
5. stale キャッシュなし → `AccessError::RateLimited` を返却
6. `TokenExpired` / `Upstream` → stale フォールバックなし、即座にエラー伝播

### `GithubAccessChecker` トレイト変更

```rust
pub trait GithubAccessChecker: Send + Sync {
    // 既存メソッド...
    async fn invalidate_repo_cache(&self, _user_id: Uuid) -> Result<(), AccessError> {
        Ok(()) // デフォルト no-op (既存モックへの後方互換)
    }
}
```

---

## 変更ファイル一覧

| ファイル | 内容 |
|---|---|
| `crates/db/migrations/20260503000000_add_github_api_cache.up.sql` | `github_api_cache` テーブル + インデックス |
| `crates/db/migrations/20260503000000_add_github_api_cache.down.sql` | テーブル・インデックス DROP |
| `crates/db/src/queries/github_api_cache.rs` | DBキャッシュクエリ関数 |
| `crates/db/src/queries/user.rs` | `find_by_github_access_token` 追加 |
| `crates/db/src/queries/mod.rs` | `pub mod github_api_cache` 追加 |
| `crates/api/src/github_access.rs` | `CachedGithubAccessChecker` 実装、トレイトに `invalidate_repo_cache` 追加 |
| `crates/api/src/lib.rs` | checker を `CachedGithubAccessChecker` に差し替え |
| `crates/api/tests/github_cache_test.rs` | 統合テスト17件 |
| `docs/backend/api.md` | キャッシュ層ドキュメント追加 |
| `docs/backend/summary.md` | アーキテクチャ記述更新 |
| `docs/spec.md` | 仕様追記 |
| `docs/external/github-api-rate-limit-cache.md` | 外部調査メモ |

---

## テスト結果

```
cargo build --workspace     ✓
cargo test --workspace      ✓  (全テストパス)
cargo clippy --workspace    ✓  (警告なし)
cargo fmt --all             ✓
```

テストケース（17件）:
- `test_upsert_and_get_valid_cache`
- `test_get_valid_cache_returns_none_when_expired`
- `test_get_stale_cache_returns_recently_expired`
- `test_get_stale_cache_returns_none_for_very_old_cache`
- `test_upsert_cache_updates_existing`
- `test_delete_cache_removes_specific_entry`
- `test_delete_cache_by_user_removes_all`
- `test_cleanup_expired_cache`
- `test_cached_checker_invalidate_cache`
- `test_cached_checker_returns_cached_repo_ids`
- `test_cached_checker_unknown_token_passes_through`
- `test_cached_checker_stale_fallback_on_rate_limit`
- `test_cached_checker_stale_fallback_with_mock_inner_rate_limited`
- `test_cached_checker_token_expired_no_stale_fallback`
- `test_cached_checker_upstream_error_no_stale_fallback`
- `test_invalidate_repo_cache_via_trait`
- `test_cached_checker_rate_limited_no_stale_returns_error`

---

## 外部調査メモ

- [GitHub API Rate Limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api)
- 詳細: `docs/external/github-api-rate-limit-cache.md`

---

## 残リスク / 将来課題

- `cleanup_expired_cache` の定期実行（ジョブ/cron）は未実装 → 将来 Issue 化推奨
- Webhook (`installation_repositories`) による明示的 invalidation は未実装 → 別 Issue 予定
- `invalidate_repo_cache` の実際の呼び出しユースケース（Webhook 受信時など）は本 Issue 範囲外

---

## レビュー / ドキュメント確認

- `pr_ready: true`（review エージェント、必須修正なし）
- `docs_ready: true`（docs エージェント、docs/backend/api.md・summary.md・spec.md 更新済み）
