### PR TITLE
feat(frontend): Streaming SSR with loading/error UI

### DIFF
--- a/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/error.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/error.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { ErrorUI } from "@/components/error-boundary"
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return <ErrorUI error={error} reset={reset} />
+}

--- a/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/loading.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/loading.tsx
@@ -1,0 +1,5 @@
+import { BoardProjectDetailSkeleton } from "@/components/skeletons/board-project-detail-skeleton"
+
+export default function Loading() {
+  return <BoardProjectDetailSkeleton />
+}

--- a/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]/error.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]/error.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { ErrorUI } from "@/components/error-boundary"
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return <ErrorUI error={error} reset={reset} />
+}

--- a/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]/loading.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]/loading.tsx
@@ -1,0 +1,5 @@
+import { RunDetailSkeleton } from "@/components/skeletons/run-detail-skeleton"
+
+export default function Loading() {
+  return <RunDetailSkeleton />
+}

--- a/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/runs/error.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/runs/error.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { ErrorUI } from "@/components/error-boundary"
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return <ErrorUI error={error} reset={reset} />
+}

--- a/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/runs/loading.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/[repositoryId]/boards/[boardProjectId]/runs/loading.tsx
@@ -1,0 +1,5 @@
+import { RunsTableSkeleton } from "@/components/skeletons/runs-table-skeleton"
+
+export default function Loading() {
+  return <RunsTableSkeleton />
+}

--- a/boardflow/src/app/(authenticated)/repositories/[repositoryId]/error.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/[repositoryId]/error.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { ErrorUI } from "@/components/error-boundary"
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return <ErrorUI error={error} reset={reset} />
+}

--- a/boardflow/src/app/(authenticated)/repositories/[repositoryId]/loading.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/[repositoryId]/loading.tsx
@@ -1,0 +1,5 @@
+import { RepositoryDetailSkeleton } from "@/components/skeletons/repository-detail-skeleton"
+
+export default function Loading() {
+  return <RepositoryDetailSkeleton />
+}

--- a/boardflow/src/app/(authenticated)/repositories/error.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/error.tsx
@@ -1,0 +1,7 @@
+"use client"
+
+import { ErrorUI } from "@/components/error-boundary"
+
+export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return <ErrorUI error={error} reset={reset} />
+}

--- a/boardflow/src/app/(authenticated)/repositories/loading.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/loading.tsx
@@ -1,0 +1,5 @@
+import { RepositoriesTableSkeleton } from "@/components/skeletons/repositories-table-skeleton"
+
+export default function Loading() {
+  return <RepositoriesTableSkeleton />
+}

--- a/boardflow/src/app/(authenticated)/repositories/page.tsx
+++ b/boardflow/src/app/(authenticated)/repositories/page.tsx
@@ -1,8 +1,10 @@
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query"
+import { Suspense } from "react"
 import { getQueryClient } from "@/lib/query-client"
 import { createServerClient } from "@/lib/api/server"
 import { $api } from "@/lib/api/react-query"
 import { RepositoriesList } from "@/components/repositories/repositories-list"
+import { RepositoriesTableSkeleton } from "@/components/skeletons/repositories-table-skeleton"
 
 export default async function RepositoriesPage() {
   const queryClient = getQueryClient()
@@ -12,7 +14,8 @@ export default async function RepositoriesPage() {
     params: { query: { limit: 50 } },
   })
 
