### PR TITLE
feat: implement boardflow-action Docker Action for GitHub Actions (#60)

### DIFF
--- a/action/Dockerfile
+++ b/action/Dockerfile
@@ -1,0 +1,22 @@
+FROM kicad/kicad:9.0
+
+USER root
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-pip \
+    xvfb \
+    jq \
+    curl \
+    zip \
+    ca-certificates \
+    python3-yaml \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --break-system-packages interactivehtmlbom
+
+COPY entrypoint.sh /action/entrypoint.sh
+COPY lib/ /action/lib/
+
+RUN chmod +x /action/entrypoint.sh /action/lib/*.sh
+
+ENTRYPOINT ["/action/entrypoint.sh"]

--- a/action/action.yml
+++ b/action/action.yml
@@ -1,0 +1,36 @@
+name: 'BoardFlow Action'
+description: 'KiCad CI/CD - Generate artifacts and upload to BoardFlow'
+author: 'BoardFlow'
+branding:
+  icon: 'cpu'
+  color: 'blue'
+inputs:
+  token:
+    description: 'BoardFlow API token'
+    required: true
+  mode:
+    description: '"auto" or "all"'
+    required: false
+    default: 'auto'
+  exclude-paths:
+    description: 'Newline-separated glob patterns to exclude'
+    required: false
+    default: ''
+  api-url:
+    description: 'BoardFlow API URL'
+    required: false
+    default: 'https://api.boardflow.example.com'
+  fail-on-drc:
+    description: 'Fail action on DRC errors'
+    required: false
+    default: 'false'
+  fail-on-erc:
+    description: 'Fail action on ERC errors'
+    required: false
+    default: 'false'
+outputs:
+  result:
+    description: 'JSON summary of processed projects'
+runs:
+  using: 'docker'
+  image: 'Dockerfile'

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -116,15 +116,25 @@ for entry in "${VALID_PROJECTS[@]}"; do
     rel_dir="."
   fi
 
+  # R-2: project_path is .kicad_pro relative path
+  rel_pro="${pro_file#$WORKSPACE/}"
   yml_rel="$rel_dir/.boardflow.yml"
-  files=$(list_project_files "$project_dir" "$all_excludes" | jq -R -s 'split("\n") | map(select(. != ""))')
+
+  # R-3: files array with per-file sha256
+  files_json="[]"
+  while IFS= read -r rel_path; do
+    [ -z "$rel_path" ] && continue
+    local_hash=$(compute_file_sha256 "$project_dir/$rel_path")
+    files_json=$(echo "$files_json" | jq --arg p "$rel_path" --arg h "sha256:$local_hash" \
+      '. + [{"path": $p, "sha256": $h}]')
+  done < <(list_project_files "$project_dir" "$all_excludes" | LC_ALL=C sort)
 
   plan_projects=$(echo "$plan_projects" | jq \
-    --arg path "$rel_dir" \
+    --arg path "$rel_pro" \
     --arg config_path "$yml_rel" \
     --arg project_dir "$rel_dir" \
     --arg hash "sha256:$tree_hash" \
-    --argjson files "$files" \
+    --argjson files "$files_json" \
     '. + [{"project_path": $path, "config_path": $config_path, "project_dir": $project_dir, "tree_hash": $hash, "files": $files}]')
 done
 
@@ -168,7 +178,8 @@ for i in "${!VALID_PROJECTS[@]}"; do
     rel_dir="."
   fi
 
-  rel_project_path="$rel_dir"
+  # R-2: project_path is .kicad_pro relative path
+  rel_project_path="${pro_file#$WORKSPACE/}"
 
   decision=$(echo "$decisions" | jq -r --arg path "$rel_project_path" '.[] | select(.project_path == $path) | .decision // "skip"')
 
@@ -220,12 +231,12 @@ for i in "${!VALID_PROJECTS[@]}"; do
   run_erc "$sch_file" "$erc_json"
   erc_exit=$?
   if [ $erc_exit -eq 0 ] || [ $erc_exit -eq 5 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"erc","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "erc_report" "checks/erc.json" "application/json" "$erc_json")
     if [ "$erc_exit" -eq 5 ] && [ "$FAIL_ON_ERC" = "true" ]; then
       EXIT_CODE=1
     fi
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"erc","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "erc_report" "ERC execution failed")
   fi
 
   # Run DRC
@@ -233,12 +244,12 @@ for i in "${!VALID_PROJECTS[@]}"; do
   run_drc "$pcb_file" "$drc_json"
   drc_exit=$?
   if [ $drc_exit -eq 0 ] || [ $drc_exit -eq 5 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"drc","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "drc_report" "checks/drc.json" "application/json" "$drc_json")
     if [ "$drc_exit" -eq 5 ] && [ "$FAIL_ON_DRC" = "true" ]; then
       EXIT_CODE=1
     fi
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"drc","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "drc_report" "DRC execution failed")
   fi
 
   # Export PCB PDF
@@ -246,17 +257,17 @@ for i in "${!VALID_PROJECTS[@]}"; do
   mkdir -p "$pdf_dir"
   run_pcb_pdf "$pcb_file" "$pdf_dir/pcb.pdf"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_pdf","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "pcb_pdf" "review/pcb.pdf" "application/pdf" "$pdf_dir/pcb.pdf")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_pdf","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "pcb_pdf" "PCB PDF export failed")
   fi
 
   # Export Schematic PDF
   run_sch_pdf "$sch_file" "$pdf_dir/schematic.pdf"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"sch_pdf","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "schematic_pdf" "review/schematic.pdf" "application/pdf" "$pdf_dir/schematic.pdf")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"sch_pdf","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "schematic_pdf" "Schematic PDF export failed")
   fi
 
   # Export SVG
@@ -264,36 +275,54 @@ for i in "${!VALID_PROJECTS[@]}"; do
   mkdir -p "$svg_dir"
   run_pcb_svg_top "$pcb_file" "$svg_dir/pcb_top.svg"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_svg_top","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "pcb_top_svg" "review/pcb_top.svg" "image/svg+xml" "$svg_dir/pcb_top.svg")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_svg_top","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "pcb_top_svg" "PCB top SVG export failed")
   fi
 
   run_pcb_svg_bottom "$pcb_file" "$svg_dir/pcb_bottom.svg"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_svg_bottom","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "pcb_bottom_svg" "review/pcb_bottom.svg" "image/svg+xml" "$svg_dir/pcb_bottom.svg")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_svg_bottom","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "pcb_bottom_svg" "PCB bottom SVG export failed")
   fi
 
   # Export Gerber
   gerber_dir="$output_dir/gerber"
   mkdir -p "$gerber_dir"
   run_gerber_export "$pcb_file" "$gerber_dir"
-  if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"gerber","status":"success"}]')
-  else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"gerber","status":"failed"}]')
-  fi
+  gerber_exit=$?
 
   # Export Drill
   drill_dir="$output_dir/drill"
   mkdir -p "$drill_dir"
   run_drill_export "$pcb_file" "$drill_dir"
-  if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"drill","status":"success"}]')
+  drill_exit=$?
+
+  # Create zip archives for gerber/drill/fabrication before tracking artifacts
+  gerbers_zip="$output_dir/gerbers.zip"
+  drill_zip="$output_dir/drill.zip"
+  fab_zip="$output_dir/fabrication.zip"
+  if [ $gerber_exit -eq 0 ]; then
+    (cd "$gerber_dir" && zip -qr "$gerbers_zip" . 2>/dev/null)
+    artifacts_status=$(add_artifact_available "$artifacts_status" "gerber_zip" "fabrication/gerbers.zip" "application/zip" "$gerbers_zip")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"drill","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "gerber_zip" "Gerber export failed")
+  fi
+
+  if [ $drill_exit -eq 0 ]; then
+    (cd "$drill_dir" && zip -qr "$drill_zip" . 2>/dev/null)
+    artifacts_status=$(add_artifact_available "$artifacts_status" "drill_zip" "fabrication/drill.zip" "application/zip" "$drill_zip")
+  else
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "drill_zip" "Drill export failed")
+  fi
+
+  # Create combined fabrication.zip
+  create_fabrication_zip "$gerber_dir" "$drill_dir" "$fab_zip"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(add_artifact_available "$artifacts_status" "fabrication_zip" "fabrication/fabrication.zip" "application/zip" "$fab_zip")
+  else
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "fabrication_zip" "Fabrication zip creation failed")
   fi
 
   # Export BOM
@@ -301,9 +330,9 @@ for i in "${!VALID_PROJECTS[@]}"; do
   mkdir -p "$bom_dir"
   run_bom_export "$sch_file" "$bom_dir/bom.csv"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"bom","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "bom_csv" "assembly/bom.csv" "text/csv" "$bom_dir/bom.csv")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"bom","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "bom_csv" "BOM export failed")
   fi
 
   # Export Position
@@ -311,9 +340,9 @@ for i in "${!VALID_PROJECTS[@]}"; do
   mkdir -p "$pos_dir"
   run_position_export "$pcb_file" "$pos_dir/position.csv"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"position","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "position_csv" "assembly/position.csv" "text/csv" "$pos_dir/position.csv")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"position","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "position_csv" "Position export failed")
   fi
 
   # Export 3D renders
@@ -321,16 +350,16 @@ for i in "${!VALID_PROJECTS[@]}"; do
   mkdir -p "$render_dir"
   run_3d_render "$pcb_file" "$render_dir/top.png" "top"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"3d_top","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "render_top_png" "review/render_top.png" "image/png" "$render_dir/top.png")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"3d_top","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "render_top_png" "3D top render failed")
   fi
 
   run_3d_render "$pcb_file" "$render_dir/bottom.png" "bottom"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"3d_bottom","status":"success"}]')
+    artifacts_status=$(add_artifact_available "$artifacts_status" "render_bottom_png" "review/render_bottom.png" "image/png" "$render_dir/bottom.png")
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"3d_bottom","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "render_bottom_png" "3D bottom render failed")
   fi
 
   # Run iBOM
@@ -338,14 +367,32 @@ for i in "${!VALID_PROJECTS[@]}"; do
   mkdir -p "$ibom_dir"
   run_ibom "$pcb_file" "$ibom_dir"
   if [ $? -eq 0 ]; then
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"ibom","status":"success"}]')
+    ibom_file=$(find "$ibom_dir" -name "*.html" -type f | head -1)
+    if [ -n "$ibom_file" ]; then
+      artifacts_status=$(add_artifact_available "$artifacts_status" "ibom" "assembly/ibom.html" "text/html" "$ibom_file")
+    else
+      artifacts_status=$(add_artifact_failed "$artifacts_status" "ibom" "iBOM HTML not found")
+    fi
   else
-    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"ibom","status":"failed"}]')
+    artifacts_status=$(add_artifact_failed "$artifacts_status" "ibom" "iBOM generation failed")
   fi
 
-  # Create fabrication.zip (H-7: individual gerbers.zip and drill.zip)
-  fab_zip="$output_dir/fabrication.zip"
-  create_fabrication_zip "$gerber_dir" "$drill_dir" "$fab_zip"
+  # R-1: Add KiCad source artifacts
+  while IFS= read -r src_file; do
+    [ -z "$src_file" ] && continue
+    src_rel="${src_file#$project_dir/}"
+    if ! is_excluded "$src_rel" "$all_excludes"; then
+      kicad_type=""
+      case "$src_rel" in
+        *.kicad_pro) kicad_type="kicad_project" ;;
+        *.kicad_sch) kicad_type="kicad_schematic" ;;
+        *.kicad_pcb) kicad_type="kicad_pcb" ;;
+        *.kicad_wks) kicad_type="kicad_worksheet" ;;
+      esac
+      staging_path="kicad/$rel_dir/$src_rel"
+      artifacts_status=$(add_artifact_available "$artifacts_status" "$kicad_type" "$staging_path" "application/octet-stream" "$src_file")
+    fi
+  done < <(find "$project_dir" -maxdepth 1 -type f \( -name "*.kicad_pro" -o -name "*.kicad_sch" -o -name "*.kicad_pcb" -o -name "*.kicad_wks" \) | LC_ALL=C sort)
 
   # M-3: Generate diff metadata files
   diff_dir="$output_dir/diff"
@@ -372,6 +419,8 @@ for i in "${!VALID_PROJECTS[@]}"; do
   cp "$pdf_dir/pcb.pdf" "$staging_dir/review/" 2>/dev/null
   cp "$svg_dir/pcb_top.svg" "$staging_dir/review/" 2>/dev/null
   cp "$svg_dir/pcb_bottom.svg" "$staging_dir/review/" 2>/dev/null
+  cp "$render_dir/top.png" "$staging_dir/review/render_top.png" 2>/dev/null
+  cp "$render_dir/bottom.png" "$staging_dir/review/render_bottom.png" 2>/dev/null
 
   # assembly/
   cp "$ibom_dir"/*.html "$staging_dir/assembly/ibom.html" 2>/dev/null
@@ -379,8 +428,8 @@ for i in "${!VALID_PROJECTS[@]}"; do
   cp "$pos_dir/position.csv" "$staging_dir/assembly/" 2>/dev/null
 
   # fabrication/ (H-7: individual zips)
-  (cd "$gerber_dir" && zip -qr "$staging_dir/fabrication/gerbers.zip" . 2>/dev/null)
-  (cd "$drill_dir" && zip -qr "$staging_dir/fabrication/drill.zip" . 2>/dev/null)
+  cp "$gerbers_zip" "$staging_dir/fabrication/gerbers.zip" 2>/dev/null
+  cp "$drill_zip" "$staging_dir/fabrication/drill.zip" 2>/dev/null
   cp "$fab_zip" "$staging_dir/fabrication/fabrication.zip" 2>/dev/null
 
   # checks/

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -1,0 +1,474 @@
+#!/bin/bash
+# BoardFlow Action - Main Entrypoint
+# Orchestrates KiCad artifact generation and upload to BoardFlow
+
+# Source library scripts
+for lib in /action/lib/*.sh; do
+  source "$lib"
+done
+
+# Parse inputs (C-1: GitHub Actions converts hyphens to underscores)
+TOKEN="${INPUT_TOKEN:-}"
+MODE="${INPUT_MODE:-auto}"
+EXCLUDE_PATHS="${INPUT_EXCLUDE_PATHS:-}"
+API_URL="${INPUT_API_URL:-https://api.boardflow.example.com}"
+FAIL_ON_DRC="${INPUT_FAIL_ON_DRC:-false}"
+FAIL_ON_ERC="${INPUT_FAIL_ON_ERC:-false}"
+
+WORKSPACE="/github/workspace"
+EVENT_NAME="${GITHUB_EVENT_NAME:-}"
+REPO="${GITHUB_REPOSITORY:-}"
+SHA="${GITHUB_SHA:-}"
+REF="${GITHUB_REF:-}"
+BRANCH="${GITHUB_REF_NAME:-}"
+RUN_ID="${GITHUB_RUN_ID:-}"
+RUN_ATTEMPT="${GITHUB_RUN_ATTEMPT:-1}"
+OWNER="${REPO%%/*}"
+REPO_NAME="${REPO#*/}"
+
+# Validate required inputs
+if [ -z "$TOKEN" ]; then
+  echo "::error::Input 'token' is required" >&2
+  exit 1
+fi
+
+# Check unsupported events
+if [ "$EVENT_NAME" = "pull_request" ]; then
+  write_unsupported_event_summary "$EVENT_NAME"
+  echo '{"status":"skipped","reason":"unsupported event: pull_request"}' > "$GITHUB_OUTPUT" 2>/dev/null || true
+  exit 0
+fi
+
+# Detect projects
+PROJECTS=()
+detect_projects
+
+if [ ${#PROJECTS[@]} -eq 0 ]; then
+  echo "::error::No .boardflow.yml found in workspace" >&2
+  exit 1
+fi
+
+# Validate all projects (H-4: track detection errors)
+VALID_PROJECTS=()
+DETECTION_ERRORS=0
+
+for project_dir in "${PROJECTS[@]}"; do
+  yml_path="$project_dir/.boardflow.yml"
+  config_json=$(parse_boardflow_yml "$yml_path")
+  if [ $? -ne 0 ]; then
+    echo "::warning::Failed to parse $yml_path" >&2
+    DETECTION_ERRORS=$((DETECTION_ERRORS + 1))
+    continue
+  fi
+
+  if ! validate_schema_v1 "$config_json"; then
+    echo "::warning::Invalid schema in $yml_path" >&2
+    DETECTION_ERRORS=$((DETECTION_ERRORS + 1))
+    continue
+  fi
+
+  yml_excludes=$(get_exclude_paths_from_config "$config_json")
+  all_excludes=$(merge_excludes "$BUILTIN_EXCLUDES" "$EXCLUDE_PATHS" "$yml_excludes")
+
+  pro_file=$(resolve_kicad_pro "$project_dir")
+  if [ $? -ne 0 ] || [ -z "$pro_file" ]; then
+    echo "::warning::No unique .kicad_pro in $project_dir" >&2
+    DETECTION_ERRORS=$((DETECTION_ERRORS + 1))
+    continue
+  fi
+
+  pro_stem=$(basename "$pro_file" .kicad_pro)
+  pcb_file=$(resolve_pcb_file "$project_dir" "$pro_stem")
+  if [ $? -ne 0 ] || [ -z "$pcb_file" ]; then
+    echo "::warning::No .kicad_pcb found for $pro_stem in $project_dir" >&2
+    DETECTION_ERRORS=$((DETECTION_ERRORS + 1))
+    continue
+  fi
+
+  sch_file=$(resolve_root_schematic "$project_dir" "$pro_stem")
+  if [ $? -ne 0 ] || [ -z "$sch_file" ]; then
+    echo "::warning::No .kicad_sch found for $pro_stem in $project_dir" >&2
+    DETECTION_ERRORS=$((DETECTION_ERRORS + 1))
+    continue
+  fi
+
+  if ! validate_required_files "$project_dir" "$pro_file" "$pcb_file" "$sch_file" "$all_excludes"; then
+    echo "::warning::Required files excluded in $project_dir" >&2
+    DETECTION_ERRORS=$((DETECTION_ERRORS + 1))
+    continue
+  fi
+
+  VALID_PROJECTS+=("$project_dir|$pro_file|$pcb_file|$sch_file|$all_excludes|$config_json")
+done
+
+if [ ${#VALID_PROJECTS[@]} -eq 0 ]; then
+  echo "::error::No valid projects found" >&2
+  exit 1
+fi
+
+# Compute hashes and build plan payload (M-6: spec compliant)
+plan_projects="[]"
+for entry in "${VALID_PROJECTS[@]}"; do
+  IFS='|' read -r project_dir pro_file pcb_file sch_file all_excludes config_json <<< "$entry"
+  tree_hash=$(compute_tree_hash "$project_dir" "$all_excludes")
+  rel_dir="${project_dir#$WORKSPACE/}"
+  if [ "$rel_dir" = "$project_dir" ]; then
+    rel_dir="."
+  fi
+
+  yml_rel="$rel_dir/.boardflow.yml"
+  files=$(list_project_files "$project_dir" "$all_excludes" | jq -R -s 'split("\n") | map(select(. != ""))')
+
+  plan_projects=$(echo "$plan_projects" | jq \
+    --arg path "$rel_dir" \
+    --arg config_path "$yml_rel" \
+    --arg project_dir "$rel_dir" \
+    --arg hash "sha256:$tree_hash" \
+    --argjson files "$files" \
+    '. + [{"project_path": $path, "config_path": $config_path, "project_dir": $project_dir, "tree_hash": $hash, "files": $files}]')
+done
+
+# Call Plan API (M-6: spec compliant payload)
+plan_payload=$(jq -n \
+  --arg owner "$OWNER" \
+  --arg name "$REPO_NAME" \
+  --arg sha "$SHA" \
+  --arg ref "$REF" \
+  --arg branch "$BRANCH" \
+  --arg event "$EVENT_NAME" \
+  --arg mode "$MODE" \
+  --arg run_id "$RUN_ID" \
+  --arg run_attempt "$RUN_ATTEMPT" \
+  --arg workflow "BoardFlow" \
+  --argjson projects "$plan_projects" \
+  '{
+    repository: {owner: $owner, name: $name},
+    git: {ref: $ref, branch: $branch, commit_sha: $sha, event_name: $event},
+    action: {workflow: $workflow, run_id: $run_id, run_attempt: $run_attempt},
+    mode: $mode,
+    projects: $projects
+  }')
+
+decisions=$(call_plan_api "$plan_payload")
+if [ $? -ne 0 ]; then
+  echo "::error::Plan API call failed" >&2
+  exit 1
+fi
+
+# Process each project based on decisions
+EXIT_CODE=0
+RESULTS="[]"
+
+for i in "${!VALID_PROJECTS[@]}"; do
+  entry="${VALID_PROJECTS[$i]}"
+  IFS='|' read -r project_dir pro_file pcb_file sch_file all_excludes config_json <<< "$entry"
+
+  rel_dir="${project_dir#$WORKSPACE/}"
+  if [ "$rel_dir" = "$project_dir" ]; then
+    rel_dir="."
+  fi
+
+  rel_project_path="$rel_dir"
+
+  decision=$(echo "$decisions" | jq -r --arg path "$rel_project_path" '.[] | select(.project_path == $path) | .decision // "skip"')
+
+  if [ "$decision" != "build" ]; then
+    RESULTS=$(echo "$RESULTS" | jq --arg path "$rel_project_path" --arg status "skipped" \
+      '. + [{"path": $path, "status": $status}]')
+    continue
+  fi
+
+  pro_stem=$(basename "$pro_file" .kicad_pro)
+  output_dir=$(mktemp -d "/tmp/boardflow-${pro_stem}-XXXXXX")
+  artifacts_status="[]"
+  board_run_id=""
+  upload_url=""
+  staging_object_key=""
+
+  # H-2: Get board_project_id from plan decisions
+  board_project_id=$(echo "$decisions" | jq -r --arg path "$rel_project_path" '.[] | select(.project_path == $path) | .board_project_id')
+
+  # Create board run (H-2: spec-compliant payload)
+  tree_hash=$(compute_tree_hash "$project_dir" "$all_excludes")
+  create_payload=$(jq -n \
+    --arg board_project_id "$board_project_id" \
+    --arg project_path "$rel_project_path" \
+    --arg tree_hash "sha256:$tree_hash" \
+    --arg commit_sha "$SHA" \
+    --arg branch "$BRANCH" \
+    --arg ref "$REF" \
+    --arg github_run_id "$RUN_ID" \
+    --arg github_run_attempt "$RUN_ATTEMPT" \
+    '{board_project_id: $board_project_id, project_path: $project_path, tree_hash: $tree_hash, commit_sha: $commit_sha, branch: $branch, ref: $ref, github_run_id: $github_run_id, github_run_attempt: $github_run_attempt}')
+
+  create_response=$(call_create_board_run "$create_payload")
+  if [ $? -ne 0 ]; then
+    echo "::error::Failed to create board run for $rel_project_path" >&2
+    RESULTS=$(echo "$RESULTS" | jq --arg path "$rel_project_path" --arg status "error" \
+      '. + [{"path": $path, "status": $status, "error": "create_board_run failed"}]')
+    EXIT_CODE=1
+    continue
+  fi
+
+  # C-2: Extract board_run_id, upload_url, and staging_object_key
+  board_run_id=$(echo "$create_response" | jq -r '.board_run_id')
+  upload_url=$(echo "$create_response" | jq -r '.artifact_bundle.upload_url')
+  staging_object_key=$(echo "$create_response" | jq -r '.artifact_bundle.object_key')
+
+  # Run ERC
+  erc_json="$output_dir/erc.json"
+  run_erc "$sch_file" "$erc_json"
+  erc_exit=$?
+  if [ $erc_exit -eq 0 ] || [ $erc_exit -eq 5 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"erc","status":"success"}]')
+    if [ "$erc_exit" -eq 5 ] && [ "$FAIL_ON_ERC" = "true" ]; then
+      EXIT_CODE=1
+    fi
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"erc","status":"failed"}]')
+  fi
+
+  # Run DRC
+  drc_json="$output_dir/drc.json"
+  run_drc "$pcb_file" "$drc_json"
+  drc_exit=$?
+  if [ $drc_exit -eq 0 ] || [ $drc_exit -eq 5 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"drc","status":"success"}]')
+    if [ "$drc_exit" -eq 5 ] && [ "$FAIL_ON_DRC" = "true" ]; then
+      EXIT_CODE=1
+    fi
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"drc","status":"failed"}]')
+  fi
+
+  # Export PCB PDF
+  pdf_dir="$output_dir/pdf"
+  mkdir -p "$pdf_dir"
+  run_pcb_pdf "$pcb_file" "$pdf_dir/pcb.pdf"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_pdf","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_pdf","status":"failed"}]')
+  fi
+
+  # Export Schematic PDF
+  run_sch_pdf "$sch_file" "$pdf_dir/schematic.pdf"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"sch_pdf","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"sch_pdf","status":"failed"}]')
+  fi
+
+  # Export SVG
+  svg_dir="$output_dir/svg"
+  mkdir -p "$svg_dir"
+  run_pcb_svg_top "$pcb_file" "$svg_dir/pcb_top.svg"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_svg_top","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_svg_top","status":"failed"}]')
+  fi
+
+  run_pcb_svg_bottom "$pcb_file" "$svg_dir/pcb_bottom.svg"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_svg_bottom","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"pcb_svg_bottom","status":"failed"}]')
+  fi
+
+  # Export Gerber
+  gerber_dir="$output_dir/gerber"
+  mkdir -p "$gerber_dir"
+  run_gerber_export "$pcb_file" "$gerber_dir"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"gerber","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"gerber","status":"failed"}]')
+  fi
+
+  # Export Drill
+  drill_dir="$output_dir/drill"
+  mkdir -p "$drill_dir"
+  run_drill_export "$pcb_file" "$drill_dir"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"drill","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"drill","status":"failed"}]')
+  fi
+
+  # Export BOM
+  bom_dir="$output_dir/bom"
+  mkdir -p "$bom_dir"
+  run_bom_export "$sch_file" "$bom_dir/bom.csv"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"bom","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"bom","status":"failed"}]')
+  fi
+
+  # Export Position
+  pos_dir="$output_dir/position"
+  mkdir -p "$pos_dir"
+  run_position_export "$pcb_file" "$pos_dir/position.csv"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"position","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"position","status":"failed"}]')
+  fi
+
+  # Export 3D renders
+  render_dir="$output_dir/3d"
+  mkdir -p "$render_dir"
+  run_3d_render "$pcb_file" "$render_dir/top.png" "top"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"3d_top","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"3d_top","status":"failed"}]')
+  fi
+
+  run_3d_render "$pcb_file" "$render_dir/bottom.png" "bottom"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"3d_bottom","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"3d_bottom","status":"failed"}]')
+  fi
+
+  # Run iBOM
+  ibom_dir="$output_dir/ibom"
+  mkdir -p "$ibom_dir"
+  run_ibom "$pcb_file" "$ibom_dir"
+  if [ $? -eq 0 ]; then
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"ibom","status":"success"}]')
+  else
+    artifacts_status=$(echo "$artifacts_status" | jq '. + [{"name":"ibom","status":"failed"}]')
+  fi
+
+  # Create fabrication.zip (H-7: individual gerbers.zip and drill.zip)
+  fab_zip="$output_dir/fabrication.zip"
+  create_fabrication_zip "$gerber_dir" "$drill_dir" "$fab_zip"
+
+  # M-3: Generate diff metadata files
+  diff_dir="$output_dir/diff"
+  mkdir -p "$diff_dir"
+  generate_file_hashes_json "$project_dir" "$all_excludes" "$diff_dir/file_hashes.json"
+  generate_bom_summary_json "$bom_dir/bom.csv" "$diff_dir/bom_summary.json"
+  generate_checks_summary_json "$erc_json" "$drc_json" "$diff_dir/checks_summary.json"
+  generate_artifacts_summary_json "$artifacts_status" "$diff_dir/artifacts_summary.json"
+  generate_previews_json "$output_dir" "$diff_dir/previews.json"
+
+  # M-4: Create manifest (spec compliant)
+  yml_rel="$rel_dir/.boardflow.yml"
+  manifest_path="$output_dir/manifest.json"
+  create_manifest "$board_project_id" "$rel_project_path" "$rel_dir" "$yml_rel" \
+    "$tree_hash" "$SHA" "$REF" "$BRANCH" "$RUN_ID" "$RUN_ATTEMPT" \
+    "$diff_dir/checks_summary.json" "$artifacts_status" "$diff_dir" "$manifest_path"
+
+  # H-6: Build staging directory with spec-compliant structure
+  staging_dir="$output_dir/staging"
+  mkdir -p "$staging_dir/review" "$staging_dir/assembly" "$staging_dir/fabrication" "$staging_dir/checks" "$staging_dir/diff"
+
+  # review/
+  cp "$pdf_dir/schematic.pdf" "$staging_dir/review/" 2>/dev/null
+  cp "$pdf_dir/pcb.pdf" "$staging_dir/review/" 2>/dev/null
+  cp "$svg_dir/pcb_top.svg" "$staging_dir/review/" 2>/dev/null
+  cp "$svg_dir/pcb_bottom.svg" "$staging_dir/review/" 2>/dev/null
+
+  # assembly/
+  cp "$ibom_dir"/*.html "$staging_dir/assembly/ibom.html" 2>/dev/null
+  cp "$bom_dir/bom.csv" "$staging_dir/assembly/" 2>/dev/null
+  cp "$pos_dir/position.csv" "$staging_dir/assembly/" 2>/dev/null
+
+  # fabrication/ (H-7: individual zips)
+  (cd "$gerber_dir" && zip -qr "$staging_dir/fabrication/gerbers.zip" . 2>/dev/null)
+  (cd "$drill_dir" && zip -qr "$staging_dir/fabrication/drill.zip" . 2>/dev/null)
+  cp "$fab_zip" "$staging_dir/fabrication/fabrication.zip" 2>/dev/null
+
+  # checks/
+  cp "$erc_json" "$staging_dir/checks/erc.json" 2>/dev/null
+  cp "$drc_json" "$staging_dir/checks/drc.json" 2>/dev/null
+
+  # diff/
+  cp "$diff_dir/file_hashes.json" "$staging_dir/diff/" 2>/dev/null
+  cp "$diff_dir/bom_summary.json" "$staging_dir/diff/" 2>/dev/null
+  cp "$diff_dir/checks_summary.json" "$staging_dir/diff/" 2>/dev/null
+  cp "$diff_dir/artifacts_summary.json" "$staging_dir/diff/" 2>/dev/null
+  cp "$diff_dir/previews.json" "$staging_dir/diff/" 2>/dev/null
+
+  # H-5: Collect KiCad source files
+  kicad_staging="$staging_dir/kicad/$rel_dir"
+  mkdir -p "$kicad_staging"
+  find "$project_dir" -maxdepth 1 \( -name "*.kicad_pro" -o -name "*.kicad_sch" -o -name "*.kicad_pcb" -o -name "*.kicad_wks" \) -type f | while IFS= read -r src_file; do
+    src_rel="${src_file#$project_dir/}"
+    if ! is_excluded "$src_rel" "$all_excludes"; then
+      cp "$src_file" "$kicad_staging/"
+    fi
+  done
+
+  # manifest.json at root
+  cp "$manifest_path" "$staging_dir/manifest.json"
+
+  bundle_path="$output_dir/bundle.zip"
+  create_bundle_zip "$staging_dir" "$bundle_path"
+  if [ $? -ne 0 ]; then
+    echo "::error::Failed to create bundle for $rel_project_path" >&2
+    call_fail_api "$board_run_id" "Bundle creation failed" "Failed to create bundle.zip"
+    RESULTS=$(echo "$RESULTS" | jq --arg path "$rel_project_path" --arg status "error" \
+      '. + [{"path": $path, "status": $status, "error": "bundle creation failed"}]')
+    EXIT_CODE=1
+    continue
+  fi
+
+  bundle_sha256=$(compute_bundle_sha256 "$bundle_path")
+
+  # M-5: Upload bundle with timeouts
+  http_status=$(curl -s -o /dev/null -w "%{http_code}" \
+    -X PUT \
+    -H "Content-Type: application/zip" \
+    --connect-timeout 30 \
+    --max-time 600 \
+    --data-binary "@$bundle_path" \
+    "$upload_url")
+
+  if [ "$http_status" -lt 200 ] || [ "$http_status" -ge 300 ]; then
+    echo "::error::Upload failed for $rel_project_path (HTTP $http_status)" >&2
+    call_fail_api "$board_run_id" "Upload failed" "HTTP status: $http_status"
+    RESULTS=$(echo "$RESULTS" | jq --arg path "$rel_project_path" --arg status "error" \
+      '. + [{"path": $path, "status": $status, "error": "upload failed"}]')
+    EXIT_CODE=1
+    continue
+  fi
+
+  # C-2: Import API payload with staging_object_key and bundle_size_bytes
+  bundle_size=$(stat -c%s "$bundle_path")
+  import_payload=$(jq -n \
+    --arg key "$staging_object_key" \
+    --arg sha256 "sha256:$bundle_sha256" \
+    --argjson size "$bundle_size" \
+    '{staging_object_key: $key, bundle_sha256: $sha256, bundle_size_bytes: $size}')
+
+  call_import_api "$board_run_id" "$import_payload"
+  if [ $? -ne 0 ]; then
+    echo "::error::Import API failed for $rel_project_path" >&2
+    call_fail_api "$board_run_id" "Import failed" "Import API call failed"
+    RESULTS=$(echo "$RESULTS" | jq --arg path "$rel_project_path" --arg status "error" \
+      '. + [{"path": $path, "status": $status, "error": "import failed"}]')
+    EXIT_CODE=1
+    continue
+  fi
+
+  RESULTS=$(echo "$RESULTS" | jq --arg path "$rel_project_path" --arg status "success" \
+    '. + [{"path": $path, "status": $status}]')
+done
+
+# Write Job Summary
+write_job_summary "$RESULTS"
+
+# Set output
+echo "result=$RESULTS" >> "$GITHUB_OUTPUT" 2>/dev/null || true
+
+# H-4: Fail if detection errors occurred
+if [ $DETECTION_ERRORS -gt 0 ]; then
+  EXIT_CODE=1
+fi
+
+exit $EXIT_CODE

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -377,7 +377,7 @@ for i in "${!VALID_PROJECTS[@]}"; do
     artifacts_status=$(add_artifact_failed "$artifacts_status" "ibom" "iBOM generation failed")
   fi
 
-  # R-1: Add KiCad source artifacts
+  # R-1: Add KiCad source artifacts (with source_path per spec §8.6)
   while IFS= read -r src_file; do
     [ -z "$src_file" ] && continue
     src_rel="${src_file#$project_dir/}"
@@ -390,7 +390,8 @@ for i in "${!VALID_PROJECTS[@]}"; do
         *.kicad_wks) kicad_type="kicad_worksheet" ;;
       esac
       staging_path="kicad/$rel_dir/$src_rel"
-      artifacts_status=$(add_artifact_available "$artifacts_status" "$kicad_type" "$staging_path" "application/octet-stream" "$src_file")
+      source_path="$rel_dir/$src_rel"
+      artifacts_status=$(add_artifact_source "$artifacts_status" "$kicad_type" "$staging_path" "$source_path" "$src_file")
     fi
   done < <(find "$project_dir" -maxdepth 1 -type f \( -name "*.kicad_pro" -o -name "*.kicad_sch" -o -name "*.kicad_pcb" -o -name "*.kicad_wks" \) | LC_ALL=C sort)
 

--- a/action/entrypoint.sh
+++ b/action/entrypoint.sh
@@ -389,8 +389,13 @@ for i in "${!VALID_PROJECTS[@]}"; do
         *.kicad_pcb) kicad_type="kicad_pcb" ;;
         *.kicad_wks) kicad_type="kicad_worksheet" ;;
       esac
-      staging_path="kicad/$rel_dir/$src_rel"
-      source_path="$rel_dir/$src_rel"
+      if [ "$rel_dir" = "." ]; then
+        staging_path="kicad/$src_rel"
+        source_path="$src_rel"
+      else
+        staging_path="kicad/$rel_dir/$src_rel"
+        source_path="$rel_dir/$src_rel"
+      fi
       artifacts_status=$(add_artifact_source "$artifacts_status" "$kicad_type" "$staging_path" "$source_path" "$src_file")
     fi
   done < <(find "$project_dir" -maxdepth 1 -type f \( -name "*.kicad_pro" -o -name "*.kicad_sch" -o -name "*.kicad_pcb" -o -name "*.kicad_wks" \) | LC_ALL=C sort)
@@ -445,7 +450,11 @@ for i in "${!VALID_PROJECTS[@]}"; do
   cp "$diff_dir/previews.json" "$staging_dir/diff/" 2>/dev/null
 
   # H-5: Collect KiCad source files
-  kicad_staging="$staging_dir/kicad/$rel_dir"
+  if [ "$rel_dir" = "." ]; then
+    kicad_staging="$staging_dir/kicad"
+  else
+    kicad_staging="$staging_dir/kicad/$rel_dir"
+  fi
   mkdir -p "$kicad_staging"
   find "$project_dir" -maxdepth 1 \( -name "*.kicad_pro" -o -name "*.kicad_sch" -o -name "*.kicad_pcb" -o -name "*.kicad_wks" \) -type f | while IFS= read -r src_file; do
     src_rel="${src_file#$project_dir/}"

--- a/action/lib/api.sh
+++ b/action/lib/api.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# api.sh - SaaS API calls with retry logic
+
+# Generic API request with retry (3 attempts, exponential backoff for 5xx/timeout)
+api_request() {
+  local method="$1"
+  local endpoint="$2"
+  local body="${3:-}"
+
+  local url="${API_URL}${endpoint}"
+  local max_retries=3
+  local attempt=0
+  local backoff=1
+
+  while [ $attempt -lt $max_retries ]; do
+    attempt=$((attempt + 1))
+    local response
+    local curl_args=(
+      -s
+      -X "$method"
+      -H "Authorization: Bearer $TOKEN"
+      -H "Content-Type: application/json"
+      -w "\n%{http_code}"
+      --connect-timeout 30
+      --max-time 60
+    )
+
+    if [ -n "$body" ]; then
+      curl_args+=(-d "$body")
+    fi
+
+    response=$(curl "${curl_args[@]}" "$url" 2>/dev/null)
+    local curl_exit=$?
+
+    if [ $curl_exit -ne 0 ]; then
+      # Connection timeout or error
+      if [ $attempt -lt $max_retries ]; then
+        echo "Retry $attempt: curl error $curl_exit for $endpoint" >&2
+        sleep $backoff
+        backoff=$((backoff * 2))
+        continue
+      fi
+      echo "API request failed after $max_retries attempts: $endpoint" >&2
+      return 1
+    fi
+
+    local http_status
+    http_status=$(echo "$response" | tail -n1)
+    local response_body
+    response_body=$(echo "$response" | sed '$d')
+
+    if [ "$http_status" -ge 500 ] 2>/dev/null; then
+      if [ $attempt -lt $max_retries ]; then
+        echo "Retry $attempt: HTTP $http_status for $endpoint" >&2
+        sleep $backoff
+        backoff=$((backoff * 2))
+        continue
+      fi
+      echo "API request failed with HTTP $http_status after $max_retries attempts: $endpoint" >&2
+      return 1
+    fi
+
+    if [ "$http_status" -ge 400 ] 2>/dev/null; then
+      echo "API error HTTP $http_status: $response_body" >&2
+      return 1
+    fi
+
+    echo "$response_body"
+    return 0
+  done
+
+  return 1
+}
+
+# POST /api/v1/runs/plan (H-1: return .projects not .decisions)
+call_plan_api() {
+  local payload_json="$1"
+  local response
+  response=$(api_request "POST" "/api/v1/runs/plan" "$payload_json")
+  if [ $? -ne 0 ]; then
+    return 1
+  fi
+  echo "$response" | jq '.projects'
+}
+
+# POST /api/v1/board-runs
+call_create_board_run() {
+  local payload_json="$1"
+  api_request "POST" "/api/v1/board-runs" "$payload_json"
+}
+
+# POST /api/v1/board-runs/{id}/artifact-bundles/import
+call_import_api() {
+  local board_run_id="$1"
+  local payload_json="$2"
+  api_request "POST" "/api/v1/board-runs/${board_run_id}/artifact-bundles/import" "$payload_json"
+}
+
+# POST /api/v1/board-runs/{id}/fail (H-3: spec-compliant payload)
+call_fail_api() {
+  local board_run_id="$1"
+  local message="$2"
+  local details="${3:-}"
+  local payload
+  payload=$(jq -n --arg msg "$message" --arg det "$details" \
+    '{status: "failed", error: {message: $msg, details: $det}}')
+  api_request "POST" "/api/v1/board-runs/${board_run_id}/fail" "$payload"
+}

--- a/action/lib/bundle.sh
+++ b/action/lib/bundle.sh
@@ -1,0 +1,216 @@
+#!/bin/bash
+# bundle.sh - Manifest/zip bundle creation
+
+# Create fabrication.zip from gerber + drill files
+create_fabrication_zip() {
+  local gerber_dir="$1"
+  local drill_dir="$2"
+  local output_path="$3"
+
+  local tmp_dir
+  tmp_dir=$(mktemp -d)
+  cp "$gerber_dir"/* "$tmp_dir/" 2>/dev/null
+  cp "$drill_dir"/* "$tmp_dir/" 2>/dev/null
+
+  (cd "$tmp_dir" && zip -q "$output_path" ./* 2>/dev/null)
+  local exit_code=$?
+  rm -rf "$tmp_dir"
+  return $exit_code
+}
+
+# Generate file hashes JSON: {files: [{path, sha256}...]}
+generate_file_hashes_json() {
+  local project_dir="$1"
+  local excludes="$2"
+  local output_path="$3"
+
+  local files_json="[]"
+  while IFS= read -r rel_path; do
+    [ -z "$rel_path" ] && continue
+    local file_hash
+    file_hash=$(compute_file_sha256 "$project_dir/$rel_path")
+    files_json=$(echo "$files_json" | jq --arg p "$rel_path" --arg h "$file_hash" \
+      '. + [{"path": $p, "sha256": $h}]')
+  done < <(list_project_files "$project_dir" "$excludes" | LC_ALL=C sort)
+
+  jq -n --argjson files "$files_json" '{files: $files}' > "$output_path"
+}
+
+# Generate BOM summary JSON from CSV (C-3: use sys.argv for paths)
+generate_bom_summary_json() {
+  local bom_csv_path="$1"
+  local output_path="$2"
+
+  if [ ! -f "$bom_csv_path" ]; then
+    echo '{"components":[],"total_count":0}' > "$output_path"
+    return 0
+  fi
+
+  python3 - "$bom_csv_path" "$output_path" <<'PYTHON'
+import csv, json, sys
+bom_csv_path = sys.argv[1]
+output_path = sys.argv[2]
+components = []
+try:
+    with open(bom_csv_path, 'r') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            components.append({
+                'reference': row.get('Reference', row.get('Refs', '')),
+                'value': row.get('Value', ''),
+                'footprint': row.get('Footprint', ''),
+                'quantity': row.get('Qty', '1')
+            })
+except Exception as e:
+    print(str(e), file=sys.stderr)
+result = {'components': components, 'total_count': len(components)}
+with open(output_path, 'w') as f:
+    json.dump(result, f, indent=2)
+PYTHON
+}
+
+# Generate checks summary JSON from ERC/DRC
+generate_checks_summary_json() {
+  local erc_json="$1"
+  local drc_json="$2"
+  local output_path="$3"
+
+  local erc_errors=0
+  local erc_warnings=0
+  local drc_errors=0
+  local drc_warnings=0
+
+  if [ -f "$erc_json" ]; then
+    erc_errors=$(jq '[.violations[]? | select(.severity == "error")] | length' "$erc_json" 2>/dev/null || echo 0)
+    erc_warnings=$(jq '[.violations[]? | select(.severity == "warning")] | length' "$erc_json" 2>/dev/null || echo 0)
+  fi
+
+  if [ -f "$drc_json" ]; then
+    drc_errors=$(jq '[.violations[]? | select(.severity == "error")] | length' "$drc_json" 2>/dev/null || echo 0)
+    drc_warnings=$(jq '[.violations[]? | select(.severity == "warning")] | length' "$drc_json" 2>/dev/null || echo 0)
+  fi
+
+  jq -n \
+    --argjson erc_errors "$erc_errors" \
+    --argjson erc_warnings "$erc_warnings" \
+    --argjson drc_errors "$drc_errors" \
+    --argjson drc_warnings "$drc_warnings" \
+    '{erc: {errors: $erc_errors, warnings: $erc_warnings}, drc: {errors: $drc_errors, warnings: $drc_warnings}}' > "$output_path"
+}
+
+# Generate artifacts summary JSON
+generate_artifacts_summary_json() {
+  local artifacts_status="$1"
+  local output_path="$2"
+
+  echo "$artifacts_status" | jq '{artifacts: .}' > "$output_path"
+}
+
+# Generate previews JSON
+generate_previews_json() {
+  local output_dir="$1"
+  local output_path="$2"
+
+  local previews="[]"
+  for f in "$output_dir/svg/pcb_top.svg" "$output_dir/svg/pcb_bottom.svg" \
+           "$output_dir/3d/top.png" "$output_dir/3d/bottom.png"; do
+    if [ -f "$f" ]; then
+      local name
+      name=$(basename "$f")
+      previews=$(echo "$previews" | jq --arg name "$name" --arg path "$f" \
+        '. + [{"name": $name, "path": $path}]')
+    fi
+  done
+
+  jq -n --argjson previews "$previews" '{previews: $previews}' > "$output_path"
+}
+
+# Create manifest.json (M-4: spec section 8.5 compliant)
+create_manifest() {
+  local board_project_id="$1"
+  local project_path="$2"
+  local project_dir_rel="$3"
+  local config_path="$4"
+  local tree_hash="$5"
+  local sha="$6"
+  local ref="$7"
+  local branch="$8"
+  local run_id="$9"
+  local run_attempt="${10}"
+  local checks_path="${11}"
+  local artifacts_status="${12}"
+  local diff_dir="${13}"
+  local output_path="${14}"
+
+  local checks="{}"
+  if [ -f "$checks_path" ]; then
+    checks=$(cat "$checks_path")
+  fi
+
+  # Build diff_metadata
+  local diff_metadata="{}"
+  if [ -d "$diff_dir" ]; then
+    diff_metadata=$(python3 - "$diff_dir" <<'PYTHON'
+import json, sys, os, hashlib
+diff_dir = sys.argv[1]
+result = {}
+for name in ["file_hashes", "bom_summary", "checks_summary", "artifacts_summary", "previews"]:
+    path = os.path.join(diff_dir, f"{name}.json")
+    if os.path.exists(path):
+        size = os.path.getsize(path)
+        with open(path, 'rb') as f:
+            sha = hashlib.sha256(f.read()).hexdigest()
+        result[name] = {"path": f"diff/{name}.json", "sha256": f"sha256:{sha}", "size_bytes": size}
+print(json.dumps(result))
+PYTHON
+    )
+  fi
+
+  # Build artifacts array from artifacts_status
+  local artifacts_array="[]"
+  if [ -n "$artifacts_status" ] && [ "$artifacts_status" != "[]" ]; then
+    artifacts_array="$artifacts_status"
+  fi
+
+  jq -n \
+    --argjson schema_version 1 \
+    --arg board_project_id "$board_project_id" \
+    --arg project_path "$project_path" \
+    --arg project_dir "$project_dir_rel" \
+    --arg config_path "$config_path" \
+    --arg ref "$ref" \
+    --arg branch "$branch" \
+    --arg commit_sha "$sha" \
+    --arg run_id "$run_id" \
+    --arg run_attempt "$run_attempt" \
+    --arg tree_hash "sha256:$tree_hash" \
+    --argjson checks "$checks" \
+    --argjson diff_metadata "$diff_metadata" \
+    --argjson artifacts "$artifacts_array" \
+    '{
+      schema_version: $schema_version,
+      board_project_id: $board_project_id,
+      project: {project_path: $project_path, project_dir: $project_dir, config_path: $config_path},
+      git: {ref: $ref, branch: $branch, commit_sha: $commit_sha},
+      github_actions: {run_id: $run_id, run_attempt: $run_attempt},
+      kicad: {version: "9.0.x"},
+      hash: {tree_hash: $tree_hash},
+      diff_metadata: $diff_metadata,
+      checks: $checks,
+      artifacts: $artifacts
+    }' > "$output_path"
+}
+
+# Create bundle zip from staging directory
+create_bundle_zip() {
+  local staging_dir="$1"
+  local output_path="$2"
+
+  (cd "$staging_dir" && zip -qr "$output_path" . 2>/dev/null)
+}
+
+# Compute SHA256 of bundle
+compute_bundle_sha256() {
+  local bundle_path="$1"
+  sha256sum "$bundle_path" | cut -d' ' -f1
+}

--- a/action/lib/bundle.sh
+++ b/action/lib/bundle.sh
@@ -22,6 +22,28 @@ add_artifact_available() {
     '. + [{"type": $type, "status": "available", "path": $path, "content_type": $ct, "sha256": $sha, "size_bytes": $size}]'
 }
 
+# Add artifact entry for KiCad source file (includes source_path)
+add_artifact_source() {
+  local artifacts_json="$1"
+  local type="$2"
+  local path="$3"
+  local source_path="$4"
+  local file_path="$5"
+
+  local sha256 size_bytes
+  sha256=$(sha256sum "$file_path" | cut -d' ' -f1)
+  size_bytes=$(stat -c%s "$file_path")
+
+  echo "$artifacts_json" | jq \
+    --arg type "$type" \
+    --arg path "$path" \
+    --arg sp "$source_path" \
+    --arg ct "text/plain; charset=utf-8" \
+    --arg sha "sha256:$sha256" \
+    --argjson size "$size_bytes" \
+    '. + [{"type": $type, "status": "available", "path": $path, "source_path": $sp, "content_type": $ct, "sha256": $sha, "size_bytes": $size}]'
+}
+
 # Add artifact entry for failed artifact
 add_artifact_failed() {
   local artifacts_json="$1"

--- a/action/lib/bundle.sh
+++ b/action/lib/bundle.sh
@@ -1,6 +1,39 @@
 #!/bin/bash
 # bundle.sh - Manifest/zip bundle creation
 
+# Add artifact entry for available artifact
+add_artifact_available() {
+  local artifacts_json="$1"
+  local type="$2"
+  local path="$3"
+  local content_type="$4"
+  local file_path="$5"
+
+  local sha256 size_bytes
+  sha256=$(sha256sum "$file_path" | cut -d' ' -f1)
+  size_bytes=$(stat -c%s "$file_path")
+
+  echo "$artifacts_json" | jq \
+    --arg type "$type" \
+    --arg path "$path" \
+    --arg ct "$content_type" \
+    --arg sha "sha256:$sha256" \
+    --argjson size "$size_bytes" \
+    '. + [{"type": $type, "status": "available", "path": $path, "content_type": $ct, "sha256": $sha, "size_bytes": $size}]'
+}
+
+# Add artifact entry for failed artifact
+add_artifact_failed() {
+  local artifacts_json="$1"
+  local type="$2"
+  local error_message="$3"
+
+  echo "$artifacts_json" | jq \
+    --arg type "$type" \
+    --arg msg "$error_message" \
+    '. + [{"type": $type, "status": "failed", "error_message": $msg}]'
+}
+
 # Create fabrication.zip from gerber + drill files
 create_fabrication_zip() {
   local gerber_dir="$1"

--- a/action/lib/config.sh
+++ b/action/lib/config.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+# config.sh - .boardflow.yml schema validation and exclude_paths parsing
+
+# Parse .boardflow.yml to JSON using python3 (C-3: use sys.argv for path)
+parse_boardflow_yml() {
+  local path="$1"
+  python3 - "$path" <<'PYTHON'
+import yaml, json, sys
+try:
+    with open(sys.argv[1], 'r') as f:
+        data = yaml.safe_load(f)
+    if data is None:
+        data = {}
+    print(json.dumps(data))
+except Exception as e:
+    print(str(e), file=sys.stderr)
+    sys.exit(1)
+PYTHON
+}
+
+# Validate schema version 1
+validate_schema_v1() {
+  local json="$1"
+  local valid
+  valid=$(echo "$json" | python3 -c "
+import json, sys
+
+data = json.load(sys.stdin)
+allowed_top = {'version', 'outputs', 'exclude_paths'}
+allowed_outputs = {'preset'}
+
+# Check version
+if data.get('version') != 1:
+    print('invalid version', file=sys.stderr)
+    sys.exit(1)
+
+# Check unknown top-level fields
+unknown = set(data.keys()) - allowed_top
+if unknown:
+    print(f'unknown fields: {unknown}', file=sys.stderr)
+    sys.exit(1)
+
+# Check outputs fields if present
+if 'outputs' in data and isinstance(data['outputs'], dict):
+    unknown_out = set(data['outputs'].keys()) - allowed_outputs
+    if unknown_out:
+        print(f'unknown output fields: {unknown_out}', file=sys.stderr)
+        sys.exit(1)
+
+print('ok')
+" 2>&1)
+
+  if [ "$valid" = "ok" ]; then
+    return 0
+  else
+    echo "$valid" >&2
+    return 1
+  fi
+}
+
+# Extract exclude_paths from config JSON
+get_exclude_paths_from_config() {
+  local json="$1"
+  echo "$json" | jq -r '.exclude_paths // [] | .[]' 2>/dev/null
+}
+
+# Merge three exclude lists into union (newline-separated)
+merge_excludes() {
+  local builtin="$1"
+  local input="$2"
+  local yml="$3"
+
+  {
+    echo "$builtin"
+    echo "$input"
+    echo "$yml"
+  } | grep -v '^$' | sort -u
+}

--- a/action/lib/detect.sh
+++ b/action/lib/detect.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+# detect.sh - .boardflow.yml detection and BoardProject candidate resolution
+
+WORKSPACE="${WORKSPACE:-/github/workspace}"
+
+# Find all .boardflow.yml files in the workspace
+find_boardflow_ymls() {
+  find "$WORKSPACE" -name ".boardflow.yml" -type f 2>/dev/null
+}
+
+# Detect projects and populate PROJECTS array
+detect_projects() {
+  PROJECTS=()
+  while IFS= read -r yml; do
+    [ -z "$yml" ] && continue
+    PROJECTS+=("$(dirname "$yml")")
+  done < <(find_boardflow_ymls)
+}
+
+# Resolve unique .kicad_pro in directory
+resolve_kicad_pro() {
+  local dir="$1"
+  local pros=()
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    pros+=("$f")
+  done < <(find "$dir" -maxdepth 1 -name "*.kicad_pro" -type f 2>/dev/null)
+
+  if [ ${#pros[@]} -eq 0 ]; then
+    echo "No .kicad_pro found in $dir" >&2
+    return 1
+  fi
+  if [ ${#pros[@]} -gt 1 ]; then
+    echo "Multiple .kicad_pro found in $dir" >&2
+    return 1
+  fi
+  echo "${pros[0]}"
+  return 0
+}
+
+# Resolve PCB file: prefer same stem, fallback to unique .kicad_pcb
+resolve_pcb_file() {
+  local dir="$1"
+  local pro_stem="$2"
+  local same_stem="$dir/${pro_stem}.kicad_pcb"
+
+  if [ -f "$same_stem" ]; then
+    echo "$same_stem"
+    return 0
+  fi
+
+  local pcbs=()
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    pcbs+=("$f")
+  done < <(find "$dir" -maxdepth 1 -name "*.kicad_pcb" -type f 2>/dev/null)
+
+  if [ ${#pcbs[@]} -eq 1 ]; then
+    echo "${pcbs[0]}"
+    return 0
+  fi
+
+  echo "Cannot resolve unique .kicad_pcb in $dir" >&2
+  return 1
+}
+
+# Resolve root schematic: prefer same stem, fallback to unique .kicad_sch
+resolve_root_schematic() {
+  local dir="$1"
+  local pro_stem="$2"
+  local same_stem="$dir/${pro_stem}.kicad_sch"
+
+  if [ -f "$same_stem" ]; then
+    echo "$same_stem"
+    return 0
+  fi
+
+  local schs=()
+  while IFS= read -r f; do
+    [ -z "$f" ] && continue
+    schs+=("$f")
+  done < <(find "$dir" -maxdepth 1 -name "*.kicad_sch" -type f 2>/dev/null)
+
+  if [ ${#schs[@]} -eq 1 ]; then
+    echo "${schs[0]}"
+    return 0
+  fi
+
+  echo "Cannot resolve unique .kicad_sch in $dir" >&2
+  return 1
+}
+
+# Validate that required files are not excluded
+validate_required_files() {
+  local dir="$1"
+  local pro="$2"
+  local pcb="$3"
+  local sch="$4"
+  local excludes="$5"
+
+  for file in "$pro" "$pcb" "$sch"; do
+    local rel="${file#$dir/}"
+    if is_excluded "$rel" "$excludes"; then
+      echo "Required file $rel is excluded" >&2
+      return 1
+    fi
+  done
+  return 0
+}

--- a/action/lib/hash.sh
+++ b/action/lib/hash.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# hash.sh - File hash and tree_hash computation
+
+# Built-in exclude patterns
+BUILTIN_EXCLUDES="**/*.lck
+**/*.bak
+**/*-backups/**
+**/fp-info-cache
+**/.DS_Store
+**/output/**
+**/outputs/**
+**/fabrication/**
+**/gerber/**
+**/gerbers/**"
+
+# Check if a path matches any exclude pattern using fnmatch (C-3: use sys.argv/stdin)
+is_excluded() {
+  local path="$1"
+  local excludes="$2"
+  echo "$excludes" | python3 - "$path" <<'PYTHON'
+import fnmatch, sys
+path = sys.argv[1]
+excludes = sys.stdin.read().strip().splitlines()
+for pattern in excludes:
+    pattern = pattern.strip()
+    if not pattern:
+        continue
+    if fnmatch.fnmatch(path, pattern):
+        sys.exit(0)
+sys.exit(1)
+PYTHON
+}
+
+# List project files filtered by excludes (M-1: batch filtering in single Python call)
+list_project_files() {
+  local project_dir="$1"
+  local excludes="$2"
+
+  find "$project_dir" -type f 2>/dev/null | \
+    EXCLUDES="$excludes" python3 - "$project_dir" <<'PYTHON'
+import fnmatch, sys, os
+project_dir = sys.argv[1]
+excludes = os.environ.get('EXCLUDES', '').strip().splitlines()
+excludes = [p.strip() for p in excludes if p.strip()]
+for line in sys.stdin:
+    filepath = line.strip()
+    if not filepath:
+        continue
+    rel = os.path.relpath(filepath, project_dir)
+    excluded = False
+    for pattern in excludes:
+        if fnmatch.fnmatch(rel, pattern):
+            excluded = True
+            break
+    if not excluded:
+        print(rel)
+PYTHON
+}
+
+# Compute SHA256 of a file
+compute_file_sha256() {
+  local path="$1"
+  sha256sum "$path" | cut -d' ' -f1
+}
+
+# Compute tree hash: sha256(sorted(relative_path\0sha256\n))
+compute_tree_hash() {
+  local project_dir="$1"
+  local excludes="$2"
+
+  local entries=""
+  while IFS= read -r rel_path; do
+    [ -z "$rel_path" ] && continue
+    local file_hash
+    file_hash=$(compute_file_sha256 "$project_dir/$rel_path")
+    entries+="${rel_path}\x00${file_hash}\n"
+  done < <(list_project_files "$project_dir" "$excludes" | LC_ALL=C sort)
+
+  printf "%b" "$entries" | sha256sum | cut -d' ' -f1
+}

--- a/action/lib/ibom.sh
+++ b/action/lib/ibom.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# ibom.sh - InteractiveHtmlBom generation
+
+# Generate Interactive HTML BOM
+# Failure is non-fatal: recorded as artifact status=failed, BoardRun continues
+run_ibom() {
+  local pcb_path="$1"
+  local output_dir="$2"
+
+  xvfb-run generate_interactive_bom \
+    --no-browser \
+    --dest-dir "$output_dir" \
+    "$pcb_path" 2>&1
+
+  local exit_code=$?
+  if [ $exit_code -ne 0 ]; then
+    echo "iBOM generation failed with exit code $exit_code" >&2
+    return 1
+  fi
+  return 0
+}

--- a/action/lib/kicad.sh
+++ b/action/lib/kicad.sh
@@ -1,0 +1,146 @@
+#!/bin/bash
+# kicad.sh - KiCad CLI execution wrappers
+
+KICAD_TIMEOUT=300
+
+# Run ERC check
+run_erc() {
+  local sch_file="$1"
+  local output_json="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli sch erc \
+    --format json \
+    --severity-all \
+    --exit-code-violations \
+    --output "$output_json" \
+    "$sch_file" 2>&1
+
+  local exit_code=$?
+  # exit 5 = violations found but JSON generated successfully
+  if [ $exit_code -eq 0 ] || [ $exit_code -eq 5 ]; then
+    return $exit_code
+  fi
+  echo "ERC failed with exit code $exit_code" >&2
+  return $exit_code
+}
+
+# Run DRC check
+run_drc() {
+  local pcb_file="$1"
+  local output_json="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli pcb drc \
+    --format json \
+    --severity-all \
+    --exit-code-violations \
+    --output "$output_json" \
+    "$pcb_file" 2>&1
+
+  local exit_code=$?
+  if [ $exit_code -eq 0 ] || [ $exit_code -eq 5 ]; then
+    return $exit_code
+  fi
+  echo "DRC failed with exit code $exit_code" >&2
+  return $exit_code
+}
+
+# Export PCB PDF
+run_pcb_pdf() {
+  local pcb_file="$1"
+  local output_pdf="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli pcb export pdf \
+    --layers "F.Cu,B.Cu,F.Silkscreen,B.Silkscreen,Edge.Cuts" \
+    --output "$output_pdf" \
+    "$pcb_file" 2>&1
+}
+
+# Export Schematic PDF
+run_sch_pdf() {
+  local sch_file="$1"
+  local output_pdf="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli sch export pdf \
+    --output "$output_pdf" \
+    "$sch_file" 2>&1
+}
+
+# Export PCB SVG (top)
+run_pcb_svg_top() {
+  local pcb_file="$1"
+  local output_svg="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli pcb export svg \
+    --mode-multi \
+    --layers "F.Cu,F.Silkscreen,F.Mask,Edge.Cuts" \
+    --output "$output_svg" \
+    "$pcb_file" 2>&1
+}
+
+# Export PCB SVG (bottom)
+run_pcb_svg_bottom() {
+  local pcb_file="$1"
+  local output_svg="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli pcb export svg \
+    --mode-multi \
+    --layers "B.Cu,B.Silkscreen,B.Mask,Edge.Cuts" \
+    --output "$output_svg" \
+    "$pcb_file" 2>&1
+}
+
+# Export Gerbers
+run_gerber_export() {
+  local pcb_file="$1"
+  local output_dir="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli pcb export gerbers \
+    --output "$output_dir/" \
+    "$pcb_file" 2>&1
+}
+
+# Export Drill files
+run_drill_export() {
+  local pcb_file="$1"
+  local output_dir="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli pcb export drill \
+    --format excellon \
+    --excellon-separate-th \
+    --output "$output_dir/" \
+    "$pcb_file" 2>&1
+}
+
+# Export BOM
+run_bom_export() {
+  local sch_file="$1"
+  local output_csv="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli sch export bom \
+    --output "$output_csv" \
+    "$sch_file" 2>&1
+}
+
+# Export Position file
+run_position_export() {
+  local pcb_file="$1"
+  local output_csv="$2"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli pcb export pos \
+    --format csv \
+    --output "$output_csv" \
+    "$pcb_file" 2>&1
+}
+
+# Render 3D view
+run_3d_render() {
+  local pcb_file="$1"
+  local output_png="$2"
+  local side="$3"
+
+  timeout "$KICAD_TIMEOUT" kicad-cli pcb render \
+    --side "$side" \
+    --quality basic \
+    --output "$output_png" \
+    "$pcb_file" 2>&1
+}

--- a/action/lib/summary.sh
+++ b/action/lib/summary.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# summary.sh - GitHub Actions Job Summary output
+
+# Write Job Summary with project results
+write_job_summary() {
+  local results="$1"
+  local summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+  {
+    echo "## BoardFlow Action Results"
+    echo ""
+    echo "| Project | Status | Details |"
+    echo "|---------|--------|---------|"
+
+    echo "$results" | jq -r '.[] | "| \(.path) | \(.status) | \(.error // "-") |"'
+
+    echo ""
+
+    local total
+    total=$(echo "$results" | jq 'length')
+    local success
+    success=$(echo "$results" | jq '[.[] | select(.status == "success")] | length')
+    local skipped
+    skipped=$(echo "$results" | jq '[.[] | select(.status == "skipped")] | length')
+    local errors
+    errors=$(echo "$results" | jq '[.[] | select(.status == "error")] | length')
+
+    echo "**Total:** $total projects | **Success:** $success | **Skipped:** $skipped | **Errors:** $errors"
+  } >> "$summary_file"
+}
+
+# Write summary for unsupported events
+write_unsupported_event_summary() {
+  local event_name="$1"
+  local summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+  {
+    echo "## BoardFlow Action"
+    echo ""
+    echo "⚠️ Unsupported event: \`$event_name\`"
+    echo ""
+    echo "BoardFlow Action only runs on push events. Pull request support is planned for a future release."
+  } >> "$summary_file"
+}

--- a/docs/external/github-actions-docker-action.md
+++ b/docs/external/github-actions-docker-action.md
@@ -1,0 +1,169 @@
+# GitHub Actions Docker Container Action 仕様
+
+## 概要
+
+GitHub Actions Docker container actionは、Dockerコンテナ内でアクションロジックを実行する仕組み。
+Linuxランナー専用。
+
+**出典**:
+- https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions
+- https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action
+- https://docs.github.com/en/actions/reference/workflows-and-actions/variables
+
+## ファイル構成
+
+```
+my-action/
+  action.yml        # アクションメタデータ (必須)
+  Dockerfile        # コンテナ定義
+  entrypoint.sh     # 実行スクリプト
+```
+
+## action.yml 完全スキーマ (Docker container action)
+
+```yaml
+name: 'Action Name'          # 必須
+author: 'Author Name'        # オプション
+description: 'Description'   # 必須
+
+branding:                    # オプション (GitHub Marketplace用)
+  icon: 'package'            # Feather icon名
+  color: 'blue'              # white|black|yellow|blue|green|orange|red|purple|gray-dark
+
+inputs:
+  input-id:                  # 入力パラメータID (小文字推奨)
+    description: '...'       # 必須
+    required: true           # オプション (デフォルト: false)
+    default: 'value'         # オプション
+    deprecationMessage: ''   # オプション (非推奨警告)
+
+outputs:
+  output-id:                 # 出力パラメータID
+    description: '...'       # 必須
+
+runs:
+  using: 'docker'                      # 必須。'docker'固定
+  image: 'Dockerfile'                  # 必須。ローカルDockerfile or 'docker://image:tag'
+  env:                                 # オプション。コンテナ内環境変数
+    KEY: value
+  pre-entrypoint: 'setup.sh'           # オプション。entrypoint前スクリプト
+  pre-if: 'always()'                   # オプション。pre-entrypoint実行条件
+  entrypoint: 'main.sh'               # オプション。ENTRYPOINT上書き
+  args:                                # オプション。entrypointへの引数
+    - ${{ inputs.input-id }}
+    - 'literal'
+  post-entrypoint: 'cleanup.sh'        # オプション。entrypoint後スクリプト
+  post-if: 'always()'                  # オプション。post-entrypoint実行条件
+```
+
+## image 指定方法
+
+```yaml
+# 方法1: リポジトリ内Dockerfileからビルド (初回実行時にビルド)
+image: 'Dockerfile'
+
+# 方法2: Docker Hubから取得
+image: 'docker://debian:stretch-slim'
+
+# 方法3: GitHub Container Registry等から取得 (推奨: 事前ビルド済みで高速)
+image: 'docker://ghcr.io/owner/action-image:v1'
+```
+
+## inputs の受け渡し
+
+inputsを定義すると、Docker container action内で自動的に環境変数として設定される:
+- `input-id: api-url` → 環境変数 `INPUT_API-URL`
+- 変換規則: `INPUT_` + 大文字化 (ハイフンはそのまま)
+
+```yaml
+# action.yml
+inputs:
+  api-url:
+    description: 'API endpoint URL'
+    required: true
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.api-url }}  # entrypointの引数として渡す方法
+```
+
+```bash
+# entrypoint.sh 内でのアクセス方法
+# 方法1: 環境変数から (自動注入)
+echo "$INPUT_API-URL"
+
+# 方法2: args経由 (位置引数)
+API_URL="$1"
+```
+
+## outputs の設定
+
+```bash
+# entrypoint.sh 内
+echo "artifact-url=https://example.com/artifact/123" >> "$GITHUB_OUTPUT"
+echo "status=success" >> "$GITHUB_OUTPUT"
+```
+
+## Job Summary ($GITHUB_STEP_SUMMARY)
+
+```bash
+# entrypoint.sh 内
+echo '## Build Results' >> "$GITHUB_STEP_SUMMARY"
+echo '' >> "$GITHUB_STEP_SUMMARY"
+echo '| Check | Result |' >> "$GITHUB_STEP_SUMMARY"
+echo '|-------|--------|' >> "$GITHUB_STEP_SUMMARY"
+echo "| ERC | ✅ Pass |" >> "$GITHUB_STEP_SUMMARY"
+echo "| DRC | ❌ 3 errors |" >> "$GITHUB_STEP_SUMMARY"
+echo '' >> "$GITHUB_STEP_SUMMARY"
+echo '[View full report](https://example.com/report)' >> "$GITHUB_STEP_SUMMARY"
+```
+
+- GitHub Flavored Markdown完全サポート (テーブル、コードブロック、Mermaid等)
+- 複数回の `>>` 追記可能 (同一ステップ内)
+- ステップごとにファイルパスが変わる
+
+## Docker container action 内で利用可能な環境変数
+
+### GitHub提供のデフォルト環境変数 (entrypoint内で利用可能)
+
+| 変数 | 説明 | 例 |
+|------|------|-----|
+| `GITHUB_REPOSITORY` | owner/repo | `octocat/Hello-World` |
+| `GITHUB_SHA` | コミットSHA | `ffac537e6cbb...` |
+| `GITHUB_REF` | ref (フル形式) | `refs/heads/main` |
+| `GITHUB_REF_NAME` | ブランチ/タグ名 | `main` |
+| `GITHUB_RUN_ID` | 実行ID | `1658821493` |
+| `GITHUB_RUN_ATTEMPT` | 試行回数 | `1` |
+| `GITHUB_RUN_NUMBER` | 実行番号 | `3` |
+| `GITHUB_WORKSPACE` | ワークスペースパス | `/github/workspace` |
+| `GITHUB_OUTPUT` | 出力ファイルパス | (ステップ毎に異なる) |
+| `GITHUB_STEP_SUMMARY` | サマリファイルパス | (ステップ毎に異なる) |
+| `GITHUB_SERVER_URL` | GitHubサーバURL | `https://github.com` |
+| `GITHUB_API_URL` | API URL | `https://api.github.com` |
+| `GITHUB_EVENT_NAME` | イベント名 | `push` |
+| `GITHUB_EVENT_PATH` | イベントペイロードJSON | `/github/workflow/event.json` |
+| `GITHUB_ACTOR` | 実行者名 | `octocat` |
+| `GITHUB_TOKEN` | 自動生成トークン | (secrets経由で渡す必要あり) |
+| `RUNNER_TEMP` | 一時ディレクトリ | `/home/runner/work/_temp` |
+
+### 注意事項
+
+- Dockerfile内の `RUN` 命令ではGITHUB_*変数は利用不可 (ビルド時にはまだ設定されない)
+- entrypoint.sh の実行時にのみ利用可能
+- `/github/workspace` にリポジトリのチェックアウト内容がマウントされる
+- `GITHUB_TOKEN` はsecretsから明示的にinput経由で渡す必要がある:
+
+```yaml
+# ワークフロー側
+- uses: owner/action@v1
+  with:
+    token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Docker container actionの制約
+
+- **Linuxランナー専用** (ubuntu-latest等)
+- image指定が `'Dockerfile'` の場合、毎回ビルドが走る (キャッシュなし)
+- 事前ビルド済みイメージ (`docker://ghcr.io/...`) を使えば起動が高速
+- outputs上限: 1 MB/job, 全outputs合計 50 MB/workflow run

--- a/docs/external/github-actions-docker-action.md
+++ b/docs/external/github-actions-docker-action.md
@@ -72,8 +72,8 @@ image: 'docker://ghcr.io/owner/action-image:v1'
 ## inputs の受け渡し
 
 inputsを定義すると、Docker container action内で自動的に環境変数として設定される:
-- `input-id: api-url` → 環境変数 `INPUT_API-URL`
-- 変換規則: `INPUT_` + 大文字化 (ハイフンはそのまま)
+- `input-id: api-url` → 環境変数 `INPUT_API_URL`
+- 変換規則: `INPUT_` + 大文字化 + ハイフンをアンダースコアに変換
 
 ```yaml
 # action.yml
@@ -90,8 +90,8 @@ runs:
 
 ```bash
 # entrypoint.sh 内でのアクセス方法
-# 方法1: 環境変数から (自動注入)
-echo "$INPUT_API-URL"
+# 方法1: 環境変数から (自動注入、ハイフンはアンダースコアに変換される)
+echo "$INPUT_API_URL"
 
 # 方法2: args経由 (位置引数)
 API_URL="$1"

--- a/docs/logs/60/worklog.md
+++ b/docs/logs/60/worklog.md
@@ -961,3 +961,114 @@ H-NEW-1 (source_path欠落) はbackend検証で拒否される可能性が高く
 1. `bundle.sh` に `add_artifact_kicad_source()` 関数追加（source_path, content_type="text/plain; charset=utf-8" を含む）
 2. `entrypoint.sh` L381-395 で当該関数を使用、rel_dir="." 時のパス正規化を追加
 3. 再レビュー実施
+
+---
+
+## ドキュメント確認
+
+**実施日時**: 2026-05-04
+**対象コミット**: `1e7fc9b` (fix: add source_path to KiCad source artifacts (H-NEW-1))
+
+### 1. spec.md §2.2 workflow例 vs action.yml
+
+| 項目 | spec.md §2.2 | action.yml | 整合性 |
+|------|-------------|------------|--------|
+| uses | `example/boardflow-action@v1` | - | ✅ 参考パス |
+| token | `${{ secrets.BOARDFLOW_TOKEN }}` | input定義あり | ✅ |
+| mode | `${{ github.event.inputs.mode \|\| 'auto' }}` | default: 'auto' | ✅ |
+| exclude-paths | 複数行glob | input定義あり | ✅ |
+| api-url | (未使用) | default設定あり | ✅ |
+| fail-on-drc | (未使用) | default: 'false' | ✅ |
+| fail-on-erc | (未使用) | default: 'false' | ✅ |
+
+**結果**: ✅ 整合
+
+### 2. spec.md §5.2 Action inputs vs action.yml
+
+| 項目 | spec §5.2 | action.yml (実装) | 整合性 |
+|------|-----------|-------------------|--------|
+| name | `BoardFlow` | `BoardFlow Action` | ⚠️ 軽微差異（機能影響なし） |
+| description | `Build KiCad projects and upload artifacts to BoardFlow` | `KiCad CI/CD - Generate artifacts and upload to BoardFlow` | ⚠️ 軽微差異 |
+| inputs 全6項目 | 定義あり | 完全一致 | ✅ |
+| outputs.result | なし | 定義あり（追加） | ✅ 追加は問題なし |
+| runs.using | `docker` | `docker` | ✅ |
+| runs.image | `Dockerfile` | `Dockerfile` | ✅ |
+| runs.args | `- run` | **なし** | ⚠️ 乖離あり |
+
+**乖離点**: spec §5.2 では `args: - run` を定義しているが、action.yml にはargsが含まれない。entrypoint.shはargs不要で動作するため機能影響はないが、将来サブコマンド追加時に不整合となる。
+
+**推奨対応**: spec.md側の `args: - run` を削除するか、action.ymlに `args: - run` を追加してentrypoint.shで引数を受け取るようにする。現時点ではどちらも実害なし。
+
+### 3. docs/external/kicad-docker-cli.md §4 vs action/Dockerfile
+
+| 項目 | §4参考例 | 実装Dockerfile | 整合性 |
+|------|---------|---------------|--------|
+| ベースイメージ | `kicad/kicad:9.0` | `kicad/kicad:9.0` | ✅ |
+| USER root | あり | あり | ✅ |
+| python3-pip | あり | あり | ✅ |
+| xvfb | あり | あり | ✅ |
+| interactivehtmlbom | `pip install` | `pip3 install` | ✅ 同等 |
+| --break-system-packages | あり | あり | ✅ |
+| 追加パッケージ | なし | jq, curl, zip, ca-certificates, python3-yaml | ✅ 正当な追加 |
+| ENTRYPOINT | コメントアウト | `/action/entrypoint.sh` | ✅ |
+
+**結果**: ✅ 整合。実装は参考例を適切に拡張している。
+
+### 4. docs/external/github-actions-docker-action.md の正確性
+
+| セクション | 内容 | 正確性 |
+|-----------|------|--------|
+| ファイル構成 | action.yml / Dockerfile / entrypoint.sh | ✅ |
+| action.yml スキーマ | runs.using, image, args等 | ✅ |
+| image指定方法 | Dockerfile / docker:// | ✅ |
+| **inputs受け渡し** | `INPUT_` + 大文字化 (ハイフンはそのまま) | ❌ **誤り** |
+| outputs設定 | `$GITHUB_OUTPUT` | ✅ |
+| Job Summary | `$GITHUB_STEP_SUMMARY` | ✅ |
+| 環境変数一覧 | GITHUB_* 各種 | ✅ |
+| Docker制約 | Linux限定, imageビルドキャッシュなし | ✅ |
+
+**重大な誤り**: ドキュメント内の inputs 受け渡しセクションに以下の記述がある:
+
+> `input-id: api-url` → 環境変数 `INPUT_API-URL`
+> 変換規則: `INPUT_` + 大文字化 (ハイフンはそのまま)
+
+**実際の動作**: GitHub Actionsはハイフンをアンダースコアに変換する。正しくは:
+- `input-id: api-url` → 環境変数 `INPUT_API_URL`
+- 変換規則: `INPUT_` + 大文字化 + ハイフン→アンダースコア変換
+
+entrypoint.shの実装（C-1修正後）は `INPUT_API_URL` で正しく参照しており、ドキュメントの方が不正確。
+
+### 5. docs/logs/60/worklog.md の正確性
+
+| セクション | 内容 | 正確性 |
+|-----------|------|--------|
+| Issue経緯 | 既存issue/docの参照 | ✅ |
+| 調査結果 | action.yml仕様, env変数, Job Summary | ✅（上記INPUT_*の誤り除く） |
+| 計画 | ファイル構成, 関数設計, 実装順序 | ✅ |
+| 実装内容 | ファイル一覧, 主要判断 | ✅ |
+| レビュー結果 (初回) | C-1〜C-3, H-1〜H-7, M-1〜M-6 | ✅ 指摘は正確 |
+| 再レビュー結果 | R-1〜R-6 | ✅ |
+| 最終レビュー結果 | H-NEW-1, M-NEW-1, M-NEW-2 | ✅ |
+
+### 6. 未修正の残存乖離（M-NEW-2）
+
+`entrypoint.sh` L392-393 で `rel_dir="."` 時のパス正規化が未実装:
+
+```bash
+staging_path="kicad/$rel_dir/$src_rel"  # → "kicad/./file.kicad_pro"
+source_path="$rel_dir/$src_rel"          # → "./file.kicad_pro"
+```
+
+spec §8.5 の例では `"kicad/hardware/motor_driver/motor_driver.kicad_pro"` のようにクリーンなパスを要求。root-levelプロジェクトでは `"kicad/file.kicad_pro"` が正しい。
+
+### 判定
+
+**`docs_ready: false`**
+
+### 修正が必要な箇所
+
+| # | ファイル | 内容 | 優先度 |
+|---|---------|------|--------|
+| 1 | `docs/external/github-actions-docker-action.md` | INPUT_* 環境変数のハイフン→アンダースコア変換ルールの記述を修正 | High |
+| 2 | `docs/spec.md` §5.2 または `action/action.yml` | `args: - run` の有無を一致させる | Low |
+| 3 | `action/entrypoint.sh` L392-393 | M-NEW-2: `rel_dir="."` 時のパス正規化（`./` prefix除去） | Medium |

--- a/docs/logs/60/worklog.md
+++ b/docs/logs/60/worklog.md
@@ -522,3 +522,442 @@ sys.exit(0 if fnmatch.fnmatch(sys.argv[1], sys.argv[2]) else 1)
 6. **INPUT_*環境変数**: ハイフン付き入力名はそのまま `INPUT_EXCLUDE-PATHS` 等で参照
 7. **pull_requestイベント**: サマリ出力のみで即座にexit 0（未サポートイベント）
 8. **タイムアウト**: 全KiCad CLIコマンドに300秒のtimeoutを設定
+
+---
+
+## レビュー結果
+
+**pr_ready: false**
+
+### Critical（修正必須）
+
+#### C-1: 環境変数のパース不正（entrypoint.sh L14-17）
+
+```bash
+EXCLUDE_PATHS="${INPUT_EXCLUDE-PATHS:-}"
+API_URL="${INPUT_API-URL:-https://api.boardflow.example.com}"
+FAIL_ON_DRC="${INPUT_FAIL-ON-DRC:-false}"
+FAIL_ON_ERC="${INPUT_FAIL-ON-ERC:-false}"
+```
+
+**問題**: bashの変数名にハイフンは使用不可。`${INPUT_EXCLUDE-PATHS:-}` はbashにより `INPUT_EXCLUDE` を変数名、`-` を「未定義時のデフォルト値」演算子、`PATHS:-` をデフォルト値として解釈される。結果として、全入力値が常にデフォルト値（または空文字）になる。
+
+GitHub Actions Docker actionsでは、input名のハイフンはアンダースコアに変換されて環境変数化される。
+
+**修正**: 以下に変更する:
+```bash
+EXCLUDE_PATHS="${INPUT_EXCLUDE_PATHS:-}"
+API_URL="${INPUT_API_URL:-https://api.boardflow.example.com}"
+FAIL_ON_DRC="${INPUT_FAIL_ON_DRC:-false}"
+FAIL_ON_ERC="${INPUT_FAIL_ON_ERC:-false}"
+```
+
+#### C-2: Import API ペイロード不足（entrypoint.sh L381-383）
+
+```bash
+import_payload=$(jq -n \
+  --arg sha256 "$bundle_sha256" \
+  '{bundle_sha256: $sha256}')
+```
+
+**問題**: spec §9.3 では `staging_object_key` と `bundle_size_bytes` も必須フィールド。`staging_object_key` は BoardRun作成APIのレスポンスから取得し、`bundle_size_bytes` は bundle.zip のサイズを計算して含める必要がある。
+
+**修正**: BoardRun作成レスポンスから `object_key` を取得し、bundle のファイルサイズを計算してペイロードに含める:
+```bash
+staging_object_key=$(echo "$create_response" | jq -r '.artifact_bundle.object_key')
+bundle_size=$(stat -c%s "$bundle_path")
+import_payload=$(jq -n \
+  --arg key "$staging_object_key" \
+  --arg sha256 "$bundle_sha256" \
+  --argjson size "$bundle_size" \
+  '{staging_object_key: $key, bundle_sha256: $sha256, bundle_size_bytes: $size}')
+```
+
+#### C-3: コマンドインジェクション脆弱性（config.sh, hash.sh, bundle.sh）
+
+**問題**: Python呼び出しで変数をシングルクォート内にbash変数展開で埋め込んでいる:
+
+```bash
+# config.sh L7
+python3 -c "... with open('$path', 'r') as f: ..."
+# hash.sh L23
+python3 -c "... path = '$path' ..."
+# bundle.sh L56
+python3 -c "... with open('$bom_csv_path', 'r') as f: ..."
+```
+
+ファイルパスにシングルクォートが含まれる場合、Pythonコード文字列を脱出し任意コード実行が可能。
+
+**修正**: 環境変数経由でPythonに値を渡す:
+```bash
+parse_boardflow_yml() {
+  local path="$1"
+  BOARDFLOW_YML_PATH="$path" python3 -c "
+import yaml, json, sys, os
+try:
+    with open(os.environ['BOARDFLOW_YML_PATH'], 'r') as f:
+        data = yaml.safe_load(f)
+    ...
+"
+}
+```
+
+### High（重要な乖離）
+
+#### H-1: Plan APIレスポンスのフィールド名不一致（entrypoint.sh, api.sh）
+
+**問題**: `call_plan_api` が `.decisions` を抽出しているが、spec §6.6 のレスポンス例では配列はトップレベルの `.projects` フィールドに格納される。
+
+**修正**: `api.sh` L80を修正:
+```bash
+echo "$response" | jq '.projects'
+```
+
+#### H-2: BoardRun作成APIペイロードのフィールド名不一致（entrypoint.sh L143-152）
+
+**問題**: 実装では `{repository, commit_sha, ref, project_path, tree_hash, run_id, run_attempt}` を送信しているが、spec §9.2 では:
+- `github_run_id`（not `run_id`）
+- `github_run_attempt`（not `run_attempt`）  
+- `board_project_id`（Plan APIレスポンスから取得すべき）
+- `branch` フィールドも必要
+
+**修正**: Plan APIのレスポンスから `board_project_id` を取得し、フィールド名をspec準拠に修正。
+
+#### H-3: Fail APIペイロード形式不一致（api.sh L97-99）
+
+**問題**: 実装は `{message, details}` を送信しているが、spec §9.6 では `{status: "failed", error: {message, details}}` 形式。
+
+**修正**:
+```bash
+payload=$(jq -n --arg msg "$message" --arg det "$details" \
+  '{status: "failed", error: {message: $msg, details: $det}}')
+```
+
+#### H-4: 検出エラー時にjob失敗にしていない（entrypoint.sh L49-75）
+
+**問題**: spec §3.2「検出エラーが1件でもある場合、最終的なGitHub Actions jobは失敗とする」。現在の実装では、一部プロジェクトがバリデーション失敗（schema不正、.kicad_pro不在等）しても `::warning` を出すだけで、有効なプロジェクトが1つでもあれば `EXIT_CODE=0` で終了する。
+
+**修正**: 検出エラーのカウンターを追加し、1件でもあれば最終的に `EXIT_CODE=1` にする。
+
+#### H-5: KiCadソースファイルのbundle収集が未実装（entrypoint.sh）
+
+**問題**: spec §8.2 で `kicad/` ディレクトリ配下に `.kicad_pro`, `.kicad_sch`, `.kicad_pcb`, `.kicad_wks` をコピーしてbundleに含める要件がある。実装には該当処理が存在しない。
+
+**修正**: staging ディレクトリに `kicad/` サブディレクトリを作成し、project_dir配下の対象拡張子ファイルをexclude適用後にコピーする処理を追加。
+
+#### H-6: bundleのディレクトリ構造がspec非準拠（entrypoint.sh L325-340）
+
+**問題**: spec §8.6 では `review/`, `assembly/`, `fabrication/`, `checks/`, `diff/`, `kicad/` のサブディレクトリ構造を要求。実装ではPDF/SVG/gerber等を各出力ディレクトリ名のままフラットにコピーしている（`pdf/`, `svg/`, `gerber/` 等）。
+
+**修正**: staging構築時にspec準拠のディレクトリ構造にマッピングする:
+- `pdf/schematic.pdf` → `review/schematic.pdf`
+- `pdf/pcb.pdf` → `review/pcb.pdf`
+- `svg/pcb_top.svg` → `review/pcb_top.svg`
+- `ibom/` → `assembly/ibom.html`
+- `bom/bom.csv` → `assembly/bom.csv`
+- `erc.json`, `drc.json` → `checks/`
+- メタデータ → `diff/`
+
+#### H-7: gerbers.zip / drill.zip の個別生成が未実装
+
+**問題**: spec §8.2 では `fabrication/gerbers.zip`, `fabrication/drill.zip`, `fabrication/fabrication.zip` の3つを要求。実装は `fabrication.zip`（gerber+drill結合）のみ生成。
+
+**修正**: gerber_dirをzip化した `gerbers.zip`、drill_dirをzip化した `drill.zip` をそれぞれ個別に生成し、fabrication/ に配置。
+
+### Medium（改善推奨）
+
+#### M-1: is_excluded の性能問題（hash.sh）
+
+**問題**: `list_project_files` で各ファイルごとにPythonプロセスを起動してfnmatch判定している。100ファイルのプロジェクトなら100回のPython起動。大規模プロジェクトでは深刻な遅延になる。
+
+**改善案**: ファイルリスト全体を一度のPython呼び出しでフィルタリングする。
+
+#### M-2: パイプ区切りのVALID_PROJECTS配列（entrypoint.sh L78）
+
+**問題**: `|` を区切り文字として使用しているが、`config_json` にJSON文字列が含まれる場合 `|` が出現する可能性がある（例: jqフィルタ文字列やURL）。
+
+**改善案**: 一時ファイルにJSON形式で書き出すか、配列インデックスで管理する。
+
+#### M-3: メタデータのディレクトリ名（entrypoint.sh）
+
+**問題**: 実装では `meta/` ディレクトリに差分メタデータを生成しているが、spec §7.5 では `diff/` ディレクトリを要求。
+
+**修正**: `meta_dir` → `diff_dir` にリネームし、出力パスを `diff/` 配下に変更。
+
+#### M-4: manifest.json の構造がspec非準拠（bundle.sh L131-145）
+
+**問題**: 実装の manifest は `{version, project, checks, artifacts, diff}` だが、spec §8.5 では `schema_version`, `board_project_id`, `project`, `git`, `github_actions`, `kicad`, `hash`, `diff_metadata`, `checks`, `artifacts` を含む詳細な構造。
+
+**修正**: specに準拠したフィールド構造でmanifest.jsonを生成する。
+
+#### M-5: upload用curlにタイムアウト未設定（entrypoint.sh L361-368）
+
+**問題**: bundle uploadの `curl` に `--connect-timeout` / `--max-time` が設定されていない。大きなbundleの場合、ハングする可能性がある。
+
+**改善案**: `--connect-timeout 30 --max-time 600` を追加。
+
+#### M-6: Plan APIリクエストの `projects[].path` フィールド名
+
+**問題**: 実装では `path` を使用しているが、spec §6.5 の例では `project_path`, `config_path`, `project_dir`, `tree_hash` 等より詳細な構造。
+
+**修正**: Plan APIの正式なリクエストスキーマに合わせてフィールドを追加。
+
+### Low（軽微）
+
+#### L-1: Dockerコンテナがroot実行
+
+**問題**: Dockerfileで `USER root` 設定後、非rootユーザーに戻していない。セキュリティベストプラクティスとして最小権限で実行すべき。ただしGitHub Actions Docker actionsでは `/github/workspace` へのアクセスにroot権限が必要な場合があり、実害は限定的。
+
+#### L-2: 一時ディレクトリの明示的クリーンアップなし
+
+**問題**: `mktemp -d` で作成した `output_dir` のクリーンアップが明示的に行われていない。コンテナ終了で自動削除されるため実害はないが、ディスク容量制約のあるランナーでは問題になる可能性。
+
+#### L-3: jq による配列構築の O(n²) 性能
+
+**問題**: `artifacts_status` や `RESULTS` の配列構築で毎回 `echo "$arr" | jq '. + [...]'` を使用。要素数に対して O(n²) のパフォーマンス特性。プロジェクト数が少ないMVPでは問題にならないが、将来的にはボトルネックになりうる。
+
+#### L-4: python3-yaml パッケージ不足の可能性
+
+**問題**: Dockerfile で `python3-yaml` をインストールしているが、パッケージ名は `python3-yaml` ではなく Debian では `python3-yaml` で正しい（PyYAMLのDebianパッケージ）。動作に問題はないが、`import yaml` の動作確認が必要。
+
+#### L-5: tree_hash のファイル名にバックスラッシュを含む場合
+
+**問題**: `printf "%b"` がファイル名中の `\n`, `\t`, `\x00` 等のエスケープシーケンスを解釈してしまう。KiCadファイル名にこれらが含まれることは極めて稀だが、理論上は不正なハッシュになる。
+
+### 総合評価
+
+| 観点 | 評価 |
+|------|------|
+| 仕様準拠性 | △ APIペイロード形式・bundle構造・ディレクトリレイアウトに複数の乖離 |
+| 正確性 | △ 環境変数パースのCriticalバグ、KiCadコマンドオプションは正確 |
+| エラーハンドリング | ○ 部分失敗継続は概ね仕様通り。検出エラー時のjob失敗が不足 |
+| セキュリティ | △ コマンドインジェクション脆弱性あり |
+| ロバスト性 | △ パイプ区切り・性能問題あり |
+| 保守性 | ○ 関数分割・命名は適切 |
+
+### 必要なアクション
+
+1. Critical 3件を全て修正する（特にC-1は全入力が無視される致命的バグ）
+2. High 7件のうち、少なくともH-1〜H-6を修正する（API通信とbundle構造の仕様準拠）
+3. Medium のうち M-3, M-4 は仕様乖離のため修正推奨
+4. 修正後に再レビューを実施する
+
+---
+
+## 再レビュー結果
+
+**レビュー日**: 2026-05-04
+**対象ブランチ**: feat/60-boardflow-action
+**判定**: `pr_ready: false`
+
+### 前回指摘事項の修正確認
+
+| ID | 指摘内容 | 修正状況 |
+|----|----------|----------|
+| C-1 | INPUT環境変数パース | ✅ `INPUT_EXCLUDE_PATHS`等正しく参照 |
+| C-2 | Import APIペイロード | ✅ `staging_object_key`, `bundle_sha256`, `bundle_size_bytes` 追加 |
+| C-3 | コマンドインジェクション | ✅ `sys.argv`/`stdin`経由に変更 |
+| H-1 | Plan APIレスポンス `.projects` | ✅ `jq '.projects'` で正しく抽出 |
+| H-2 | BoardRun作成ペイロード | ✅ `board_project_id`, `github_run_id`等追加 |
+| H-3 | Fail APIペイロード | ✅ `{status, error: {message, details}}` 形式 |
+| H-4 | 検出エラー時job失敗 | ✅ `DETECTION_ERRORS`カウンター実装 |
+| H-5 | KiCadソースファイル収集 | ✅ `kicad/`ディレクトリへコピー |
+| H-6 | bundleディレクトリ構造 | ✅ `review/assembly/fabrication/checks/diff/kicad/` |
+| H-7 | gerbers.zip/drill.zip個別生成 | ✅ 各ディレクトリから個別zip生成 |
+| M-1 | is_excluded性能 | ✅ `list_project_files`でバッチ処理 |
+| M-3 | diffディレクトリ名 | ✅ `diff_dir` 変数使用 |
+| M-4 | manifest構造 | ⚠️ 部分的修正。構造は改善されたが `artifacts` フィールドが不完全 |
+| M-5 | upload curlタイムアウト | ✅ `--connect-timeout 30 --max-time 600` |
+| M-6 | Plan APIリクエスト | ⚠️ 部分的修正。構造は改善されたが `project_path` と `files` 形式に乖離あり |
+
+### 新規発見事項
+
+#### R-1: manifest `artifacts` 配列が仕様不適合 【Critical】
+
+**箇所**: `bundle.sh` → `create_manifest()` / `entrypoint.sh` の `artifacts_status` 構築
+
+**問題**: 現在のartifacts配列は `[{"name":"erc","status":"success"}]` 形式だが、spec §8.5 / §8.6 は以下を要求:
+
+```json
+{
+  "type": "schematic_pdf",
+  "status": "available",
+  "path": "review/schematic.pdf",
+  "content_type": "application/pdf",
+  "sha256": "sha256:...",
+  "size_bytes": 123456
+}
+```
+
+spec §8.6 のbundle検証ルール:
+- "manifest内の各artifactに type / status がある"
+- "`available` なartifactには path / content_type / sha256 / size_bytes がある"
+
+**影響**: backendのimport workerがbundleを拒否し、全BoardRunが `failed` になる。
+
+**修正方針**: `artifacts_status` の各エントリに `type`（spec §8.3準拠）、`status`（`available`/`failed`）、`path`（staging内相対パス）、`content_type`、`sha256`、`size_bytes` を含める。
+
+#### R-2: `project_path` がディレクトリパスを使用 【High】
+
+**箇所**: `entrypoint.sh` L107-115（plan_projects構築）、L172（decision matching）、L189（BoardRun作成）
+
+**問題**: `project_path` に `$rel_dir`（ディレクトリ）を設定しているが、spec §6.5, §6.6, §8.5, §9.2 は全て `.kicad_pro` ファイルパスを `project_path` として使用。
+
+```
+spec例: "project_path": "hardware/motor_driver/motor_driver.kicad_pro"
+実装:   "project_path": "hardware/motor_driver"  (ディレクトリ)
+```
+
+**影響**: Plan APIの応答とのマッチング自体は（SaaS側がミラーする前提で）動作するが、manifestの `project.project_path` が仕様不適合となり、backend検証で問題になる可能性。
+
+**修正方針**: `pro_file` の相対パスを `project_path` として使用する。
+
+#### R-3: Plan API `files` 配列がフラット文字列配列 【High】
+
+**箇所**: `entrypoint.sh` L108
+
+**問題**: 現在:
+```bash
+files=$(list_project_files ... | jq -R -s 'split("\n") | map(select(. != ""))')
+# → ["motor_driver.kicad_pcb", "motor_driver.kicad_sch", ...]
+```
+
+spec §6.5 が期待する形式:
+```json
+"files": [{"path": "hardware/motor_driver/motor_driver.kicad_pcb", "sha256": "sha256:..."}]
+```
+
+**影響**: SaaSのplan APIが `files` 配列の `sha256` フィールドを使って将来的なファイル単位diff判定に活用できない。ただしMVPでは `tree_hash` のみで判定しているため、即時の機能不全にはならない。
+
+**修正方針**: `list_project_files` の出力に対してファイル単位sha256を計算し、objects配列として構築する。パスはリポジトリルート相対にする。
+
+#### R-4: manifest `checks` 構造が不完全 【Medium】
+
+**箇所**: `bundle.sh` → `generate_checks_summary_json()` / `create_manifest()`
+
+**問題**: 現在の `checks` は `{erc: {errors: N, warnings: N}, drc: {errors: N, warnings: N}}` だが、spec §8.5 は `enabled`, `status`, `report` フィールドも含む:
+
+```json
+"erc": {"enabled": true, "status": "passed", "errors": 0, "warnings": 2, "report": "checks/erc.json"}
+```
+
+**修正方針**: `enabled: true`, `status` (`passed`/`failed` をerrors数で判定), `report` パスを追加。
+
+#### R-5: Plan API `repository` に `github_repository_id` 不足 【Medium】
+
+**箇所**: `entrypoint.sh` L133
+
+**問題**: spec §6.5 の `repository` オブジェクトには `github_repository_id` フィールドがあるが、実装では `owner` と `name` のみ。spec §9.1 には "SaaSは、Actionから送られた `github_repository_id` をそのまま信用せず、tokenに紐づく…と一致するか必ず検証する" とある。
+
+**影響**: SaaS側がこのフィールドを必須バリデーションしている場合、Plan APIが400で拒否される。
+
+**修正方針**: `GITHUB_REPOSITORY_ID` 環境変数（GitHub Actionsが提供）を取得して送信する。
+
+#### R-6: manifest `github_actions.workflow` フィールド不足 【Low】
+
+**箇所**: `bundle.sh` → `create_manifest()`
+
+**問題**: spec §8.5 の manifest例では `github_actions` に `workflow` フィールドがあるが、実装では `run_id` と `run_attempt` のみ。
+
+### 総合評価
+
+| 観点 | 前回 | 今回 | 備考 |
+|------|------|------|------|
+| 仕様準拠性 | △ | ○△ | API構造改善。manifest artifacts が未対応 |
+| 正確性 | △ | ○ | Critical バグ修正完了。新規致命バグなし |
+| エラーハンドリング | ○ | ○ | DETECTION_ERRORS追加で改善 |
+| セキュリティ | △ | ○ | コマンドインジェクション修正済み |
+| ロバスト性 | △ | ○ | タイムアウト追加、バッチ処理改善 |
+| 保守性 | ○ | ○ | 変更なし |
+
+### 判定
+
+**`pr_ready: false`**
+
+#### ブロッカー (修正必須)
+
+- **R-1** (Critical): manifest `artifacts` 配列が仕様不適合。backendがbundleを拒否するため、E2E動作しない。
+
+#### 強く推奨 (PR前に修正すべき)
+
+- **R-2** (High): `project_path` のディレクトリ/ファイル不一致。backend実装が spec に従えば不整合が発生する。
+- **R-3** (High): `files` 配列形式。MVPではtree_hash判定のみのため即時影響は限定的だが、仕様乖離を残すとbackend側の対応コストが増大する。
+
+#### 許容可 (PR後でも対応可)
+
+- **R-4** (Medium): checks構造の追加フィールド
+- **R-5** (Medium): `github_repository_id` の送信
+- **R-6** (Low): `workflow` フィールド追加
+
+### 推奨対応順序
+
+1. R-1 修正（artifacts配列をspec準拠に構築）
+2. R-2 修正（project_pathを.kicad_proファイルパスに変更）
+3. R-3 修正（files配列をobjects形式に変更）
+4. 再レビュー実施
+
+---
+
+## 最終レビュー結果
+
+**実施日時**: 2026-05-04
+**対象コミット**: `bcbc4ff` (fix: spec-compliant artifacts array, project_path, and files format (R-1,R-2,R-3))
+
+### 前回指摘の修正確認
+
+| ID | 内容 | 状態 |
+|----|------|------|
+| R-1 | artifacts配列: type/status/path/content_type/sha256/size_bytes (§8.5準拠) | ✅ 修正済み |
+| R-2 | project_pathが.kicad_proの相対パス | ✅ 修正済み |
+| R-3 | Plan API files配列が[{path, sha256}]形式 | ✅ 修正済み |
+| C-1 | INPUT_* ハイフン→アンダースコア変換 | ✅ 維持 |
+| C-2 | create_board_run応答からboard_run_id/upload_url/staging_object_key抽出 | ✅ 維持 |
+| C-3 | Pythonスクリプトでsys.argv使用 | ✅ 維持 |
+| H-1 | Plan API応答 `.projects` 参照 | ✅ 維持 |
+| H-2 | board_project_idをplan decisionsから取得 | ✅ 維持 |
+| H-3 | Fail API spec準拠ペイロード | ✅ 維持 |
+| H-4 | DETECTION_ERRORSによるjob失敗 | ✅ 維持 |
+| H-5 | KiCad sourceファイルをstaging収集 | ✅ 維持 |
+| H-6 | staging構造がspec §8.6準拠 | ✅ 維持 |
+| H-7 | gerbers.zip/drill.zip個別作成 | ✅ 維持 |
+| M-1 | Python一括フィルタリング | ✅ 維持 |
+| M-3 | diff metadata生成 | ✅ 維持 |
+| M-4 | manifest spec準拠 | ✅ 維持 |
+| M-5 | アップロードtimeout設定 | ✅ 維持 |
+| M-6 | Plan APIペイロード spec準拠 | ✅ 維持 |
+
+### 新規指摘
+
+#### H-NEW-1 (High): KiCad source artifacts に `source_path` フィールドが欠落
+
+**根拠**: spec §8.6 "source artifact は `kicad/` 以下に閉じ込め、元の repository 相対pathを `source_path` としてmanifestに保存する"
+spec §8.5 example にも `"source_path": "hardware/motor_driver/motor_driver.kicad_pro"` が明示。
+
+**該当箇所**: `action/entrypoint.sh` L393
+```bash
+artifacts_status=$(add_artifact_available "$artifacts_status" "$kicad_type" "$staging_path" "application/octet-stream" "$src_file")
+```
+
+**修正方針**: `add_artifact_available` にオプション引数として `source_path` を追加するか、KiCad source専用の `add_artifact_kicad_source()` を作成して `source_path` フィールドを含める。`source_path` の値は `$rel_dir/$src_rel`（rel_dir="." の場合は `$src_rel` のみ）。
+
+#### M-NEW-1 (Medium, 非ブロッカー): KiCad source の content_type
+
+spec §8.5 example: `"text/plain; charset=utf-8"`
+実装: `"application/octet-stream"`
+
+#### M-NEW-2 (Medium, 非ブロッカー): root-levelプロジェクトでの staging_path
+
+`rel_dir` が "." の場合、`staging_path = "kicad/./filename.kicad_pro"` となる。
+`"kicad/filename.kicad_pro"` が正しい。
+
+### 判定
+
+**`pr_ready: false`**
+
+H-NEW-1 (source_path欠落) はbackend検証で拒否される可能性が高く、修正必須。
+
+### 修正手順
+
+1. `bundle.sh` に `add_artifact_kicad_source()` 関数追加（source_path, content_type="text/plain; charset=utf-8" を含む）
+2. `entrypoint.sh` L381-395 で当該関数を使用、rel_dir="." 時のパス正規化を追加
+3. 再レビュー実施

--- a/docs/logs/60/worklog.md
+++ b/docs/logs/60/worklog.md
@@ -27,3 +27,498 @@ GitHub Actions向けのDocker Workflowやそこで動かすKiCadのラッパー�
 - Docker imageサイズが大きい場合のCI実行時間への影響
 - GHCRへの事前publishフローの設計が必要
 - spec.mdの詳細なフロー（Plan API→KiCad CLI→Import API）の実装複雑度
+
+## 調査結果
+
+### 1. GitHub Actions Docker container action の action.yml 仕様
+
+**出典**: https://docs.github.com/en/actions/reference/workflows-and-actions/metadata-syntax#runs-for-docker-container-actions
+
+#### `runs` セクション（Docker container actions向け）の完全なschema:
+
+```yaml
+runs:
+  using: 'docker'           # 必須。'docker'固定
+  image: 'Dockerfile'       # 必須。'Dockerfile'(ローカルビルド) or 'docker://image:tag'(レジストリ)
+  env:                      # オプション。コンテナ内の環境変数をkey/valueで設定
+    KEY: value
+  pre-entrypoint: 'setup.sh'   # オプション。entrypoint前に実行するスクリプト
+  pre-if: ''                    # オプション。pre-entrypointの実行条件
+  entrypoint: 'main.sh'        # オプション。DockerfileのENTRYPOINTを上書き
+  args:                         # オプション。ENTRYPOINTに渡す引数(CMDの代替)
+    - ${{ inputs.param1 }}
+    - 'literal-value'
+  post-entrypoint: 'cleanup.sh' # オプション。entrypoint後のクリーンアップスクリプト
+  post-if: ''                    # オプション。post-entrypointの実行条件
+```
+
+#### 重要なポイント:
+- **Linuxランナー限定**: Docker Actionsは `ubuntu-latest` 等のLinuxランナーでのみ動作
+- **image指定方法**: `'Dockerfile'`（リポジトリ内Dockerfileからビルド）または `'docker://debian:stretch-slim'`（レジストリから取得）
+- **inputs → 環境変数**: inputを定義すると `INPUT_<UPPERCASE_NAME>` 環境変数が自動設定される
+- **args経由で入力渡し**: Docker container actionsでは `args` キーワードでinputsをentrypointに渡す
+- **ファイル名**: `action.yml` または `action.yaml`（名前変更するとMarketplaceで旧バージョンが非表示に）
+
+#### action.yml トップレベル構造:
+```yaml
+name: 'Action Name'          # 必須
+author: 'Author'             # オプション
+description: 'Description'   # 必須
+branding:                    # オプション (Marketplace用)
+  icon: 'package'
+  color: 'blue'
+inputs:
+  input-id:
+    description: '...'       # 必須
+    required: true/false     # オプション
+    default: 'value'         # オプション
+    deprecationMessage: ''   # オプション
+outputs:
+  output-id:
+    description: '...'       # 必須
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+  args:
+    - ${{ inputs.input-id }}
+```
+
+#### ファイルシステムマッピング:
+- ランナーの `GITHUB_WORKSPACE` → コンテナ内 `/github/workspace` に自動マウント
+- コンテナが `/github/workspace` に出力したファイルは後続ステップからアクセス可能
+
+---
+
+### 2. GitHub Actions Job Summary ($GITHUB_STEP_SUMMARY)
+
+**出典**: https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/
+
+#### 基本的な使い方:
+```bash
+# シンプルなMarkdown追記
+echo '### Hello world! 🚀' >> $GITHUB_STEP_SUMMARY
+
+# 複数行のMarkdown
+echo '### Build Results' >> $GITHUB_STEP_SUMMARY
+echo '| File | Status |' >> $GITHUB_STEP_SUMMARY
+echo '|------|--------|' >> $GITHUB_STEP_SUMMARY
+echo '| main.c | ✅ Pass |' >> $GITHUB_STEP_SUMMARY
+```
+
+#### 仕組み:
+- `$GITHUB_STEP_SUMMARY` はランナー上のファイルパスを格納する環境変数
+- 例: `/home/runner/_layout/_work/_temp/_runner_file_commands/step_summary_<uuid>`
+- **ステップごとにパスが変わる**（各ステップ固有のファイル）
+- GitHub Flavored Markdown（GFM）をフルサポート
+- テーブル、コードブロック、リンク、Mermaid図、HTML、絵文字が使用可能
+- 複数ステップから `>>` で追記可能（同一ステップ内でも複数回追記OK）
+- **Docker container action内でも `$GITHUB_STEP_SUMMARY` は利用可能**（環境変数として自動注入される）
+
+#### boardflow-actionでの活用想定:
+- KiCad ERC/DRCの結果サマリ表示
+- 生成アーティファクト一覧テーブル
+- アップロード結果のリンク表示
+
+---
+
+### 3. Docker container action 内でアクセス可能な環境変数
+
+**出典**: https://docs.github.com/en/actions/reference/workflows-and-actions/variables#default-environment-variables
+
+Docker container actionのentrypoint内では、以下のGitHubデフォルト環境変数にすべてアクセス可能:
+
+| 変数名 | 内容 | 用途(boardflow-action) |
+|--------|------|----------------------|
+| `GITHUB_REPOSITORY` | `owner/repo` 形式 | API呼び出し時のリポジトリ識別 |
+| `GITHUB_SHA` | トリガーしたコミットSHA | アーティファクトとコミットの紐付け |
+| `GITHUB_REF` | `refs/heads/branch` 形式 | ブランチ/タグ情報取得 |
+| `GITHUB_REF_NAME` | ブランチ/タグの短縮名 | 表示用 |
+| `GITHUB_RUN_ID` | ワークフロー実行ID (数値) | 一意な実行識別 |
+| `GITHUB_RUN_ATTEMPT` | リラン回数 (1始まり) | リトライ判定 |
+| `GITHUB_WORKSPACE` | ランナーのワークスペースパス | ソースコード読み取り先 |
+| `GITHUB_OUTPUT` | 出力設定ファイルのパス | `echo "key=value" >> $GITHUB_OUTPUT` |
+| `GITHUB_STEP_SUMMARY` | Job Summaryファイルのパス | Markdownサマリ出力 |
+| `GITHUB_SERVER_URL` | `https://github.com` | URL組み立て |
+| `GITHUB_API_URL` | `https://api.github.com` | API呼び出し |
+| `GITHUB_ACTION_PATH` | アクション自体のパス (composite用) | - |
+| `GITHUB_EVENT_NAME` | トリガーイベント名 | push/pull_request判定 |
+| `GITHUB_EVENT_PATH` | イベントペイロードJSONのパス | 詳細なイベント情報取得 |
+| `GITHUB_ACTOR` | ワークフロー起動者 | 情報表示 |
+| `RUNNER_TEMP` | 一時ディレクトリ | 中間ファイル出力先 |
+
+#### Docker container action固有の注意点:
+- **すべてのデフォルト環境変数はentrypoint内で利用可能**（Dockerfile内のRUNでは不可、entrypoint.shの実行時のみ）
+- inputs は `INPUT_<UPPERCASE_NAME>` として自動注入される（例: `input: api-url` → `$INPUT_API-URL`）
+- `/github/workspace` にワークスペースがマウントされる
+- `$GITHUB_OUTPUT` / `$GITHUB_STEP_SUMMARY` は実ファイルパス。Docker内でも書き込み可能
+
+---
+
+### 調査結論
+
+| 項目 | ステータス |
+|------|-----------|
+| 結論ステータス | `implementation_required` |
+| 追加ドキュメント | `docs/external/github-actions-docker-action.md` を新規作成推奨 |
+| ブロッカー | なし |
+
+#### 追加ドキュメント推奨理由:
+既存の `docs/external/` には GitHub Actions Docker container action の action.yml 仕様・Job Summary・環境変数に関するドキュメントがない。実装時に参照できるよう、上記の調査結果を `docs/external/github-actions-docker-action.md` として整理することを推奨する。
+
+#### 実装への示唆:
+1. `action.yml` では `using: 'docker'` + `image: 'docker://ghcr.io/...'`（事前ビルド済みイメージ）方式が高速
+2. entrypoint.sh 内で `$INPUT_*` で入力を受け取り、`$GITHUB_OUTPUT` / `$GITHUB_STEP_SUMMARY` で結果を返す
+3. ワークスペース（KiCadプロジェクト）は `/github/workspace` でアクセス可能
+4. `$GITHUB_REPOSITORY` / `$GITHUB_SHA` でAPI呼び出し時のコンテキスト情報を取得可能
+
+---
+
+## 計画
+
+### 1. ファイル一覧と役割
+
+```
+action/
+├── action.yml          # GitHub Actions メタデータ (inputs/outputs/runs定義)
+├── Dockerfile          # KiCad 9.0 + 必要ツールのコンテナ定義
+├── entrypoint.sh       # メインスクリプト (全フローのオーケストレーション)
+└── lib/
+    ├── detect.sh       # .boardflow.yml検出・BoardProject候補決定
+    ├── config.sh       # .boardflow.yml schema検証・exclude_paths解析
+    ├── hash.sh         # file hash / tree_hash 計算
+    ├── api.sh          # SaaS API呼び出し (plan/board-run/import/fail)
+    ├── kicad.sh        # KiCad CLI実行 (ERC/DRC/PDF/SVG/Gerber/BOM/Position/3D)
+    ├── ibom.sh         # InteractiveHtmlBom生成 (xvfb-run)
+    ├── bundle.sh       # diff metadata/manifest/fabrication.zip/bundle.zip作成
+    └── summary.sh      # GitHub Actions Job Summary出力
+```
+
+### 2. action.yml 設計
+
+```yaml
+name: 'BoardFlow Action'
+description: 'KiCad CI/CD - Generate artifacts and upload to BoardFlow'
+author: 'BoardFlow'
+
+branding:
+  icon: 'cpu'
+  color: 'blue'
+
+inputs:
+  token:
+    description: 'BoardFlow API token'
+    required: true
+  mode:
+    description: '"auto" or "all"'
+    required: false
+    default: 'auto'
+  exclude-paths:
+    description: 'Newline-separated glob patterns to exclude'
+    required: false
+    default: ''
+  api-url:
+    description: 'BoardFlow API URL'
+    required: false
+    default: 'https://api.boardflow.example.com'
+  fail-on-drc:
+    description: 'Fail action on DRC errors'
+    required: false
+    default: 'false'
+  fail-on-erc:
+    description: 'Fail action on ERC errors'
+    required: false
+    default: 'false'
+
+outputs:
+  result:
+    description: 'JSON summary of processed projects'
+
+runs:
+  using: 'docker'
+  image: 'Dockerfile'
+```
+
+### 3. Dockerfile 設計
+
+```dockerfile
+FROM kicad/kicad:9.0
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-pip \
+    xvfb \
+    jq \
+    curl \
+    zip \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN pip3 install --break-system-packages interactivehtmlbom
+
+COPY entrypoint.sh /action/entrypoint.sh
+COPY lib/ /action/lib/
+
+RUN chmod +x /action/entrypoint.sh /action/lib/*.sh
+
+ENTRYPOINT ["/action/entrypoint.sh"]
+```
+
+### 4. entrypoint.sh 関数分割設計
+
+#### 4.1 メインフロー (entrypoint.sh)
+
+```
+main()
+  ├── source lib/*.sh
+  ├── parse_inputs()           # INPUT_* 環境変数を正規化
+  ├── check_unsupported_event()  # pull_request → 早期成功終了
+  ├── detect_projects()        # .boardflow.yml探索 → 候補リスト
+  ├── validate_projects()      # schema検証 + 必須ファイル確認
+  ├── compute_hashes()         # exclude適用 → file hash → tree_hash
+  ├── call_plan_api()          # POST /api/v1/runs/plan
+  ├── for each decision=build:
+  │     ├── create_board_run()   # POST /api/v1/board-runs
+  │     ├── run_kicad_checks()   # ERC + DRC
+  │     ├── run_kicad_exports()  # PDF/SVG/Gerber/BOM/Position/3D
+  │     ├── run_ibom()           # xvfb-run generate_interactive_bom
+  │     ├── collect_kicad_sources()  # kicad/ ディレクトリ収集
+  │     ├── generate_diff_metadata() # file_hashes/bom_summary/checks_summary/artifacts_summary/previews
+  │     ├── create_fabrication_zip() # gerber + drill → fabrication.zip
+  │     ├── create_manifest()    # manifest.json生成
+  │     ├── create_bundle()      # bundle.zip作成
+  │     ├── upload_bundle()      # presigned URL PUT
+  │     └── call_import_api()    # POST /api/v1/board-runs/{id}/artifact-bundles/import
+  ├── on failure per project:
+  │     └── call_fail_api()      # POST /api/v1/board-runs/{id}/fail
+  ├── write_job_summary()        # $GITHUB_STEP_SUMMARY
+  └── determine_exit_code()      # fail-on-drc/erc + 検出エラー判定
+```
+
+#### 4.2 補助関数一覧
+
+**lib/detect.sh**:
+- `find_boardflow_ymls()` — リポジトリ内の全.boardflow.ymlパスをリスト
+- `resolve_kicad_pro()` — 同階層の.kicad_proを特定（0個/複数はエラー）
+- `resolve_pcb_file()` — 主要.kicad_pcb特定（stem優先 → 単一候補）
+- `resolve_root_schematic()` — root .kicad_sch特定（stem優先 → 単一候補）
+- `validate_required_files()` — 必須ファイルが除外されていないか確認
+
+**lib/config.sh**:
+- `parse_boardflow_yml()` — jqでyaml→JSON変換（yqまたはpython yaml使用）
+- `validate_schema_v1()` — version:1のみ許可、未知フィールド拒否
+- `get_exclude_paths()` — yml exclude_paths抽出
+- `merge_excludes()` — built-in + input + yml の和集合
+
+**lib/hash.sh**:
+- `compute_file_sha256()` — 単一ファイルのsha256sum
+- `list_project_files()` — project_dir配下のファイル列挙（exclude適用後）
+- `compute_tree_hash()` — sorted(path\0sha256\n) の sha256
+
+**lib/api.sh**:
+- `api_request()` — curl共通ラッパー（token/content-type/error handling）
+- `call_plan_api()` — Plan APIリクエスト組み立て・レスポンス解析
+- `call_create_board_run()` — BoardRun作成・presigned URL取得
+- `call_import_api()` — Import API呼び出し
+- `call_fail_api()` — 失敗API呼び出し
+
+**lib/kicad.sh**:
+- `run_erc()` — `kicad-cli sch erc --format json`
+- `run_drc()` — `kicad-cli pcb drc --format json`
+- `export_schematic_pdf()` — `kicad-cli sch export pdf`
+- `export_pcb_pdf()` — `kicad-cli pcb export pdf`
+- `export_pcb_svg()` — `kicad-cli pcb export svg` (top/bottom)
+- `export_gerbers()` — `kicad-cli pcb export gerbers`
+- `export_drill()` — `kicad-cli pcb export drill`
+- `export_bom()` — `kicad-cli sch export bom` (CSV)
+- `export_position()` — `kicad-cli pcb export pos`
+- `export_3d_render()` — `kicad-cli pcb render` (top/bottom)
+
+**lib/ibom.sh**:
+- `run_ibom()` — `xvfb-run python3 -m InteractiveHtmlBom ...`
+
+**lib/bundle.sh**:
+- `create_fabrication_zip()` — gerber/ + drill/ → fabrication/fabrication.zip
+- `generate_file_hashes_json()` — diff/file_hashes.json
+- `generate_bom_summary_json()` — diff/bom_summary.json
+- `generate_checks_summary_json()` — diff/checks_summary.json
+- `generate_artifacts_summary_json()` — diff/artifacts_summary.json
+- `generate_previews_json()` — diff/previews.json
+- `create_manifest()` — manifest.json (artifacts + checks + diff_metadata)
+- `create_bundle_zip()` — 全成果物を1つのzipにまとめる
+- `compute_bundle_sha256()` — bundle.zipのsha256
+
+**lib/summary.sh**:
+- `write_job_summary()` — GFM形式でProject一覧/check結果/artifact状態をSummaryへ
+- `write_unsupported_event_summary()` — unsupported eventの場合の簡易表示
+
+### 5. エラーハンドリング方針
+
+| レベル | 条件 | 対応 |
+|--------|------|------|
+| Fatal (即時終了) | Plan API認可エラー、.boardflow.yml 0件 | Job失敗、全プロジェクト中断 |
+| Project Fatal | BoardRun作成失敗、bundle upload失敗、import要求失敗 | fail API呼び出し → 他プロジェクト継続 → 最終的にJob失敗 |
+| Project Error | 検出エラー（schema不正、.kicad_pro不在、必須ファイル除外） | Plan APIに送らず → Job Summary表示 → Job失敗 |
+| Artifact Error | 個別kicad-cli実行失敗 | artifact status=failed → manifest記録 → BoardRunは継続 |
+| Soft Fail | DRC/ERCエラー | 成果物uploadは完了 → fail-on-drc/ercの場合のみ最終exit code=1 |
+| Skip | decision=skip | Job Summary表示のみ → 正常扱い |
+
+**共通方針**:
+- `set -euo pipefail` は使わない（部分失敗で継続するため）
+- 各関数は戻り値で成否を返す（0=成功、非0=失敗）
+- エラー詳細は変数/一時ファイルに蓄積し、最後にSummary出力
+- API呼び出しは最大3回リトライ（exponential backoff、5xx/タイムアウトのみ）
+- KiCad CLI実行はタイムアウト300秒（個別コマンドごと）
+
+### 6. テスト方針
+
+#### 6.1 ユニットテスト（shell関数単位）
+
+テストフレームワーク: **bats-core** (Bash Automated Testing System)
+
+```
+action/tests/
+├── test_detect.bats       # detect.sh の各関数テスト
+├── test_config.bats       # config.sh schema検証テスト
+├── test_hash.bats         # hash.sh tree_hash計算テスト
+├── test_bundle.bats       # bundle.sh manifest/zip生成テスト
+├── test_summary.bats      # summary.sh 出力フォーマットテスト
+├── test_entrypoint.bats   # メインフロー分岐テスト
+└── fixtures/
+    ├── valid_project/     # 正常なKiCadプロジェクト構造
+    ├── invalid_schema/    # schema不正な.boardflow.yml
+    ├── no_pcb/            # .kicad_pcb欠損
+    ├── multi_pcb/         # 複数.kicad_pcb
+    └── mock_api_responses/ # API応答のモックJSON
+```
+
+**テスト対象（優先度高）**:
+1. `compute_tree_hash()` — ファイル順序非依存、exclude適用の正確性
+2. `validate_schema_v1()` — 有効/無効パターン網羅
+3. `resolve_kicad_pro()` — 0/1/複数 .kicad_pro の各ケース
+4. `merge_excludes()` — built-in/input/yml 和集合の正確性
+5. `create_manifest()` — JSON構造の正確性
+
+#### 6.2 統合テスト
+
+- Docker buildが成功するか
+- サンプルKiCadプロジェクト(samples/)を使った end-to-end テスト
+- API呼び出しはモックサーバー（ncat等）で受ける
+- unsupported event (pull_request) の早期終了テスト
+
+#### 6.3 CIでの実行
+
+- GitHub Actions上で `bats` テストを実行するワークフロー
+- Docker build テスト（imageが正常にビルドできるか）
+- KiCad CLI の基本動作確認（samples/ を使用）
+
+### 7. 実装順序（TDD前提）
+
+#### Phase 1: 基盤 (スケルトン + 検出)
+1. `action/action.yml` — inputs/outputs定義
+2. `action/Dockerfile` — ビルド確認のみ（ENTRYPOINTはecho）
+3. `action/entrypoint.sh` — スケルトン（source + parse_inputs + event判定）
+4. `action/lib/detect.sh` — `find_boardflow_ymls()` + テスト
+5. `action/lib/detect.sh` — `resolve_kicad_pro()` + テスト
+6. `action/lib/detect.sh` — `resolve_pcb_file()` / `resolve_root_schematic()` + テスト
+
+#### Phase 2: 設定・ハッシュ
+7. `action/lib/config.sh` — YAML解析（python3 -c 'import yaml; ...' でパース）
+8. `action/lib/config.sh` — `validate_schema_v1()` + テスト
+9. `action/lib/config.sh` — `merge_excludes()` + テスト
+10. `action/lib/hash.sh` — `list_project_files()` (exclude適用) + テスト
+11. `action/lib/hash.sh` — `compute_tree_hash()` + テスト
+
+#### Phase 3: API連携
+12. `action/lib/api.sh` — `api_request()` 共通ラッパー
+13. `action/lib/api.sh` — `call_plan_api()` + モックテスト
+14. `action/lib/api.sh` — `call_create_board_run()` + モックテスト
+15. `action/lib/api.sh` — `call_import_api()` / `call_fail_api()` + モックテスト
+
+#### Phase 4: KiCad実行
+16. `action/lib/kicad.sh` — `run_erc()` / `run_drc()` + samples/テスト
+17. `action/lib/kicad.sh` — PDF/SVG export関数群 + テスト
+18. `action/lib/kicad.sh` — Gerber/Drill/BOM/Position/3D export + テスト
+19. `action/lib/ibom.sh` — `run_ibom()` + テスト
+
+#### Phase 5: Bundle作成
+20. `action/lib/bundle.sh` — `create_fabrication_zip()` + テスト
+21. `action/lib/bundle.sh` — diff metadata生成関数群 + テスト
+22. `action/lib/bundle.sh` — `create_manifest()` + テスト
+23. `action/lib/bundle.sh` — `create_bundle_zip()` + テスト
+
+#### Phase 6: Summary + 統合
+24. `action/lib/summary.sh` — Job Summary出力 + テスト
+25. `action/entrypoint.sh` — メインフロー統合
+26. 統合テスト（Docker + samples/ + モックAPI）
+27. fail-on-drc / fail-on-erc の終了コード制御
+
+### 8. .boardflow.yml パース方法
+
+Dockerイメージには python3 が含まれるため、YAMLパースは以下で行う:
+
+```bash
+parse_boardflow_yml() {
+  local yml_path="$1"
+  python3 -c "
+import sys, json, yaml
+with open(sys.argv[1]) as f:
+    print(json.dumps(yaml.safe_load(f)))
+" "$yml_path"
+}
+```
+
+Dockerfile に `pyyaml` を追加インストールする（`pip3 install pyyaml`）。
+
+### 9. glob マッチング方法
+
+bash の `find` + カスタムマッチング関数、または python3 ワンライナーで対応:
+
+```bash
+matches_glob() {
+  local path="$1" pattern="$2"
+  python3 -c "
+import sys, fnmatch
+sys.exit(0 if fnmatch.fnmatch(sys.argv[1], sys.argv[2]) else 1)
+" "$path" "$pattern"
+}
+```
+
+### 10. 前提条件・依存関係
+
+- samples/ ディレクトリのKiCadプロジェクトをテスト用fixtureとして活用
+- SaaS API (Plan/BoardRun/Import/Fail) のエンドポイントが実装済みであること（Issue #55-#59相当）
+- bats-core はDockerイメージ内ではなくCIランナー上で実行（テスト用）
+
+### 11. 計画ステータス
+
+**実装可能**: すべての技術要素が調査済みであり、spec.mdの仕様が十分に詳細。ブロッカーなし。
+
+---
+
+## 実装内容
+
+### 作成したファイル一覧
+
+| ファイル | 役割 |
+|---------|------|
+| `action/action.yml` | GitHub Actions メタデータ（inputs/outputs/runs定義） |
+| `action/Dockerfile` | KiCad 9.0 + python3-pip, xvfb, jq, curl, zip, interactivehtmlbom |
+| `action/entrypoint.sh` | メインオーケストレーション（全フロー制御） |
+| `action/lib/detect.sh` | .boardflow.yml検出・.kicad_pro/.kicad_pcb/.kicad_sch解決 |
+| `action/lib/config.sh` | YAML→JSONパース・schema v1バリデーション・exclude_pathsマージ |
+| `action/lib/hash.sh` | SHA256計算・tree_hash計算・BUILTIN_EXCLUDES定数定義 |
+| `action/lib/api.sh` | API呼び出しラッパー（plan/create/import/fail）＋3回リトライ |
+| `action/lib/kicad.sh` | KiCad CLI全コマンドラッパー（ERC/DRC/PDF/SVG/Gerber/Drill/BOM/Pos/3D） |
+| `action/lib/ibom.sh` | xvfb-run generate_interactive_bom（非致命的失敗） |
+| `action/lib/bundle.sh` | fabrication.zip/manifest.json/bundle.zip/メタデータJSON生成 |
+| `action/lib/summary.sh` | GITHUB_STEP_SUMMARYへのGFMテーブル出力 |
+
+### 主要な実装判断
+
+1. **`set -euo pipefail` を使用しない**: 部分失敗時にBoardRunを継続するため、各コマンドの戻り値を個別にチェック
+2. **ERC/DRC exit code 5を成功扱い**: 違反検出だがJSONは正常に生成される仕様に準拠
+3. **iBOM失敗は非致命的**: artifact status=failedとして記録し、BoardRun全体は継続
+4. **APIリトライ**: exponential backoff (1s→2s→4s)、5xx/タイムアウト時のみ
+5. **tree_hash**: `printf "%b"` でnull byte + hash文字列を連結し、sorted relative_pathsで計算
+6. **INPUT_*環境変数**: ハイフン付き入力名はそのまま `INPUT_EXCLUDE-PATHS` 等で参照
+7. **pull_requestイベント**: サマリ出力のみで即座にexit 0（未サポートイベント）
+8. **タイムアウト**: 全KiCad CLIコマンドに300秒のtimeoutを設定


### PR DESCRIPTION
## Summary

Closes #60

GitHub ActionsからBoardflowを呼び出すためのDocker container actionを実装しました。
ユーザーのworkflowから `boardflow-action` を使ってKiCad CLI実行→SaaS APIアップロードの一連フローを実行できます。

## Changes

### New files
- `action/action.yml` - Action metadata (inputs: token, mode, exclude-paths, api-url, fail-on-drc, fail-on-erc)
- `action/Dockerfile` - KiCad 9.0 + python3-pip + xvfb + interactivehtmlbom + jq + curl + zip
- `action/entrypoint.sh` - Main orchestration script
- `action/lib/detect.sh` - .boardflow.yml detection and project resolution
- `action/lib/config.sh` - YAML parsing and schema v1 validation
- `action/lib/hash.sh` - SHA256 file hashing and tree_hash computation
- `action/lib/api.sh` - BoardFlow API client (Plan, BoardRun, Import, Fail)
- `action/lib/kicad.sh` - KiCad CLI wrappers (ERC/DRC/PDF/SVG/Gerber/Drill/BOM/Position/3D)
- `action/lib/ibom.sh` - InteractiveHtmlBom generation via xvfb-run
- `action/lib/bundle.sh` - Manifest and zip bundle creation
- `action/lib/summary.sh` - GitHub Actions Job Summary output
- `docs/external/github-actions-docker-action.md` - Research documentation

### Spec compliance
- Action inputs match spec §5.2
- Project detection follows spec §3 (.boardflow.yml → .kicad_pro → .kicad_pcb → .kicad_sch)
- Schema validation follows spec §4 (version: 1, allowed fields only)
- tree_hash computation follows spec §6.4 (sha256 of sorted path\0hash\n)
- Bundle structure follows spec §8.6 (review/, assembly/, fabrication/, checks/, diff/, kicad/)
- Manifest follows spec §8.5 (schema_version, project, git, github_actions, kicad, hash, diff_metadata, checks, artifacts)
- API calls follow spec §9.1-§9.6 (Plan, BoardRun, Import, Fail)
- Unsupported event handling follows spec §2.2 (pull_request → skip with Job Summary)

## Testing

- Static review: 3 review cycles, all Critical/High issues resolved
- Docker build: To be validated in CI
- E2E: Requires running SaaS API (deferred to integration testing)

## Usage Example

```yaml
- uses: f0reachARR/boardflow/action@main
  with:
    token: ${{ secrets.BOARDFLOW_TOKEN }}
    mode: auto
```