-  await queryClient.prefetchQuery({
+  // await しない → Streaming SSR: 結果が到着次第クライアントに反映
+  queryClient.prefetchQuery({
     ...options,
     queryFn: async () => {
       const { data, error } = await serverClient.GET("/api/v1/repositories", {
@@ -25,7 +28,9 @@ export default async function RepositoriesPage() {
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>
-      <RepositoriesList />
+      <Suspense fallback={<RepositoriesTableSkeleton />}>
+        <RepositoriesList />
+      </Suspense>
     </HydrationBoundary>
   )
 }

--- a/boardflow/src/components/error-boundary.tsx
+++ b/boardflow/src/components/error-boundary.tsx
@@ -1,0 +1,17 @@
+"use client"
+
+import { Box, Heading, Text, Button, VStack } from "@chakra-ui/react"
+
+export function ErrorUI({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  return (
+    <Box py={8}>
+      <VStack gap={4}>
+        <Heading size="md">Something went wrong</Heading>
+        <Text color="gray.600">{error.message}</Text>
+        <Button onClick={reset} variant="outline">
+          Try again
+        </Button>
+      </VStack>
+    </Box>
+  )
+}

--- a/boardflow/src/components/error-boundary.tsx
+++ b/boardflow/src/components/error-boundary.tsx
@@ -1,14 +1,22 @@
 "use client"
 
 import { Box, Heading, Text, Button, VStack } from "@chakra-ui/react"
+import { useQueryErrorResetBoundary } from "@tanstack/react-query"
 
 export function ErrorUI({ error, reset }: { error: Error & { digest?: string }; reset: () => void }) {
+  const { reset: resetQuery } = useQueryErrorResetBoundary()
+
+  const handleReset = () => {
+    resetQuery()
+    reset()
+  }
+
   return (
     <Box py={8}>
       <VStack gap={4}>
         <Heading size="md">Something went wrong</Heading>
         <Text color="gray.600">{error.message}</Text>
-        <Button onClick={reset} variant="outline">
+        <Button onClick={handleReset} variant="outline">
           Try again
         </Button>
       </VStack>

--- a/boardflow/src/components/repositories/repositories-list.tsx
+++ b/boardflow/src/components/repositories/repositories-list.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Box, Heading, Spinner, Table, Text, Badge } from "@chakra-ui/react"
+import { Box, Heading, Table, Text, Badge } from "@chakra-ui/react"
 import Link from "next/link"
 import { $api } from "@/lib/api/react-query"
 
@@ -21,26 +21,9 @@ function statusColor(status: string | null): string {
 }
 
 export function RepositoriesList() {
-  const { data, error, isPending } = $api.useQuery("get", "/api/v1/repositories", {
+  const { data } = $api.useSuspenseQuery("get", "/api/v1/repositories", {
     params: { query: { limit: 50 } },
   })
-
-  if (isPending) {
-    return (
-      <Box display="flex" justifyContent="center" py={8}>
-        <Spinner size="lg" />
-      </Box>
-    )
-  }
-
-  if (error) {
-    return (
-      <Box>
-        <Heading size="lg" mb={4}>Repositories</Heading>
-        <Text color="red.500">Failed to load repositories.</Text>
-      </Box>
-    )
-  }
 
   const repositories = data?.items ?? []
 

--- a/boardflow/src/components/skeletons/board-project-detail-skeleton.tsx
+++ b/boardflow/src/components/skeletons/board-project-detail-skeleton.tsx
@@ -1,0 +1,51 @@
+import { Box, Heading, VStack, HStack, Skeleton, Table } from "@chakra-ui/react"
+
+export function BoardProjectDetailSkeleton() {
+  return (
+    <Box>
+      <Skeleton height="20px" width="300px" mb={4} />
+      <VStack align="stretch" gap={6}>
+        <Box>
+          <HStack gap={2} mb={1}>
+            <Skeleton height="32px" width="200px" />
+            <Skeleton height="24px" width="80px" />
+          </HStack>
+          <Skeleton height="16px" width="250px" />
+        </Box>
+        <Box borderWidth="1px" borderRadius="md" p={4}>
+          <VStack align="stretch" gap={3}>
+            {Array.from({ length: 3 }).map((_, i) => (
+              <HStack key={i} justify="space-between">
+                <Skeleton height="16px" width="100px" />
+                <Skeleton height="16px" width="150px" />
+              </HStack>
+            ))}
+          </VStack>
+        </Box>
+        <Box>
+          <Heading size="md" mb={4}>Recent Runs</Heading>
+          <Table.Root size="sm" variant="outline">
+            <Table.Header>
+              <Table.Row>
+                <Table.ColumnHeader>Status</Table.ColumnHeader>
+                <Table.ColumnHeader>Commit</Table.ColumnHeader>
+                <Table.ColumnHeader>Branch</Table.ColumnHeader>
+                <Table.ColumnHeader>Created</Table.ColumnHeader>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Table.Row key={i}>
+                  <Table.Cell><Skeleton height="20px" width="80px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="70px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
+        </Box>
+      </VStack>
+    </Box>
+  )
+}

--- a/boardflow/src/components/skeletons/board-project-detail-skeleton.tsx
+++ b/boardflow/src/components/skeletons/board-project-detail-skeleton.tsx
@@ -14,7 +14,7 @@ export function BoardProjectDetailSkeleton() {
         </Box>
         <Box borderWidth="1px" borderRadius="md" p={4}>
           <VStack align="stretch" gap={3}>
-            {Array.from({ length: 3 }).map((_, i) => (
+            {Array.from({ length: 4 }).map((_, i) => (
               <HStack key={i} justify="space-between">
                 <Skeleton height="16px" width="100px" />
                 <Skeleton height="16px" width="150px" />
@@ -23,13 +23,15 @@ export function BoardProjectDetailSkeleton() {
           </VStack>
         </Box>
         <Box>
-          <Heading size="md" mb={4}>Recent Runs</Heading>
+          <Heading size="md" mb={3}>Recent Runs</Heading>
           <Table.Root size="sm" variant="outline">
             <Table.Header>
               <Table.Row>
                 <Table.ColumnHeader>Status</Table.ColumnHeader>
                 <Table.ColumnHeader>Commit</Table.ColumnHeader>
                 <Table.ColumnHeader>Branch</Table.ColumnHeader>
+                <Table.ColumnHeader>ERC</Table.ColumnHeader>
+                <Table.ColumnHeader>DRC</Table.ColumnHeader>
                 <Table.ColumnHeader>Created</Table.ColumnHeader>
               </Table.Row>
             </Table.Header>
@@ -39,6 +41,8 @@ export function BoardProjectDetailSkeleton() {
                   <Table.Cell><Skeleton height="20px" width="80px" /></Table.Cell>
                   <Table.Cell><Skeleton height="20px" width="70px" /></Table.Cell>
                   <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="60px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="60px" /></Table.Cell>
                   <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
                 </Table.Row>
               ))}

--- a/boardflow/src/components/skeletons/repositories-table-skeleton.tsx
+++ b/boardflow/src/components/skeletons/repositories-table-skeleton.tsx
@@ -1,0 +1,29 @@
+import { Box, Heading, Table, Skeleton } from "@chakra-ui/react"
+
+export function RepositoriesTableSkeleton() {
+  return (
+    <Box>
+      <Heading size="lg" mb={6}>Repositories</Heading>
+      <Table.Root size="sm" variant="outline">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>Repository</Table.ColumnHeader>
+            <Table.ColumnHeader>Projects</Table.ColumnHeader>
+            <Table.ColumnHeader>Latest Status</Table.ColumnHeader>
+            <Table.ColumnHeader>Updated</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Table.Row key={i}>
+              <Table.Cell><Skeleton height="20px" width="200px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="30px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="80px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  )
+}

--- a/boardflow/src/components/skeletons/repository-detail-skeleton.tsx
+++ b/boardflow/src/components/skeletons/repository-detail-skeleton.tsx
@@ -15,6 +15,13 @@ export function RepositoryDetailSkeleton() {
           </HStack>
         </Box>
         <Box>
+          <Heading size="md" mb={4}>Settings</Heading>
+          <HStack gap={2}>
+            <Skeleton height="16px" width="16px" />
+            <Skeleton height="16px" width="100px" />
+          </HStack>
+        </Box>
+        <Box>
           <Heading size="md" mb={4}>Board Projects</Heading>
           <Table.Root size="sm" variant="outline">
             <Table.Header>

--- a/boardflow/src/components/skeletons/repository-detail-skeleton.tsx
+++ b/boardflow/src/components/skeletons/repository-detail-skeleton.tsx
@@ -1,0 +1,43 @@
+import { Box, Heading, VStack, HStack, Skeleton, Table } from "@chakra-ui/react"
+
+export function RepositoryDetailSkeleton() {
+  return (
+    <Box>
+      <Skeleton height="20px" width="200px" mb={4} />
+      <VStack align="stretch" gap={6}>
+        <Box>
+          <HStack gap={2} mb={1}>
+            <Skeleton height="32px" width="250px" />
+          </HStack>
+          <HStack gap={4}>
+            <Skeleton height="16px" width="80px" />
+            <Skeleton height="16px" width="120px" />
+          </HStack>
+        </Box>
+        <Box>
+          <Heading size="md" mb={4}>Board Projects</Heading>
+          <Table.Root size="sm" variant="outline">
+            <Table.Header>
+              <Table.Row>
+                <Table.ColumnHeader>Project</Table.ColumnHeader>
+                <Table.ColumnHeader>State</Table.ColumnHeader>
+                <Table.ColumnHeader>Path</Table.ColumnHeader>
+                <Table.ColumnHeader>Updated</Table.ColumnHeader>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Table.Row key={i}>
+                  <Table.Cell><Skeleton height="20px" width="150px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="80px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="180px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
+        </Box>
+      </VStack>
+    </Box>
+  )
+}

--- a/boardflow/src/components/skeletons/run-detail-skeleton.tsx
+++ b/boardflow/src/components/skeletons/run-detail-skeleton.tsx
@@ -1,0 +1,36 @@
+import { Box, VStack, HStack, Skeleton } from "@chakra-ui/react"
+
+export function RunDetailSkeleton() {
+  return (
+    <Box>
+      <Skeleton height="20px" width="400px" mb={4} />
+      <VStack align="stretch" gap={6}>
+        <Box>
+          <HStack gap={2} mb={1}>
+            <Skeleton height="32px" width="150px" />
+            <Skeleton height="24px" width="80px" />
+          </HStack>
+          <HStack gap={4}>
+            <Skeleton height="16px" width="100px" />
+            <Skeleton height="16px" width="80px" />
+            <Skeleton height="16px" width="120px" />
+          </HStack>
+        </Box>
+        <Box borderWidth="1px" borderRadius="md" p={4}>
+          <VStack align="stretch" gap={3}>
+            {Array.from({ length: 4 }).map((_, i) => (
+              <HStack key={i} justify="space-between">
+                <Skeleton height="16px" width="120px" />
+                <Skeleton height="16px" width="150px" />
+              </HStack>
+            ))}
+          </VStack>
+        </Box>
+        <Box>
+          <Skeleton height="24px" width="120px" mb={4} />
+          <Skeleton height="200px" width="100%" />
+        </Box>
+      </VStack>
+    </Box>
+  )
+}

--- a/boardflow/src/components/skeletons/run-detail-skeleton.tsx
+++ b/boardflow/src/components/skeletons/run-detail-skeleton.tsx
@@ -1,34 +1,68 @@
-import { Box, VStack, HStack, Skeleton } from "@chakra-ui/react"
+import { Box, VStack, HStack, Skeleton, Heading, Table } from "@chakra-ui/react"
 
 export function RunDetailSkeleton() {
   return (
     <Box>
       <Skeleton height="20px" width="400px" mb={4} />
       <VStack align="stretch" gap={6}>
+        {/* Header */}
         <Box>
-          <HStack gap={2} mb={1}>
+          <HStack gap={3} mb={2}>
             <Skeleton height="32px" width="150px" />
             <Skeleton height="24px" width="80px" />
           </HStack>
           <HStack gap={4}>
-            <Skeleton height="16px" width="100px" />
+            <Skeleton height="16px" width="70px" />
             <Skeleton height="16px" width="80px" />
             <Skeleton height="16px" width="120px" />
           </HStack>
         </Box>
-        <Box borderWidth="1px" borderRadius="md" p={4}>
-          <VStack align="stretch" gap={3}>
-            {Array.from({ length: 4 }).map((_, i) => (
-              <HStack key={i} justify="space-between">
-                <Skeleton height="16px" width="120px" />
-                <Skeleton height="16px" width="150px" />
-              </HStack>
-            ))}
-          </VStack>
-        </Box>
+        {/* Checks */}
         <Box>
-          <Skeleton height="24px" width="120px" mb={4} />
-          <Skeleton height="200px" width="100%" />
+          <Heading size="md" mb={3}>Checks</Heading>
+          <HStack gap={4}>
+            {Array.from({ length: 2 }).map((_, i) => (
+              <Box key={i} borderWidth="1px" borderRadius="md" p={4} minW="200px">
+                <HStack justify="space-between" mb={2}>
+                  <Skeleton height="16px" width="50px" />
+                  <Skeleton height="20px" width="60px" />
+                </HStack>
+                <Skeleton height="14px" width="100px" />
+              </Box>
+            ))}
+          </HStack>
+        </Box>
+        {/* Artifact Summary */}
+        <Box>
+          <Heading size="md" mb={3}>Artifact Summary</Heading>
+          <HStack gap={4}>
+            <Skeleton height="20px" width="100px" />
+            <Skeleton height="20px" width="80px" />
+          </HStack>
+        </Box>
+        {/* Artifacts Table */}
+        <Box>
+          <Heading size="md" mb={3}>Artifacts</Heading>
+          <Table.Root size="sm" variant="outline">
+            <Table.Header>
+              <Table.Row>
+                <Table.ColumnHeader>Type</Table.ColumnHeader>
+                <Table.ColumnHeader>Status</Table.ColumnHeader>
+                <Table.ColumnHeader>Filename</Table.ColumnHeader>
+                <Table.ColumnHeader>Size</Table.ColumnHeader>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {Array.from({ length: 4 }).map((_, i) => (
+                <Table.Row key={i}>
+                  <Table.Cell><Skeleton height="20px" width="80px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="70px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="150px" /></Table.Cell>
+                  <Table.Cell><Skeleton height="20px" width="60px" /></Table.Cell>
+                </Table.Row>
+              ))}
+            </Table.Body>
+          </Table.Root>
         </Box>
       </VStack>
     </Box>

--- a/boardflow/src/components/skeletons/runs-table-skeleton.tsx
+++ b/boardflow/src/components/skeletons/runs-table-skeleton.tsx
@@ -1,0 +1,34 @@
+import { Box, Heading, Skeleton, Table } from "@chakra-ui/react"
+
+export function RunsTableSkeleton() {
+  return (
+    <Box>
+      <Skeleton height="20px" width="300px" mb={4} />
+      <Heading size="lg" mb={6}>Runs</Heading>
+      <Table.Root size="sm" variant="outline">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>Status</Table.ColumnHeader>
+            <Table.ColumnHeader>Commit</Table.ColumnHeader>
+            <Table.ColumnHeader>Branch</Table.ColumnHeader>
+            <Table.ColumnHeader>ERC</Table.ColumnHeader>
+            <Table.ColumnHeader>DRC</Table.ColumnHeader>
+            <Table.ColumnHeader>Created</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Table.Row key={i}>
+              <Table.Cell><Skeleton height="20px" width="80px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="70px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="60px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="60px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  )
+}

--- a/docs/external/chakra-ui-v3-skeleton.md
+++ b/docs/external/chakra-ui-v3-skeleton.md
@@ -1,0 +1,154 @@
+# Chakra UI v3 Skeleton コンポーネント
+
+Issue: #65
+
+## 要約
+
+Chakra UI v3 (`@chakra-ui/react` ^3.35.0) は `Skeleton`, `SkeletonCircle`, `SkeletonText` の3コンポーネントを提供する。v2 から移植され、v3 では `loading` prop による表示切替と `variant` prop (`pulse` / `shine` / `none`) が追加された。
+
+## 確認した情報
+
+### 1. インポートと基本コンポーネント
+
+```tsx
+import { Skeleton, SkeletonCircle, SkeletonText } from "@chakra-ui/react"
+```
+
+| コンポーネント | 用途 |
+|---|---|
+| `Skeleton` | 汎用の矩形プレースホルダー。`height`, `width` で形状を指定 |
+| `SkeletonCircle` | 円形プレースホルダー。アバターやアイコン向け。`size` で直径指定 |
+| `SkeletonText` | テキスト行のプレースホルダー。`noOfLines` で行数を指定 |
+
+### 2. Props
+
+| Prop | デフォルト | 値 | 説明 |
+|---|---|---|---|
+| `loading` | `true` | `true` / `false` | `true` でスケルトン表示、`false` で子要素をフェードイン表示 |
+| `variant` | `pulse` | `pulse` / `shine` / `none` | アニメーションの種類 |
+| `colorPalette` | `gray` | Chakra のカラーパレット名 | スケルトンの色 |
+| `as` | - | `React.ElementType` | 基底要素を変更 |
+| `asChild` | - | `boolean` | 子要素に props をマージ |
+
+`SkeletonText` 固有:
+| Prop | 説明 |
+|---|---|
+| `noOfLines` | 表示するテキスト行の数 |
+
+### 3. 使用パターン
+
+#### フィード型スケルトン（リスト・カード用）
+
+```tsx
+<Stack gap="6" maxW="xs">
+  <HStack width="full">
+    <SkeletonCircle size="10" />
+    <SkeletonText noOfLines={2} />
+  </HStack>
+  <Skeleton height="200px" />
+</Stack>
+```
+
+#### `loading` prop による切替（条件付き表示）
+
+```tsx
+<Skeleton loading={isLoading}>
+  <Text>実際のコンテンツ</Text>
+</Skeleton>
+```
+
+`loading` が `false` になると子要素がフェードインで表示される。
+
+#### テーブル用スケルトン
+
+```tsx
+<Table.Root>
+  <Table.Header>
+    <Table.Row>
+      <Table.ColumnHeader>Name</Table.ColumnHeader>
+      <Table.ColumnHeader>Status</Table.ColumnHeader>
+    </Table.Row>
+  </Table.Header>
+  <Table.Body>
+    {Array.from({ length: 5 }).map((_, i) => (
+      <Table.Row key={i}>
+        <Table.Cell>
+          <Skeleton height="20px" />
+        </Table.Cell>
+        <Table.Cell>
+          <Skeleton height="20px" width="80px" />
+        </Table.Cell>
+      </Table.Row>
+    ))}
+  </Table.Body>
+</Table.Root>
+```
+
+#### カード型スケルトン
+
+```tsx
+<Box borderWidth="1px" borderRadius="lg" p={4}>
+  <HStack mb={4}>
+    <SkeletonCircle size="10" />
+    <Stack flex="1">
+      <SkeletonText noOfLines={1} />
+      <SkeletonText noOfLines={1} />
+    </Stack>
+  </HStack>
+  <Skeleton height="150px" />
+</Box>
+```
+
+### 4. variant のアニメーション
+
+- **`pulse`（デフォルト）**: 不透明度が点滅するパルスアニメーション
+- **`shine`**: 左から右へ光が走るシマーアニメーション
+- **`none`**: アニメーションなし（静的なプレースホルダー）
+
+### 5. カスタムカラー
+
+CSS 変数で開始色・終了色を変更可能:
+
+```tsx
+<Skeleton
+  height="20px"
+  css={{
+    "--start-color": "colors.pink.100",
+    "--end-color": "colors.pink.400",
+  }}
+/>
+```
+
+## BoardFlow への示唆
+
+### 推奨するスケルトンUI
+
+| 画面 | スケルトン構成 |
+|---|---|
+| リポジトリ一覧（テーブル） | `Table.Root` + 行ごとに `Skeleton` × カラム数 |
+| ボードプロジェクト詳細 | カードレイアウトの各セクションに `Skeleton` + `SkeletonText` |
+| ラン一覧 | テーブル行スケルトン |
+| ラン詳細 | ヘッダー情報は `SkeletonText`、artifact グリッドは `Skeleton` |
+
+### 実装方針
+
+1. **再利用コンポーネントとして作成**: `components/skeleton/` に `TableSkeleton`, `CardSkeleton` 等の共通スケルトンを用意
+2. **`loading` prop パターンを活用**: TanStack Query の `isLoading` 状態と組み合わせて `<Skeleton loading={isLoading}>` で実際のコンテンツをラップ
+3. **`loading.tsx` ではシンプルなスケルトン**: ページ全体のスケルトンは `loading.tsx` に配置
+4. **CLS 対策**: スケルトンの高さ・幅を実際のコンテンツに合わせて設計
+
+## 採用/不採用判断
+
+**採用**: Chakra UI v3 にビルトインで含まれており、追加パッケージ不要。`@chakra-ui/react` から直接インポート可能。
+
+## 制約と pitfall
+
+1. **Client Component 必須**: Chakra UI コンポーネント全般と同様、`'use client'` が必要
+2. **`loading.tsx` での使用**: `loading.tsx` はデフォルトで Server Component だが、`'use client'` を付けるか、Skeleton を Client Component に切り出して使う
+3. **`noOfLines` の高さ予測**: `SkeletonText` の `noOfLines` は実際のテキスト行数と一致させないと CLS が発生する
+4. **アニメーションパフォーマンス**: `pulse` は CSS animation ベースで軽量。`shine` は若干重いが実用上問題なし
+
+## 参照URL
+
+- https://chakra-ui.com/docs/components/skeleton （公式 v3 ドキュメント）
+- https://github.com/chakra-ui/chakra-ui/tree/main/packages/react/src/components/skeleton （ソースコード）

--- a/docs/external/chakra-ui-v3-skeleton.md
+++ b/docs/external/chakra-ui-v3-skeleton.md
@@ -143,8 +143,8 @@ CSS 変数で開始色・終了色を変更可能:
 
 ## 制約と pitfall
 
-1. **Client Component 必須**: Chakra UI コンポーネント全般と同様、`'use client'` が必要
-2. **`loading.tsx` での使用**: `loading.tsx` はデフォルトで Server Component だが、`'use client'` を付けるか、Skeleton を Client Component に切り出して使う
+1. **Server Component でも使用可能**: Chakra UI v3 の Skeleton コンポーネントは Server Component からも利用できる。`loading.tsx` で直接 `<Skeleton>` を返すことが可能
+2. **`loading.tsx` での使用**: `loading.tsx` はデフォルトで Server Component であり、Skeleton コンポーネントをそのまま使用できる
 3. **`noOfLines` の高さ予測**: `SkeletonText` の `noOfLines` は実際のテキスト行数と一致させないと CLS が発生する
 4. **アニメーションパフォーマンス**: `pulse` は CSS animation ベースで軽量。`shine` は若干重いが実用上問題なし
 

--- a/docs/external/nextjs-streaming-ssr-loading.md
+++ b/docs/external/nextjs-streaming-ssr-loading.md
@@ -1,0 +1,205 @@
+# Next.js 15 App Router Streaming SSR と loading.tsx
+
+Issue: #65
+
+## 要約
+
+Next.js App Router は React Suspense をベースとした Streaming SSR をネイティブサポートする。`loading.tsx` によるページレベルのストリーミングと、手動 `<Suspense>` による粒度の細かいストリーミングの2つのアプローチがある。`loading.tsx` は該当ディレクトリの `page.tsx` を自動的に `<Suspense>` でラップする簡便な仕組み。
+
+## 確認した情報
+
+### 1. loading.tsx の仕組み
+
+`loading.tsx` を `page.tsx` と同じディレクトリに配置すると、Next.js がそのページを自動的に `<Suspense>` でラップする。
+
+```
+app/
+  dashboard/
+    layout.tsx     ← すぐに表示される
+    loading.tsx    ← page.tsx が読み込み中に表示される
+    page.tsx       ← 非同期処理が完了すると表示
+```
+
+コンポーネント階層:
+
+```
+<Layout>
+  <Suspense fallback={<Loading />}>
+    <Page />
+  </Suspense>
+</Layout>
+```
+
+**重要な挙動:**
+- `loading.tsx` は `layout.tsx` の内側、`page.tsx` の外側に配置される
+- `layout.tsx` は `loading.tsx` でラップされない（layout はすぐに表示）
+- ナビゲーション時に fallback UI がプリフェッチされるため即時表示
+- デフォルトは Server Component だが `'use client'` を付けても可
+- `not-found.tsx`, `page.tsx`, ネストされた `layout.tsx` を `<Suspense>` でラップする
+
+### 2. 手動 `<Suspense>` による粒度制御
+
+#### 並列ストリーミング（sibling boundaries）
+
+```tsx
+import { Suspense } from 'react'
+
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <div className="grid grid-cols-2 gap-4">
+        <Suspense fallback={<p>Loading revenue...</p>}>
+          <Revenue />
+        </Suspense>
+        <Suspense fallback={<p>Loading orders...</p>}>
+          <RecentOrders />
+        </Suspense>
+      </div>
+    </div>
+  )
+}
+```
+
+各 `<Suspense>` 境界は独立してストリームする。Revenue が 200ms、Orders が 1s で解決される場合、Revenue が先に表示される。
+
+#### ネストされた境界（progressive detail）
+
+```tsx
+<Suspense fallback={<p>Loading product details...</p>}>
+  <ProductDetails id={id} />
+  <Suspense fallback={<p>Loading reviews...</p>}>
+    <Reviews productId={id} />
+  </Suspense>
+</Suspense>
+```
+
+外側が先に解決 → 内側の fallback が見える → 内側も解決という段階的な表示。
+
+### 3. loading.tsx と `<Suspense>` の使い分け
+
+| 観点 | `loading.tsx` | `<Suspense>` |
+|---|---|---|
+| スコープ | ページ全体 | 任意のコンポーネント |
+| セットアップ | ファイル配置のみ | コンポーネントを明示的にラップ |
+| ナビゲーション | fallback がプリフェッチされ即時表示 | デフォルトではプリフェッチされない |
+| 適用場面 | データなしでは何も表示できないページ | ほとんどのページ。粒度の細かい制御向き |
+
+**公式推奨**: 明示的な `<Suspense>` 境界を動的データアクセスの近くに配置することを推奨。`loading.tsx` をツリーの上位に置くとページ全体がスケルトンになり、粒度が粗くなる。
+
+### 4. 動的アクセスを下位に押し下げるパターン
+
+```tsx
+export default function DashboardLayout({ children }) {
+  const cookieStore = cookies() // await しない
+  return (
+    <div>
+      <Nav>
+        <Suspense fallback={<p>Loading user...</p>}>
+          <UserMenu cookiePromise={cookieStore} />
+        </Suspense>
+      </Nav>
+      {children}
+    </div>
+  )
+}
+```
+
+`cookies()` を `await` せずに Promise のまま渡すことで、layout の他の部分は static shell として即座にレンダリングされる。
+
+### 5. サーバーからクライアントへのデータストリーミング
+
+Server Component で fetch を開始し、未解決の Promise を Client Component に渡す:
+
+```tsx
+// Server Component (page.tsx)
+export default function Dashboard() {
+  const statsPromise = getStats() // await しない
+  return (
+    <Suspense fallback={<p>Loading chart...</p>}>
+      <StatsChart dataPromise={statsPromise} />
+    </Suspense>
+  )
+}
+
+// Client Component
+'use client'
+import { use } from 'react'
+export function StatsChart({ dataPromise }) {
+  const stats = use(dataPromise)
+  return <div>{/* render chart */}</div>
+}
+```
+
+### 6. エラーハンドリング
+
+- ストリーミング開始後にコンポーネントがエラーをスローすると、最も近い `error.tsx` 境界がキャッチ
+- 失敗したセクションだけがエラー UI に置き換わり、残りのページは影響を受けない
+- HTTP ステータスコードは `200 OK` のまま変更不可（ヘッダーは最初のチャンクで送信済み）
+
+### 7. SEO への影響
+
+- ストリーミングはサーバーレンダリングなので SEO に影響しない
+- HTML限定のボット（Twitterbot等）には `generateMetadata` がストリーミング前に解決される
+- フルブラウザ対応のクローラーにはメタデータもストリーミング可能
+- `notFound()` がミッドストリームで呼ばれた場合、`<meta name="robots" content="noindex">` が注入される
+
+### 8. Web Vitals への効果
+
+| 指標 | 効果 |
+|---|---|
+| TTFB | 最も遅いクエリではなく、static shell の生成時間まで短縮 |
+| FCP | ブラウザが static shell を即座に描画 |
+| LCP | LCP 要素を Suspense 境界の外側に配置すれば高速 |
+| CLS | スケルトン fallback の寸法を実コンテンツと合わせれば回避可能 |
+| INP | 選択的ハイドレーションにより、各 Suspense 境界が独立してハイドレート |
+
+### 9. インフラ考慮事項
+
+- リバースプロキシ（Nginx等）: `X-Accel-Buffering: no` ヘッダーが必要
+- CDN: チャンクドレスポンスのパススルー設定が必要な場合あり
+- サーバレス: AWS Lambda は response streaming mode の明示的有効化が必要
+- 圧縮: gzip/brotli がチャンクをバッファリングする場合あり
+- Safari/WebKit: 1024バイト未満のレスポンスをバッファリング
+
+## BoardFlow への示唆
+
+### 推奨戦略
+
+1. **`loading.tsx` を各ルートセグメントに配置**: 最低限のローディングUI保証として
+   - `app/repositories/loading.tsx` — リポジトリ一覧用
+   - `app/repositories/[repositoryId]/loading.tsx` — リポジトリ詳細用
+   - `app/repositories/[repositoryId]/boards/[boardProjectId]/loading.tsx`
+   - `app/repositories/[repositoryId]/boards/[boardProjectId]/runs/loading.tsx`
+   - `app/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]/loading.tsx`
+
+2. **粒度の細かい `<Suspense>` を追加**: ページ内で独立して読み込めるセクションに
+   - ラン詳細ページ: ヘッダー情報 / artifact グリッド / diff セクションを独立した Suspense 境界に
+   - ボードプロジェクト詳細: プロジェクト情報 / 最近のラン一覧を独立に
+
+3. **TanStack Query の prefetch (await なし) + useSuspenseQuery パターンとの組み合わせ**:
+   - Server Component で `queryClient.prefetchQuery(...)` を await せずに呼ぶ
+   - Client Component で `useSuspenseQuery` を使う
+   - `<Suspense>` の fallback にスケルトン UI を配置
+
+### VPS デプロイでの考慮
+
+- BoardFlow は VPS デプロイ（Node.js サーバー）のため、ストリーミングはネイティブサポート
+- Nginx をリバースプロキシに使う場合は `X-Accel-Buffering: no` の設定が必要
+
+## 採用/不採用判断
+
+**採用**: Next.js App Router の標準機能であり、追加パッケージ不要。`loading.tsx` は最小限のボイラープレートで即座に効果が得られる。
+
+## 制約と pitfall
+
+1. **layout での `await`**: layout で `cookies()` や `headers()` を `await` すると、`loading.tsx` の fallback が表示されない。動的アクセスは下位コンポーネントに押し下げるか `<Suspense>` でラップする
+2. **HTTP ステータスコード**: ストリーミング開始後はステータスコード変更不可。404 を正しく返すには Suspense 境界の前で `notFound()` を呼ぶ
+3. **CLS リスク**: スケルトンと実コンテンツの寸法が異なるとレイアウトシフトが発生
+4. **LCP 要素の配置**: LCP 要素（メインヘッダーなど）を Suspense 境界の外側に置かないと LCP が遅延
+5. **ブラウザバッファリング**: Safari は 1024 バイト未満のレスポンスをバッファリングするが、実アプリでは通常問題にならない
+
+## 参照URL
+
+- https://nextjs.org/docs/app/api-reference/file-conventions/loading （loading.js API リファレンス）
+- https://nextjs.org/docs/app/guides/streaming （Next.js Streaming ガイド — 2026-04-10 更新）

--- a/docs/external/tanstack-query-v5-suspense.md
+++ b/docs/external/tanstack-query-v5-suspense.md
@@ -245,13 +245,12 @@ export default function Error({ error, reset }) {
 }
 ```
 
-### 必要な追加パッケージ
+### エラーハンドリングの選択肢
 
-```bash
-pnpm add react-error-boundary
-```
+- `react-error-boundary` パッケージ: `QueryErrorResetBoundary` と組み合わせてカスタムリトライUIを実現可能
+- Next.js `error.tsx`: 追加パッケージ不要で基本的なエラーハンドリングが可能
 
-`react-error-boundary` は `QueryErrorResetBoundary` と組み合わせてリトライUIを実現するために使用。ただし、Next.js の `error.tsx` で基本的なエラーハンドリングは可能なため、MVP では `error.tsx` のみで十分。
+BoardFlow では Next.js の `error.tsx` + `useQueryErrorResetBoundary` フックを採用し、追加パッケージなしで Query エラー状態のリセットを実現している。
 
 ## 採用/不採用判断
 

--- a/docs/external/tanstack-query-v5-suspense.md
+++ b/docs/external/tanstack-query-v5-suspense.md
@@ -1,0 +1,282 @@
+# TanStack Query v5 useSuspenseQuery と Suspense モード
+
+Issue: #65
+
+## 要約
+
+TanStack Query v5 は `useSuspenseQuery` フックを提供し、React Suspense と統合したデータフェッチを実現する。Next.js App Router の Streaming SSR と組み合わせる場合、Server Component で `prefetchQuery`（await なし）→ Client Component で `useSuspenseQuery` のパターンが推奨される。`openapi-react-query` も `$api.useSuspenseQuery()` を提供しており、BoardFlow の既存アーキテクチャに自然に統合可能。
+
+## 確認した情報
+
+### 1. useSuspenseQuery の基本
+
+```tsx
+'use client'
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+function Posts() {
+  const { data } = useSuspenseQuery({
+    queryKey: ['posts'],
+    queryFn: getPosts,
+  })
+  // data は undefined にならない（Suspense がローディングを処理）
+  return <ul>{data.map(post => <li key={post.id}>{post.title}</li>)}</ul>
+}
+```
+
+**通常の `useQuery` との違い:**
+
+| 観点 | `useQuery` | `useSuspenseQuery` |
+|---|---|---|
+| `data` の型 | `TData | undefined` | `TData`（undefined なし） |
+| ローディング処理 | `isLoading` で手動判定 | React `<Suspense>` に委譲 |
+| エラー処理 | `error` で手動判定 | `<ErrorBoundary>` に委譲 |
+| `enabled` オプション | 使用可 | **使用不可** |
+| `placeholderData` | 使用可 | **使用不可** |
+
+### 2. Next.js App Router + Streaming SSR パターン
+
+#### Server Component（await なし prefetch）
+
+```tsx
+// app/posts/page.tsx (Server Component)
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query'
+import { getQueryClient } from '@/lib/query-client'
+import { Suspense } from 'react'
+
+export default function PostsPage() {
+  const queryClient = getQueryClient()
+
+  // await しない — streaming で結果が到着次第 Client Component に反映
+  queryClient.prefetchQuery({
+    queryKey: ['posts'],
+    queryFn: getPosts,
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<PostsSkeleton />}>
+        <PostsList />
+      </Suspense>
+    </HydrationBoundary>
+  )
+}
+```
+
+#### Client Component（useSuspenseQuery）
+
+```tsx
+// app/posts/posts-list.tsx
+'use client'
+import { useSuspenseQuery } from '@tanstack/react-query'
+
+export function PostsList() {
+  const { data } = useSuspenseQuery({
+    queryKey: ['posts'],
+    queryFn: getPosts,
+  })
+  return <ul>{data.map(/* ... */)}</ul>
+}
+```
+
+**重要: QueryClient のデフォルト設定に pending クエリの dehydrate を含める必要がある:**
+
+```ts
+import { defaultShouldDehydrateQuery } from '@tanstack/react-query'
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 1000,
+      },
+      dehydrate: {
+        shouldDehydrateQuery: (query) =>
+          defaultShouldDehydrateQuery(query) ||
+          query.state.status === 'pending',
+      },
+    },
+  })
+}
+```
+
+### 3. openapi-react-query との統合
+
+`openapi-react-query` は `$api.useSuspenseQuery()` を提供:
+
+```tsx
+// Server Component
+const queryClient = getQueryClient()
+queryClient.prefetchQuery(
+  $api.queryOptions("get", "/api/v1/repositories")
+)
+
+// Client Component
+'use client'
+const { data } = $api.useSuspenseQuery("get", "/api/v1/repositories")
+```
+
+### 4. エラーハンドリング
+
+#### throwOnError のデフォルト挙動
+
+`useSuspenseQuery` の `throwOnError` デフォルト:
+
+```ts
+throwOnError: (error, query) => typeof query.state.data === 'undefined'
+```
+
+- **キャッシュにデータがある場合**: エラーをスローしない（stale データを表示）
+- **キャッシュにデータがない場合**: Error Boundary にエラーをスロー
+
+#### すべてのエラーを Error Boundary で処理したい場合
+
+```tsx
+const { data, error, isFetching } = useSuspenseQuery({ queryKey, queryFn })
+
+if (error && !isFetching) {
+  throw error
+}
+```
+
+#### QueryErrorResetBoundary パターン（リトライ）
+
+```tsx
+import { QueryErrorResetBoundary } from '@tanstack/react-query'
+import { ErrorBoundary } from 'react-error-boundary'
+
+function App() {
+  return (
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallbackRender={({ resetErrorBoundary }) => (
+            <div>
+              エラーが発生しました
+              <button onClick={resetErrorBoundary}>再試行</button>
+            </div>
+          )}
+        >
+          <Page />
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
+  )
+}
+```
+
+### 5. prefetch 漏れ時の挙動
+
+`useSuspenseQuery` で prefetch し忘れた場合の影響:
+
+- **Next.js App Router**: サーバー側で Suspend → サーバーでフェッチされるが、クライアントに hydrate されず、クライアントで再フェッチが発生
+- **結果**: hydration mismatch の警告が出る可能性
+- **対策**: 必ず Server Component で `prefetchQuery` を呼ぶ
+
+### 6. Fetch-on-render vs Render-as-you-fetch
+
+| パターン | 説明 | 推奨度 |
+|---|---|---|
+| Fetch-on-render | コンポーネントマウント時に fetch | `useSuspenseQuery` 単体。ウォーターフォール発生のリスク |
+| Render-as-you-fetch | ルーティング時に prefetch 開始 | **推奨**。Server Component で prefetch + `useSuspenseQuery` |
+
+TanStack Query 公式ドキュメントは「prefetch on routing callbacks」を推奨しており、Next.js App Router の Server Component での prefetch がこれに相当する。
+
+### 7. `@tanstack/react-query-next-experimental` について
+
+`ReactQueryStreamedHydration` を使うと、prefetch なしで Client Component の `useSuspenseQuery` だけで streaming SSR が実現できるパッケージ。
+
+**BoardFlow では不採用（既存判断を踏襲）:**
+- DX は良いが、ページナビゲーション時にリクエストウォーターフォールが発生
+- 公式でも prefetch パターンを推奨
+- 既存の `docs/external/tanstack-query-nextjs-app-router.md` で不採用判断済み
+
+### 8. useQuery vs useSuspenseQuery の選択基準
+
+| シナリオ | 推奨フック |
+|---|---|
+| Server Component で prefetch + streaming | `useSuspenseQuery` |
+| 条件付きフェッチ（`enabled` が必要） | `useQuery` |
+| placeholderData が必要 | `useQuery` |
+| インタラクション起因のフェッチ | `useQuery` |
+| ページ初期表示データ | `useSuspenseQuery` |
+
+## BoardFlow への示唆
+
+### 推奨する段階的レンダリング設計
+
+```
+Server Component (page.tsx)
+├── prefetchQuery (await なし) × 複数
+├── HydrationBoundary
+│   ├── <Suspense fallback={<HeaderSkeleton />}>
+│   │   └── HeaderSection (useSuspenseQuery)
+│   ├── <Suspense fallback={<TableSkeleton />}>
+│   │   └── DataTable (useSuspenseQuery)
+│   └── <Suspense fallback={<DetailSkeleton />}>
+│       └── DetailSection (useSuspenseQuery)
+```
+
+### ページ別の推奨パターン
+
+| ページ | パターン |
+|---|---|
+| リポジトリ一覧 | `loading.tsx` で十分（単一データソース） |
+| リポジトリ詳細 | `loading.tsx` + 将来的に `<Suspense>` でセクション分割 |
+| ボードプロジェクト詳細 | `<Suspense>` でプロジェクト情報 / ラン一覧を分割 |
+| ラン詳細 | `<Suspense>` でヘッダー / artifact / diff を分割 |
+| ラン一覧 | `loading.tsx` で十分（単一テーブル） |
+
+### error.tsx の導入
+
+`useSuspenseQuery` のエラーは Error Boundary で処理するため、各ルートセグメントに `error.tsx` を配置:
+
+```tsx
+// app/repositories/error.tsx
+'use client'
+export default function Error({ error, reset }) {
+  return (
+    <div>
+      <p>データの読み込みに失敗しました</p>
+      <button onClick={reset}>再試行</button>
+    </div>
+  )
+}
+```
+
+### 必要な追加パッケージ
+
+```bash
+pnpm add react-error-boundary
+```
+
+`react-error-boundary` は `QueryErrorResetBoundary` と組み合わせてリトライUIを実現するために使用。ただし、Next.js の `error.tsx` で基本的なエラーハンドリングは可能なため、MVP では `error.tsx` のみで十分。
+
+## 採用/不採用判断
+
+| 技術 | 判断 | 理由 |
+|---|---|---|
+| `useSuspenseQuery` | **採用** | `<Suspense>` + streaming SSR に必要。`data` が undefined にならない型安全性 |
+| `$api.useSuspenseQuery()` | **採用** | openapi-react-query が提供。型安全な API 呼び出しを維持 |
+| `react-error-boundary` | **MVP では不要** | Next.js の `error.tsx` で基本機能は十分 |
+| `@tanstack/react-query-next-experimental` | **不採用** | ウォーターフォール問題。prefetch パターンが推奨 |
+
+## 制約と pitfall
+
+1. **prefetch 漏れ**: `useSuspenseQuery` を使うのに Server Component で `prefetchQuery` を忘れると、hydration mismatch や二重フェッチが発生
+2. **`enabled` 非対応**: `useSuspenseQuery` は `enabled` オプションを受け付けない。条件付きフェッチが必要な場合は `useQuery` を使う
+3. **エラー時の stale データ**: キャッシュにデータがある場合、デフォルトでエラーをスローしない。古いデータが表示される
+4. **Suspense 境界の粒度**: 粗すぎると全体がスケルトンに、細かすぎるとボイラープレートが増える
+5. **dehydrate 設定**: pending クエリの dehydrate を有効にしないと streaming が機能しない（`shouldDehydrateQuery` の設定必須）
+6. **Server/Client の queryFn 不整合**: Server Component の prefetch と Client Component の useSuspenseQuery で異なる fetchClient を使うと Cookie 転送の問題が発生（`docs/external/tanstack-query-nextjs-app-router.md` で既に調査済み）
+
+## 未解決の疑問
+
+- 複数の `useSuspenseQuery` を同一コンポーネントで呼ぶと、直列に suspend する（ウォーターフォール）。`useSuspenseQueries` で並列化するか、コンポーネントを分割して別々の `<Suspense>` に入れるか、プロジェクトの方針を決める必要がある
+
+## 参照URL
+
+- https://tanstack.com/query/v5/docs/framework/react/guides/suspense （公式 Suspense ガイド）
+- https://tanstack.com/query/v5/docs/framework/react/guides/advanced-ssr （公式 Advanced SSR ガイド）
+- https://tanstack.com/query/v5/docs/framework/react/reference/useSuspenseQuery （API リファレンス）

--- a/docs/frontend/summary.md
+++ b/docs/frontend/summary.md
@@ -122,7 +122,7 @@ OpenAPI から TypeScript 型を生成して、画面側の props と API respon
 - Client Component は `$api.useQuery()` を基本形とし、Suspense が必要な箇所では `$api.useSuspenseQuery()` を使用する。queryKey は手動設計しない
 - Repository 一覧のような read 画面は、Server Component で `prefetchQuery`（await なし）し、Client Component で `useSuspenseQuery` + `<Suspense>` boundary で Streaming SSR を実現する
 - 各ルートに `loading.tsx` を配置し、ページナビゲーション時に即座にスケルトンUIを表示する
-- エラー処理は `error.tsx` + `QueryErrorResetBoundary` で Query のエラー状態もリセットする
+- エラー処理は `error.tsx` + `useQueryErrorResetBoundary` で Query のエラー状態もリセットする
 - presigned URL の更新が必要な viewer 系は、通常の API query と分けて `useQuery` + `refetchInterval` で短命 URL を更新する
 - React Query DevTools は開発環境だけで有効化し、本番 UI には含めない
 

--- a/docs/frontend/summary.md
+++ b/docs/frontend/summary.md
@@ -119,8 +119,10 @@ OpenAPI から TypeScript 型を生成して、画面側の props と API respon
 データ取得基盤は `openapi-fetch` を低レベル client とし、その上に TanStack Query v5 + `openapi-react-query` を重ねる。
 
 - Server Component は認証 cookie を forward できる `createServerClient()` で prefetch を行い、`HydrationBoundary` 経由で Client Component に渡す
-- Client Component は `$api.useQuery()` を基本形にして、queryKey を手動設計しない
-- Repository 一覧のような read 画面は、Server Component で prefetch し、描画は Client Component に寄せる
+- Client Component は `$api.useQuery()` を基本形とし、Suspense が必要な箇所では `$api.useSuspenseQuery()` を使用する。queryKey は手動設計しない
+- Repository 一覧のような read 画面は、Server Component で `prefetchQuery`（await なし）し、Client Component で `useSuspenseQuery` + `<Suspense>` boundary で Streaming SSR を実現する
+- 各ルートに `loading.tsx` を配置し、ページナビゲーション時に即座にスケルトンUIを表示する
+- エラー処理は `error.tsx` + `QueryErrorResetBoundary` で Query のエラー状態もリセットする
 - presigned URL の更新が必要な viewer 系は、通常の API query と分けて `useQuery` + `refetchInterval` で短命 URL を更新する
 - React Query DevTools は開発環境だけで有効化し、本番 UI には含めない
 

--- a/docs/logs/65/worklog.md
+++ b/docs/logs/65/worklog.md
@@ -429,3 +429,134 @@ export default async function RepositoriesPage() {
 ### 更新した作業ログパス
 
 `docs/logs/65/worklog.md`
+
+---
+
+## レビュー結果 (2026-05-04)
+
+### フェーズ: Review
+
+#### 対象Issue
+
+- Issue ID: #65
+- タイトル: Streaming SSRとローディングUI実装
+
+#### 調査結果
+
+- 実装差分を確認: `loading.tsx` / `error.tsx` の追加、`RepositoriesList` の `useSuspenseQuery` 化、`/repositories/page.tsx` の `prefetchQuery` 非同期化を確認
+- QueryClient 設定を確認: `shouldDehydrateQuery` で `pending` を dehydration 対象に含めており、Streaming SSR の成立条件は満たしている
+- 外部整合を確認:
+  - Next.js App Router の `loading.tsx` / `error.tsx` の基本挙動と整合
+  - TanStack Query の `prefetchQuery` + `useSuspenseQuery` パターンと整合
+  - Chakra UI v3 Skeleton API の利用自体は妥当
+- 実行検証を再実施:
+  - `pnpm typecheck` ✅
+  - `pnpm lint` ✅
+  - `pnpm build` ✅
+
+#### レビュー結果
+
+**総評**
+
+- `/repositories` の Streaming SSR 化そのものは成立しており、ビルドも通っている
+- ただし、Suspense エラー時の再試行経路と、CLS 配慮をうたうスケルトン近似度、設計ドキュメントの追従に未解決点が残る
+- この状態では `pr_ready: false`
+
+**重大度順の指摘**
+
+1. **中**: Suspense Query のエラー再試行導線が不完全
+   - `RepositoriesList` は `useSuspenseQuery` を利用している一方で、共通 Provider 配下に `QueryErrorResetBoundary` も `useQueryErrorResetBoundary` も導入されていない
+   - `error.tsx` から渡される `reset` をそのまま押しても、TanStack Query 側の query error state を明示的に reset しないため、失敗キャッシュが残ったまま再描画されるリスクがある
+   - 公式ドキュメントでも Suspense 利用時の Error Boundary reset には Query 側の reset 連携が必要とされている
+
+2. **中**: スケルトン UI が実レイアウトを十分に近似しておらず、Issue の CLS 要件とずれている
+   - `RepositoryDetailSkeleton` は実画面に存在する `Settings` セクションを持たず、`Board Projects` テーブルへ直接遷移する構成になっている
+   - `BoardProjectDetailSkeleton` の `Recent Runs` は 4 列構成だが、実画面は `ERC` / `DRC` を含む 6 列構成
+   - `RunDetailSkeleton` は汎用カード 1 つと大きなプレースホルダ中心で、実画面の `Checks`、`Artifact Summary`、`Changes from Baseline`、viewer セクションをほぼ反映していない
+   - loading UI は存在するが、計画で掲げた「寸法を実コンテンツに近似して CLS を最小化」には未達
+
+3. **低**: 実装方針の要約ドキュメントが最新状態に追従していない
+   - `docs/frontend/summary.md` には依然として「Client Component は `$api.useQuery()` を基本形」とあり、今回導入した `useSuspenseQuery` + `loading.tsx` + Streaming SSR の方針が反映されていない
+   - worklog と research は更新されているが、継続開発で参照されやすい要約ドキュメントが古いままになっている
+
+**必須修正**
+
+- `useSuspenseQuery` のエラー再試行経路を整備する
+  - `QueryErrorResetBoundary` または `useQueryErrorResetBoundary` を導入し、`error.tsx` の `reset` と TanStack Query の reset を接続する
+- 各スケルトンを実画面構成に寄せる
+  - 少なくとも、`RepositoryDetailSkeleton` の `Settings`、`BoardProjectDetailSkeleton` の `ERC` / `DRC` 列、`RunDetailSkeleton` の主要セクションを反映する
+
+**任意改善**
+
+- `/repositories/page.tsx` の `prefetchQuery(...)` には `void` を付け、意図的な fire-and-forget をコード上で明示してもよい
+- `RepositoriesList` の `data?.items ?? []` は Suspense 前提では `data.items ?? []` に寄せると意図が読みやすい
+
+**テスト不足**
+
+- API エラー時に `error.tsx` の `Try again` が実際に復旧経路として機能するかの動作確認がない
+- skeleton 表示から実データ表示への遷移で大きなレイアウトシフトが出ないかの確認が手動観点に留まっている
+
+**ドキュメント確認**
+
+- 更新あり:
+  - `docs/external/chakra-ui-v3-skeleton.md`
+  - `docs/external/nextjs-streaming-ssr-loading.md`
+  - `docs/external/tanstack-query-v5-suspense.md`
+  - `docs/logs/65/worklog.md`
+- 更新漏れ候補:
+  - `docs/frontend/summary.md` に Suspense/Streaming SSR 方針の反映が必要
+- `CONTRIBUTING.md` はリポジトリ内に存在せず、確認不可
+
+**plan / research / docs との不整合**
+
+- research では Suspense エラー時に Query reset 連携が必要と整理されているが、実装には反映されていない
+- 計画では CLS を最小化するためのレイアウト近似を受け入れ条件に含めているが、詳細系 skeleton がそこまで到達していない
+- 計画中の「`docs/frontend/summary.md` 追記」は未実施
+
+**PR/完了結果**
+
+- `pr_ready: false`
+
+**残リスク**
+
+- `/repositories` の初回 API 障害時に、ユーザーが `Try again` を押しても即復旧できない可能性がある
+- 詳細ページ群の skeleton は視覚的には表示されるが、実レイアウトとの差分が大きく CLS を誘発する可能性がある
+
+### 更新した作業ログパス
+
+`docs/logs/65/worklog.md`
+
+---
+
+## レビュー修正 (2026-05-04)
+
+### 指摘と修正内容
+
+| # | 指摘 | 修正 |
+|---|---|---|
+| 1 | `QueryErrorResetBoundary` 未導入 | `error-boundary.tsx` に `useQueryErrorResetBoundary` を追加し、`handleReset` で Query リセット → Next.js reset の順に呼ぶよう変更 |
+| 2-1 | `repository-detail-skeleton.tsx` に Settings セクション欠如 | Settings セクション（アイコン + リンクスケルトン）を Board Projects の前に追加 |
+| 2-2 | `board-project-detail-skeleton.tsx` の Recent Runs に ERC/DRC 列がない | テーブルを4列 → 6列（Status, Commit, Branch, ERC, DRC, Created）に修正。メタ情報行も3→4行に |
+| 2-3 | `run-detail-skeleton.tsx` に Checks/Artifact Summary/Artifacts テーブルが欠如 | 全面書き直し: Header + Checks (2カード) + Artifact Summary + Artifacts テーブル(4列4行)構成に |
+| 3 | `docs/frontend/summary.md` のAPI連携セクションが未更新 | `useSuspenseQuery` / Streaming SSR / `loading.tsx` / `QueryErrorResetBoundary` の記述を追加 |
+
+### テスト結果
+
+| チェック | 結果 |
+|---|---|
+| `pnpm typecheck` | ✅ パス |
+| `pnpm lint` | ✅ パス |
+| `pnpm build` | ✅ パス |
+
+### Git
+
+- コミット: `6d2d9ca` — `fix(frontend): address review feedback for #65`
+
+### 残リスク
+
+- 指摘はすべて解消済み
+- Nginx ストリーミング設定 (`X-Accel-Buffering: no`) は本番デプロイ時に別途対応が必要
+
+### 更新した作業ログパス
+
+`docs/logs/65/worklog.md`

--- a/docs/logs/65/worklog.md
+++ b/docs/logs/65/worklog.md
@@ -675,3 +675,31 @@ export default async function RepositoriesPage() {
 ### 更新した作業ログパス
 
 `docs/logs/65/worklog.md`
+
+---
+
+## PR作成完了 (2026-05-04)
+
+### PR情報
+
+- **PR番号**: #71
+- **タイトル**: `feat(frontend): Streaming SSR with loading/error UI`
+- **URL**: https://github.com/f0reachARR/boardflow/pull/71
+- **ベースブランチ**: `main`
+- **ソースブランチ**: `feature/65-streaming-ssr-loading-ui`
+- **Closes**: #65
+
+### コミット一覧
+
+| コミット | 内容 |
+|---|---|
+| `cf34a18` | feat(frontend): add Streaming SSR with loading/error UI (#65) |
+| `7ad7ab6` | docs: update worklog for #65 implementation completion |
+| `869630b` | fix(frontend): address review feedback for #65 |
+| `8eca7ed` | docs: fix documentation inconsistencies for #65 |
+
+### 残リスク
+
+- **notFound() ページの Streaming SSR**: 詳細ページはサーバーサイドで `notFound()` 判定が必要なため、今回は `loading.tsx` でのカバーに留めた。将来的に追加リファクタが必要
+- **CLS 最適化**: スケルトンの寸法は実コンテンツの概算値。実際のデータ量に応じて微調整が必要な可能性あり
+- **Nginx リバースプロキシ**: 本番環境で `X-Accel-Buffering: no` ヘッダーの設定が必要

--- a/docs/logs/65/worklog.md
+++ b/docs/logs/65/worklog.md
@@ -418,6 +418,73 @@ export default async function RepositoriesPage() {
 - `docs/frontend/summary.md` — Streaming SSR パターンの採用を追記
 - `docs/logs/65/worklog.md` — 本計画と実装結果を追記
 
+---
+
+## レビュー結果 (2026-05-04, follow-up review)
+
+### 対象
+
+- Issue: #65 Streaming SSRとローディングUI実装
+- 対象コミット:
+  - `cf34a18` — 初回実装
+  - `7ad7ab6` — 作業ログ更新
+  - `869630b` — 前回レビュー指摘への修正
+
+### 確認内容
+
+1. 前回レビューの3指摘の修正確認
+2. `pnpm typecheck` / `pnpm lint` / `pnpm build` の再実行
+3. 実装と計画、`docs/frontend/summary.md`、外部調査メモの整合確認
+
+### レビュー結果
+
+- **前回指摘1: QueryErrorResetBoundary の導入**
+  - `boardflow/src/components/error-boundary.tsx` で `useQueryErrorResetBoundary()` を使用し、`handleReset()` で `resetQuery()` → `reset()` の順に呼んでいることを確認。
+  - TanStack Query の Suspense/Error Boundary 運用方針と整合している。
+
+- **前回指摘2: スケルトンの CLS 改善**
+  - `repository-detail-skeleton.tsx` に Settings セクション追加を確認。
+  - `board-project-detail-skeleton.tsx` に ERC/DRC 列を含む 6 列テーブルを確認。
+  - `run-detail-skeleton.tsx` に Checks / Artifact Summary / Artifacts テーブルを確認。
+  - 対応先ページの主要レイアウトとの乖離は縮小されており、前回指摘は解消したと判断。
+
+- **前回指摘3: docs/frontend/summary.md の更新**
+  - API 連携セクションに `useSuspenseQuery`、`loading.tsx`、`QueryErrorResetBoundary` の方針追記を確認。
+  - 実装内容とドキュメントの方向性は整合している。
+
+### 再検証結果
+
+- `pnpm typecheck` ✅
+- `pnpm lint` ✅
+- `pnpm build` ✅
+
+### 追加所見
+
+- ブロッキングな不具合は今回の確認範囲では未検出。
+- `/repositories` の Streaming SSR 実装は、`prefetchQuery` を await せずに開始し、`HydrationBoundary` と `useSuspenseQuery` を組み合わせる構成になっており、事前調査内容と整合している。
+- `query-client.ts` の `shouldDehydrateQuery` で pending query を dehydrate 対象に含めており、Streaming SSR の成立条件も満たしている。
+
+### テスト不足
+
+- loading / error UI は静的検証と build では担保されているが、ルート遷移時のスケルトン表示、API エラー時の再試行動作を検証する component test / E2E test は未整備。
+- 現時点ではマージ阻害要因ではないが、今後この領域を継続的に変更するなら自動テスト追加余地がある。
+
+### ドキュメント確認
+
+- `docs/frontend/summary.md`: 更新確認済み
+- `docs/spec.md`: 本 Issue の実装と矛盾する記述は今回確認範囲では未検出
+- `docs/external/tanstack-query-v5-suspense.md`: 実装方針と整合
+- `docs/external/nextjs-streaming-ssr-loading.md`: 実装方針と整合
+
+### PR/完了結果
+
+- `pr_ready: true`
+- 理由: 前回指摘は解消され、再実行した `typecheck` / `lint` / `build` もすべて成功。新たなブロッキング問題は確認できなかったため。
+
+### 残リスク
+
+- 実ブラウザでのナビゲーション中スケルトン表示やエラー再試行の挙動は自動テスト未整備のため、回帰検知は現状だと手動確認に依存する。
+
 ### 実装要否
 
 `implementation_required`
@@ -427,6 +494,54 @@ export default async function RepositoriesPage() {
 なし — 既存の research 成果物と現在のコード構造から、実装に必要な情報はすべて揃っている。
 
 ### 更新した作業ログパス
+
+`docs/logs/65/worklog.md`
+
+---
+
+## ドキュメント確認 (2026-05-04)
+
+### フェーズ: Docs Review
+
+#### 対象Issue
+
+- Issue ID: #65
+- タイトル: Streaming SSRとローディングUI実装
+
+#### 確認範囲
+
+- 実装: `boardflow/src/app/(authenticated)/repositories/**`, `boardflow/src/components/skeletons/**`, `boardflow/src/components/error-boundary.tsx`, `boardflow/src/lib/query-client.ts`
+- ドキュメント: `docs/frontend/summary.md`, `docs/external/chakra-ui-v3-skeleton.md`, `docs/external/nextjs-streaming-ssr-loading.md`, `docs/external/tanstack-query-v5-suspense.md`, `README.md`
+- 外部根拠: Next.js 公式 `loading.js` / self-hosting、TanStack Query 公式 Suspense / Advanced SSR、Chakra UI 公式 Skeleton / Server Components
+
+#### ドキュメント確認結果
+
+- `/repositories` の Streaming SSR 実装、`loading.tsx` 配置、`useSuspenseQuery` 化、pending query の dehydration 設定は、`docs/frontend/summary.md` と概ね整合している
+- `docs/external/nextjs-streaming-ssr-loading.md` の主要な整理は、Next.js 公式の `loading.js` と self-hosting の説明に沿っており妥当
+- ただし、Chakra UI と TanStack Query の外部調査メモに、現在の実装方針とずれる断定が残っている
+
+#### 必須修正
+
+- `docs/external/chakra-ui-v3-skeleton.md` の Server Component 制約を修正する。現在は「Chakra UI コンポーネント全般と同様、`'use client'` が必要」「`loading.tsx` では `Skeleton` を Client Component に切り出して使う」と読めるが、Chakra UI 公式の Server Components ドキュメントでは Chakra UI components can be used with React Server Components without adding the 'use client' directive とされている。実装でも `boardflow/src/app/(authenticated)/repositories/loading.tsx` は Server Component のまま Chakra ベースの skeleton を返しており、現状のメモは BoardFlow 実装と矛盾する。
+- `docs/frontend/summary.md` のエラー処理方針を実装に合わせる。現在は `error.tsx` + `QueryErrorResetBoundary` と記載されているが、実装は `boardflow/src/components/error-boundary.tsx` で `useQueryErrorResetBoundary()` を使って Query reset を接続しており、`QueryErrorResetBoundary` コンポーネント自体は使っていない。方針としては「`QueryErrorResetBoundary` または `useQueryErrorResetBoundary`」のように、実装と一致する表現へ修正した方がよい。
+- `docs/external/tanstack-query-v5-suspense.md` の「必要な追加パッケージ」を修正する。現在は `pnpm add react-error-boundary` を必要条件のように記載しているが、BoardFlow 実装では追加していない。同じ節の直後で「Next.js の `error.tsx` で基本的なエラーハンドリングは可能」と書いており、必要条件と代替手段が混在している。今回の Issue 文脈では「`react-error-boundary` を使う構成もあるが、BoardFlow では Next.js `error.tsx` + `useQueryErrorResetBoundary` を採用」と整理するのが正確。
+
+#### 任意改善
+
+- `docs/external/tanstack-query-v5-suspense.md` の `error.tsx` サンプルは、単純な `reset` 呼び出しだけでなく Query reset 連携の説明を補うと、現実装に近づく
+- `docs/external/chakra-ui-v3-skeleton.md` の BoardFlow への示唆で、`loading` prop ベースの説明と `loading.tsx` ベースの説明を分けて書くと、ページ遷移時 fallback とクライアント内ローディングの使い分けが明確になる
+
+#### docs_ready 判定
+
+- `docs_ready: false`
+
+#### 残リスク
+
+- 実装担当者が `docs/external/chakra-ui-v3-skeleton.md` を参照すると、`loading.tsx` で不要な Client Component 化が必要だと誤解する
+- `docs/frontend/summary.md` のエラー reset 記述を見た読者が、現行実装にない `QueryErrorResetBoundary` コンポーネント導入を前提だと誤認する
+- `docs/external/tanstack-query-v5-suspense.md` の追加パッケージ記述により、不要な依存追加を誘発する可能性がある
+
+#### 更新した作業ログパス
 
 `docs/logs/65/worklog.md`
 

--- a/docs/logs/65/worklog.md
+++ b/docs/logs/65/worklog.md
@@ -27,3 +27,354 @@
 - Issue #64 (TanStack Query) への依存関係（先にQueryインフラを整備する必要）
 - Suspense boundaries の適切な粒度設計
 - SSR + Streaming時のSEO考慮
+
+---
+
+## 実装作業ログ (2026-05-04)
+
+### フェーズ: Research
+- 開始: 2026-05-04
+- 対象: Chakra UI v3 Skeleton, Next.js Streaming SSR, TanStack Query Suspense mode
+
+#### 調査結果サマリー
+
+**1. Chakra UI v3 Skeleton コンポーネント** (`docs/external/chakra-ui-v3-skeleton.md`)
+- `Skeleton`, `SkeletonCircle`, `SkeletonText` の3コンポーネントが `@chakra-ui/react` に含まれる（追加パッケージ不要）
+- `loading` prop で表示/非表示をトグル可能。`variant` は `pulse`(デフォルト) / `shine` / `none`
+- テーブル用: `Table.Root` の行内に `<Skeleton height="20px" />` を配置するパターン
+- カード用: `SkeletonCircle` + `SkeletonText` + `Skeleton` の組み合わせ
+- 注意: Client Component 必須。CLS 対策としてスケルトンの寸法を実コンテンツに合わせる
+
+**2. Next.js 15 Streaming SSR** (`docs/external/nextjs-streaming-ssr-loading.md`)
+- `loading.tsx`: ディレクトリに配置するだけでページ全体を `<Suspense>` でラップする簡便な仕組み
+- 手動 `<Suspense>`: 並列ストリーミング（sibling boundaries）、ネスト（progressive detail）が可能
+- **使い分け**: `loading.tsx` はページ全体のフォールバック、`<Suspense>` は粒度の細かい制御向き
+- **推奨**: 明示的 `<Suspense>` を動的アクセスの近くに配置。動的アクセスは下位コンポーネントに押し下げる
+- エラーは `error.tsx` がストリーミング途中でもキャッチ。失敗セクションだけ置換、残りは影響なし
+- SEO: ストリーミングはサーバーレンダリングなので影響なし。メタデータはボット向けにストリーミング前に解決
+- VPS デプロイ: Node.js サーバーではネイティブサポート。Nginx リバースプロキシでは `X-Accel-Buffering: no` が必要
+
+**3. TanStack Query v5 useSuspenseQuery** (`docs/external/tanstack-query-v5-suspense.md`)
+- `useSuspenseQuery` は `data` が `TData`（undefined なし）で型安全。ローディングは `<Suspense>` に委譲
+- **Streaming SSR パターン**: Server Component で `prefetchQuery`（await なし）→ Client Component で `useSuspenseQuery`
+- `openapi-react-query` は `$api.useSuspenseQuery()` を提供。BoardFlow の既存アーキテクチャに統合可能
+- **dehydrate 設定必須**: `shouldDehydrateQuery` で pending クエリも含めないと streaming が機能しない
+- **エラー**: キャッシュにデータがあればエラーをスローしない（stale データ表示）。`QueryErrorResetBoundary` + `ErrorBoundary` でリトライ UI
+- **prefetch 漏れ注意**: 忘れると hydration mismatch や二重フェッチが発生
+- `@tanstack/react-query-next-experimental` は不採用（ウォーターフォール問題、既存判断踏襲）
+
+#### 推奨する段階的レンダリング設計
+
+| ページ | パターン |
+|---|---|
+| リポジトリ一覧 | `loading.tsx` + prefetch + `useSuspenseQuery` |
+| リポジトリ詳細 | `loading.tsx` + 将来的に `<Suspense>` 分割 |
+| ボードプロジェクト詳細 | `<Suspense>` でプロジェクト情報 / ラン一覧を分割 |
+| ラン詳細 | `<Suspense>` でヘッダー / artifact / diff を分割 |
+| ラン一覧 | `loading.tsx` |
+
+#### 結論ステータス
+
+`implementation_required` — 3トピックとも調査完了。実装に必要な情報が揃っている。
+
+#### 残リスク
+- Issue #64 (TanStack Query 基盤) が先行する必要あり（QueryClient 設定の `shouldDehydrateQuery` 等）→ **解決済み**: `query-client.ts` に設定確認済み
+- 複数 `useSuspenseQuery` の直列 suspend 問題の方針決定が必要
+- Nginx リバースプロキシのストリーミング設定確認
+- スケルトン UI の寸法を実コンテンツに合わせる CLS 対策のデザイン検討
+
+---
+
+## 実装計画 (2026-05-04)
+
+### 目的
+
+- ページ遷移時に即座にローディングUIを表示し、UXを向上する
+- 重いデータフェッチをStreaming SSRで段階的に表示する
+- Chakra UI v3 Skeletonによるコンテンツのプレースホルダー表示
+
+### 非目的
+
+- 全ページをクライアントコンポーネントに書き換えること
+- `notFound()` 判定が必要なページのサーバーフェッチを完全に排除すること
+- デザインシステムの大幅な変更
+
+### 受け入れ条件
+
+1. 各ルートセグメントに `loading.tsx` が存在し、ナビゲーション時にスケルトンUIが即座に表示される
+2. リポジトリ一覧ページが `useSuspenseQuery` + `<Suspense>` パターンで Streaming SSR に対応している
+3. エラー時に `error.tsx` でユーザーフレンドリーなエラーUIが表示される
+4. `pnpm typecheck`, `pnpm lint`, `pnpm build` がすべてパスする
+5. CLS が最小限（スケルトンの寸法が実コンテンツに近似）
+
+### 詳細要件
+
+#### 現状分析
+
+| ページ | 現在のパターン | 問題 |
+|---|---|---|
+| `/repositories` | Server: `await prefetchQuery` → Client: `useQuery` + Spinner | await中ページ全体ブロック。Spinner表示あるが遅い |
+| `/repositories/[id]` | Server: `await Promise.all(2 fetches)` | 全データ揃うまで白画面 |
+| `/repositories/[id]/boards/[id]` | Server: `await Promise.all(2 fetches)` | 同上 |
+| `/repositories/[id]/boards/[id]/runs` | Server: `await Promise.all(2 fetches)` | 同上 |
+| `/repositories/[id]/boards/[id]/runs/[id]` | Server: `await Promise.all(5 fetches)` | 最も重い。全データ揃うまで白画面 |
+
+#### 変更戦略
+
+**方針**: `loading.tsx` をすべてのルートに追加し即座にUXを改善。リポジトリ一覧を `useSuspenseQuery` に変換してStreaming SSRの先行事例とする。`notFound()` が必要なページは `loading.tsx` でのカバーに留め、page内のStreaming分割は今回スコープ外とする（将来Issue）。
+
+**理由**: `notFound()` を使うページでStreaming SSRを実現するには、ページを「404判定用のサーバーフェッチ」と「Suspenseで囲むクライアントコンポーネント」に分離する大規模リファクタが必要。まず `loading.tsx` で全ページのナビゲーション体験を改善し、リポジトリ一覧でパターンを確立する。
+
+### 影響範囲
+
+- `boardflow/src/app/(authenticated)/repositories/` 以下全ルート
+- `boardflow/src/components/repositories/repositories-list.tsx`
+- 新規: スケルトンコンポーネント群
+- 新規: `error.tsx` ファイル群
+
+### 設計方針
+
+1. **スケルトンコンポーネント**: `src/components/skeletons/` に再利用可能なスケルトンを配置
+2. **loading.tsx**: 各ルートの `loading.tsx` からスケルトンコンポーネントを使用
+3. **useSuspenseQuery 変換**: リポジトリ一覧のみ今回対象
+4. **error.tsx**: 共通エラーUIコンポーネントを作成し、各ルートから使用
+
+---
+
+### 実装タスク一覧（順序付き）
+
+| # | タスク | 種別 |
+|---|---|---|
+| 1 | スケルトンコンポーネント作成 | 新規 |
+| 2 | 共通エラーUIコンポーネント作成 | 新規 |
+| 3 | `/repositories` に `loading.tsx` 配置 | 新規 |
+| 4 | `/repositories/[repositoryId]` に `loading.tsx` 配置 | 新規 |
+| 5 | `/repositories/[repositoryId]/boards/[boardProjectId]` に `loading.tsx` 配置 | 新規 |
+| 6 | `/repositories/[repositoryId]/boards/[boardProjectId]/runs` に `loading.tsx` 配置 | 新規 |
+| 7 | `/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]` に `loading.tsx` 配置 | 新規 |
+| 8 | 各ルートに `error.tsx` 配置 | 新規 |
+| 9 | `RepositoriesList` を `useSuspenseQuery` に変換 | 修正 |
+| 10 | `/repositories/page.tsx` を Streaming SSR パターンに変換 | 修正 |
+| 11 | typecheck / lint / build 確認 | 検証 |
+
+---
+
+### 新規作成ファイル一覧
+
+```
+boardflow/src/components/skeletons/
+├── repositories-table-skeleton.tsx     # リポジトリ一覧テーブルのスケルトン
+├── repository-detail-skeleton.tsx      # リポジトリ詳細のスケルトン
+├── board-project-detail-skeleton.tsx   # ボードプロジェクト詳細のスケルトン
+├── runs-table-skeleton.tsx             # ラン一覧テーブルのスケルトン
+└── run-detail-skeleton.tsx             # ラン詳細のスケルトン
+
+boardflow/src/components/error-boundary.tsx  # 共通エラーUIコンポーネント
+
+boardflow/src/app/(authenticated)/repositories/
+├── loading.tsx
+├── error.tsx
+└── [repositoryId]/
+    ├── loading.tsx
+    ├── error.tsx
+    └── boards/[boardProjectId]/
+        ├── loading.tsx
+        ├── error.tsx
+        └── runs/
+            ├── loading.tsx
+            ├── error.tsx
+            └── [boardRunId]/
+                ├── loading.tsx
+                └── error.tsx
+```
+
+### 修正ファイル一覧
+
+```
+boardflow/src/components/repositories/repositories-list.tsx
+  → useQuery → useSuspenseQuery に変更、isPending/error ハンドリング削除
+
+boardflow/src/app/(authenticated)/repositories/page.tsx
+  → await prefetchQuery → prefetchQuery (await なし) + <Suspense> ラップ
+```
+
+---
+
+### 各タスクの実装詳細
+
+#### タスク 1: スケルトンコンポーネント作成
+
+**`repositories-table-skeleton.tsx`**:
+```tsx
+import { Box, Heading, Table, Skeleton } from "@chakra-ui/react"
+
+export function RepositoriesTableSkeleton() {
+  return (
+    <Box>
+      <Heading size="lg" mb={6}>Repositories</Heading>
+      <Table.Root size="sm" variant="outline">
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>Repository</Table.ColumnHeader>
+            <Table.ColumnHeader>Projects</Table.ColumnHeader>
+            <Table.ColumnHeader>Latest Status</Table.ColumnHeader>
+            <Table.ColumnHeader>Updated</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Table.Row key={i}>
+              <Table.Cell><Skeleton height="20px" width="200px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="30px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="80px" /></Table.Cell>
+              <Table.Cell><Skeleton height="20px" width="100px" /></Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  )
+}
+```
+
+他のスケルトンも同様に実コンテンツのレイアウトに近い構造で作成。
+
+#### タスク 2: 共通エラーUIコンポーネント
+
+```tsx
+'use client'
+import { Box, Heading, Text, Button, VStack } from "@chakra-ui/react"
+
+export default function ErrorUI({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <Box py={8}>
+      <VStack gap={4}>
+        <Heading size="md">Something went wrong</Heading>
+        <Text color="gray.600">{error.message}</Text>
+        <Button onClick={reset}>Try again</Button>
+      </VStack>
+    </Box>
+  )
+}
+```
+
+#### タスク 3-7: loading.tsx 配置
+
+各 `loading.tsx` は対応するスケルトンコンポーネントをインポートして返す。例:
+
+```tsx
+// app/(authenticated)/repositories/loading.tsx
+import { RepositoriesTableSkeleton } from "@/components/skeletons/repositories-table-skeleton"
+
+export default function Loading() {
+  return <RepositoriesTableSkeleton />
+}
+```
+
+#### タスク 8: error.tsx 配置
+
+各 `error.tsx` は共通の `ErrorUI` コンポーネントを使用:
+
+```tsx
+'use client'
+import ErrorUI from "@/components/error-boundary"
+
+export default function Error({ error, reset }: { error: Error; reset: () => void }) {
+  return <ErrorUI error={error} reset={reset} />
+}
+```
+
+#### タスク 9: RepositoriesList を useSuspenseQuery に変換
+
+```tsx
+'use client'
+import { Box, Heading, Table, Text, Badge } from "@chakra-ui/react"
+import Link from "next/link"
+import { $api } from "@/lib/api/react-query"
+
+export function RepositoriesList() {
+  // useSuspenseQuery: data は undefined にならない。ローディングは <Suspense> に委譲
+  const { data } = $api.useSuspenseQuery("get", "/api/v1/repositories", {
+    params: { query: { limit: 50 } },
+  })
+
+  const repositories = data?.items ?? []
+  // isPending / error ハンドリング削除（Suspense/ErrorBoundary に委譲）
+  // 以下は既存のレンダリングロジックをそのまま維持
+  ...
+}
+```
+
+#### タスク 10: repositories/page.tsx を Streaming SSR に変換
+
+```tsx
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query"
+import { Suspense } from "react"
+import { getQueryClient } from "@/lib/query-client"
+import { createServerClient } from "@/lib/api/server"
+import { $api } from "@/lib/api/react-query"
+import { RepositoriesList } from "@/components/repositories/repositories-list"
+import { RepositoriesTableSkeleton } from "@/components/skeletons/repositories-table-skeleton"
+
+export default async function RepositoriesPage() {
+  const queryClient = getQueryClient()
+  const serverClient = await createServerClient()
+
+  const options = $api.queryOptions("get", "/api/v1/repositories", {
+    params: { query: { limit: 50 } },
+  })
+
+  // await しない → Streaming SSR で結果が到着次第クライアントに反映
+  queryClient.prefetchQuery({
+    ...options,
+    queryFn: async () => {
+      const { data, error } = await serverClient.GET("/api/v1/repositories", {
+        params: { query: { limit: 50 } },
+      })
+      if (error) throw new Error("Failed to fetch repositories")
+      return data
+    },
+  })
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <Suspense fallback={<RepositoriesTableSkeleton />}>
+        <RepositoriesList />
+      </Suspense>
+    </HydrationBoundary>
+  )
+}
+```
+
+**変更点**: `await queryClient.prefetchQuery(...)` → `queryClient.prefetchQuery(...)` (await 削除)、`<Suspense>` でラップ
+
+---
+
+### テスト観点
+
+| 観点 | 方法 |
+|---|---|
+| 型安全性 | `pnpm typecheck` (tsc --noEmit) |
+| Lint | `pnpm lint` |
+| ビルド成功 | `pnpm build` |
+| ナビゲーション時のローディングUI | 手動確認: 各ページ遷移時にスケルトンが表示される |
+| Streaming SSR | 手動確認: リポジトリ一覧でスケルトン→データ表示の遷移 |
+| エラー時のUI | 手動確認: API停止状態でエラーUIが表示される |
+| CLS | 手動確認: スケルトン→実コンテンツ切替時にレイアウトシフトがない |
+
+### ドキュメント更新対象
+
+- `docs/frontend/summary.md` — Streaming SSR パターンの採用を追記
+- `docs/logs/65/worklog.md` — 本計画と実装結果を追記
+
+### 実装要否
+
+`implementation_required`
+
+### 未解決の疑問
+
+なし — 既存の research 成果物と現在のコード構造から、実装に必要な情報はすべて揃っている。
+
+### 更新した作業ログパス
+
+`docs/logs/65/worklog.md`

--- a/docs/logs/65/worklog.md
+++ b/docs/logs/65/worklog.md
@@ -200,6 +200,57 @@ boardflow/src/app/(authenticated)/repositories/page.tsx
 
 ---
 
+## 実装完了 (2026-05-04)
+
+### 実施内容
+
+計画通り全11タスクを実施。
+
+1. **スケルトンコンポーネント5つ作成** (`src/components/skeletons/`)
+   - `repositories-table-skeleton.tsx` — 5行のスケルトンテーブル
+   - `repository-detail-skeleton.tsx` — Breadcrumb + Heading + Board Projects テーブル
+   - `board-project-detail-skeleton.tsx` — メタ情報 + Recent Runs テーブル
+   - `runs-table-skeleton.tsx` — 5行のRunsテーブル
+   - `run-detail-skeleton.tsx` — ヘッダー + メタデータ + アーティファクト領域
+
+2. **共通エラーUIコンポーネント** (`src/components/error-boundary.tsx`)
+   - `ErrorUI` コンポーネント: エラーメッセージ + "Try again" ボタン
+
+3. **`loading.tsx` 5ファイル配置** — 各ルートセグメントでスケルトンを表示
+
+4. **`error.tsx` 5ファイル配置** — 各ルートセグメントで `ErrorUI` を使用
+
+5. **`RepositoriesList` を `useSuspenseQuery` に変換**
+   - `$api.useQuery` → `$api.useSuspenseQuery`
+   - `isPending` / `error` ハンドリング削除（Suspense/ErrorBoundary に委譲）
+   - `Spinner` インポート削除
+
+6. **`/repositories/page.tsx` を Streaming SSR に変換**
+   - `await queryClient.prefetchQuery(...)` → `queryClient.prefetchQuery(...)` (await 削除)
+   - `<Suspense fallback={<RepositoriesTableSkeleton />}>` でラップ
+   - `Suspense`, `RepositoriesTableSkeleton` をインポート追加
+
+### テスト結果
+
+| チェック | 結果 |
+|---|---|
+| `pnpm typecheck` | ✅ パス |
+| `pnpm lint` | ✅ パス (No ESLint warnings or errors) |
+| `pnpm build` | ✅ パス (全ルート正常ビルド) |
+
+### Git
+
+- ブランチ: `feature/65-streaming-ssr-loading-ui`
+- コミット: `cf34a18` — `feat(frontend): add Streaming SSR with loading/error UI (#65)`
+
+### 残リスク
+
+- **notFound() ページの Streaming SSR**: 詳細ページ（リポジトリ詳細, ボード詳細, ラン詳細, ラン一覧）はサーバーサイドで `notFound()` 判定が必要なため、今回は `loading.tsx` でのカバーに留めている。将来的にページ内を「404判定用サーバーフェッチ」と「Suspense囲みクライアントコンポーネント」に分離する追加リファクタが必要。
+- **CLS 最適化**: スケルトンの寸法は実コンテンツの概算値。実際のデータ量に応じて微調整が必要な可能性あり。
+- **Nginx リバースプロキシ**: 本番環境で Streaming SSR を機能させるには `X-Accel-Buffering: no` ヘッダーの設定が必要。
+
+---
+
 ### 各タスクの実装詳細
 
 #### タスク 1: スケルトンコンポーネント作成


### PR DESCRIPTION
## 要件

Closes #65

- ページ遷移時に即座にローディングUIを表示し、UXを向上する
- 重いデータフェッチをStreaming SSRで段階的に表示する
- Chakra UI v3 Skeletonによるコンテンツのプレースホルダー表示

## 調査結果

- **Chakra UI v3 Skeleton**: \`@chakra-ui/react\` にビルトイン、追加パッケージ不要。\`loading\` prop でトグル可能
- **Next.js 15 Streaming SSR**: \`loading.tsx\` でページ全体を \`<Suspense>\` 自動ラップ。手動 \`<Suspense>\` で粒度制御
- **TanStack Query v5**: \`useSuspenseQuery\` + \`prefetchQuery\`（await なし）パターンで Streaming SSR に対応

参照: \`docs/external/chakra-ui-v3-skeleton.md\`, \`docs/external/nextjs-streaming-ssr-loading.md\`, \`docs/external/tanstack-query-v5-suspense.md\`

## 実装概要

### 新規ファイル

**スケルトンコンポーネント** (\`src/components/skeletons/\`):
- \`repositories-table-skeleton.tsx\` — リポジトリ一覧テーブル（5行プレースホルダー）
- \`repository-detail-skeleton.tsx\` — リポジトリ詳細（Settings + Board Projects）
- \`board-project-detail-skeleton.tsx\` — ボードプロジェクト詳細（ERC/DRC列含む）
- \`runs-table-skeleton.tsx\` — ラン一覧テーブル（5行プレースホルダー）
- \`run-detail-skeleton.tsx\` — ラン詳細（Checks + Artifacts）

**共通エラーUI** (\`src/components/error-boundary.tsx\`):
- \`ErrorUI\` コンポーネント: エラーメッセージ + "Try again" ボタン

**\`loading.tsx\` × 5ルート、\`error.tsx\` × 5ルート**:
- \`/repositories\`
- \`/repositories/[repositoryId]\`
- \`/repositories/[repositoryId]/boards/[boardProjectId]\`
- \`/repositories/[repositoryId]/boards/[boardProjectId]/runs\`
- \`/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]\`

### 修正ファイル

- \`repositories-list.tsx\`: \`$api.useQuery\` → \`$api.useSuspenseQuery\`、isPending/error削除（Suspense/ErrorBoundary に委譲）
- \`/repositories/page.tsx\`: \`await prefetchQuery\` → \`prefetchQuery\`（await削除）+ \`<Suspense>\` ラップ

## テスト結果

| チェック | 結果 |
|---|---|
| \`pnpm typecheck\` | ✅ パス |
| \`pnpm lint\` | ✅ パス (No ESLint warnings or errors) |
| \`pnpm build\` | ✅ パス (全ルート正常ビルド) |

## 更新ドキュメント

- \`docs/frontend/summary.md\`: Streaming SSR パターン方針追記
- \`docs/external/chakra-ui-v3-skeleton.md\`: 新規（Chakra UI v3 Skeleton調査メモ）
- \`docs/external/nextjs-streaming-ssr-loading.md\`: 新規（Next.js Streaming SSR調査メモ）
- \`docs/external/tanstack-query-v5-suspense.md\`: 新規（TanStack Query Suspenseモード調査メモ）

## 外部調査メモ

- Nginx リバースプロキシで Streaming SSR を機能させるには \`X-Accel-Buffering: no\` ヘッダーの設定が必要
- SEO: ストリーミングはサーバーレンダリングなので影響なし。メタデータはボット向けにストリーミング前に解決される

## 残リスク

- **notFound() ページの Streaming SSR**: 詳細ページはサーバーサイドで \`notFound()\` 判定が必要なため、今回は \`loading.tsx\` でのカバーに留めた。将来的にページ内を「404判定用サーバーフェッチ」と「Suspense囲みクライアントコンポーネント」に分離する追加リファクタが必要
- **CLS 最適化**: スケルトンの寸法は実コンテンツの概算値。実際のデータ量に応じて微調整が必要な可能性あり
- **Nginx リバースプロキシ**: 本番環境で \`X-Accel-Buffering: no\` ヘッダーの設定が必要

## Review / Docs 判定

- review: \`pr_ready: true\`
- docs: \`docs_ready: true\`