### PR TITLE
fix(auth): フロントエンド認証リダイレクトループ修正 & ログイン後の元ページリダイレクト

### DIFF
--- a/boardflow/src/app/login/page.tsx
+++ b/boardflow/src/app/login/page.tsx
@@ -1,7 +1,17 @@
 import { Box, Button, Heading, Text, VStack } from '@chakra-ui/react';
 import Link from 'next/link';
 
-export default function LoginPage() {
+export default async function LoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ redirect_to?: string }>;
+}) {
+  const params = await searchParams;
+  const redirectTo = params.redirect_to;
+  const loginHref = redirectTo
+    ? `/api/v1/auth/login?redirect_to=${encodeURIComponent(redirectTo)}`
+    : '/api/v1/auth/login';
+
   return (
     <Box minH='100vh' display='flex' alignItems='center' justifyContent='center' bg='gray.50'>
       <VStack gap={6} p={8} bg='white' borderRadius='lg' shadow='md' maxW='sm' w='full'>
@@ -11,7 +21,7 @@ export default function LoginPage() {
             KiCad Board CI/CD Dashboard
           </Text>
         </VStack>
-        <Link href='/api/v1/auth/login' style={{ width: '100%' }}>
+        <Link href={loginHref} style={{ width: '100%' }}>
           <Button colorPalette='gray' size='lg' w='full'>
             Sign in with GitHub
           </Button>

--- a/boardflow/src/app/login/page.tsx
+++ b/boardflow/src/app/login/page.tsx
@@ -1,11 +1,19 @@
 import { Box, Button, Heading, Text, VStack } from '@chakra-ui/react';
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getCurrentUser } from '@/lib/auth';
 
 export default async function LoginPage({
   searchParams,
 }: {
   searchParams: Promise<{ redirect_to?: string }>;
 }) {
+  const user = await getCurrentUser();
+
+  if (user) {
+    redirect('/repositories');
+  }
+
   const params = await searchParams;
   const redirectTo = params.redirect_to;
   const loginHref = redirectTo

--- a/boardflow/src/lib/api/schema.d.ts
+++ b/boardflow/src/lib/api/schema.d.ts
@@ -4,1805 +4,1799 @@
  */
 
 export interface paths {
-  '/api/v1/auth/callback': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/callback": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["callback"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['callback'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/auth/login': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["login"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['login'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/auth/logout': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["logout"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations['logout'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/auth/me': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/auth/me": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["me"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['me'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-projects/{board_project_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-projects/{board_project_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_board_project"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['get_board_project'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-projects/{board_project_id}/board-runs': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-projects/{board_project_id}/board-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list_board_runs"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['list_board_runs'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-runs': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-runs": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["create_board_run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations['create_board_run'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-runs/{board_run_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-runs/{board_run_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_board_run"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['get_board_run'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-runs/{board_run_id}/artifact-bundles/import': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-runs/{board_run_id}/artifact-bundles/import": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["import_artifact_bundle"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations['import_artifact_bundle'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-runs/{board_run_id}/artifacts': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-runs/{board_run_id}/artifacts": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list_artifacts"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['list_artifacts'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-runs/{board_run_id}/checks/{check_kind}/findings': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-runs/{board_run_id}/checks/{check_kind}/findings": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list_findings"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['list_findings'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-runs/{board_run_id}/diff': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-runs/{board_run_id}/diff": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_board_run_diff"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['get_board_run_diff'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-runs/{board_run_id}/fail': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-runs/{board_run_id}/fail": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["fail_board_run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations['fail_board_run'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/board-runs/{board_run_id}/viewer-sources': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/board-runs/{board_run_id}/viewer-sources": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_viewer_sources"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['get_viewer_sources'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/repositories': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/repositories": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list_repositories"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['list_repositories'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/repositories/{github_repository_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/repositories/{github_repository_id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["get_repository"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['get_repository'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/repositories/{github_repository_id}/api-tokens': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/repositories/{github_repository_id}/api-tokens": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list_api_tokens"];
+        put?: never;
+        post: operations["create_api_token"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['list_api_tokens'];
-    put?: never;
-    post: operations['create_api_token'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/repositories/{github_repository_id}/api-tokens/{token_id}/revoke': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/repositories/{github_repository_id}/api-tokens/{token_id}/revoke": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["revoke_api_token"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations['revoke_api_token'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/repositories/{github_repository_id}/board-projects': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/repositories/{github_repository_id}/board-projects": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["list_board_projects"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['list_board_projects'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/api/v1/runs/plan': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/api/v1/runs/plan": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post: operations["plan_run"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    post: operations['plan_run'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/healthz': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/healthz": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["healthz"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations['healthz'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    ApiTokenDetailResponse: {
-      created_at: string;
-      id: string;
-      last_used_at?: string | null;
-      name: string;
-      revoked_at?: string | null;
+    schemas: {
+        ApiTokenDetailResponse: {
+            created_at: string;
+            id: string;
+            last_used_at?: string | null;
+            name: string;
+            revoked_at?: string | null;
+        };
+        ApiTokenListItem: {
+            created_at: string;
+            id: string;
+            last_used_at?: string | null;
+            name: string;
+            revoked_at?: string | null;
+        };
+        ApiTokenListResponse: {
+            has_more: boolean;
+            items: components["schemas"]["ApiTokenListItem"][];
+            next_cursor?: string | null;
+        };
+        ArtifactBundleInfo: {
+            expires_at: string;
+            method: string;
+            object_key: string;
+            upload_mode: string;
+            upload_url: string;
+        };
+        ArtifactListItem: {
+            artifact_id?: string | null;
+            content_type?: string | null;
+            created_at?: string | null;
+            filename?: string | null;
+            logical_name?: string | null;
+            sha256?: string | null;
+            /** Format: int64 */
+            size_bytes?: number | null;
+            source_path?: string | null;
+            status: string;
+            status_reason?: string | null;
+            type: string;
+        };
+        ArtifactListResponse: {
+            items: components["schemas"]["ArtifactListItem"][];
+        };
+        ArtifactSummary: {
+            /** Format: int64 */
+            available: number;
+            /** Format: int64 */
+            failed: number;
+            /** Format: int64 */
+            missing: number;
+            /** Format: int64 */
+            skipped: number;
+        };
+        BoardProjectDetailResponse: {
+            board_project_id: string;
+            created_at: string;
+            display_name: string;
+            /** Format: int32 */
+            issue_number?: number | null;
+            issue_url?: string | null;
+            latest_completed_run_id?: string | null;
+            latest_tree_hash?: string | null;
+            project_dir: string;
+            project_path: string;
+            recreate_issue_on_update: boolean;
+            repository: components["schemas"]["RepositoryRef"];
+            state: string;
+            updated_at: string;
+        };
+        BoardProjectListItem: {
+            board_project_id: string;
+            display_name: string;
+            issue_url?: string | null;
+            latest_completed_run_id?: string | null;
+            latest_tree_hash?: string | null;
+            project_dir: string;
+            project_path: string;
+            state: string;
+            updated_at: string;
+        };
+        BoardRunDetailResponse: {
+            artifact_summary: components["schemas"]["ArtifactSummary"];
+            board_project_id: string;
+            board_run_id: string;
+            branch: string;
+            checks: components["schemas"]["CheckInfo"][];
+            commit_sha: string;
+            completed_at?: string | null;
+            created_at: string;
+            github_run_attempt: string;
+            github_run_id: string;
+            ref: string;
+            status: string;
+            tree_hash?: string | null;
+        };
+        BoardRunDiffResponse: {
+            base_board_run_id?: string | null;
+            board_run_id: string;
+            created_at: string;
+            error_message?: string | null;
+            metadata?: null | components["schemas"]["DiffMetadataResponse"];
+            status: string;
+            summary?: unknown;
+        };
+        BoardRunListItem: {
+            board_run_id: string;
+            branch: string;
+            commit_sha: string;
+            completed_at?: string | null;
+            created_at: string;
+            /** Format: int32 */
+            drc_errors: number;
+            drc_status?: string | null;
+            /** Format: int32 */
+            drc_warnings: number;
+            /** Format: int32 */
+            erc_errors: number;
+            erc_status?: string | null;
+            /** Format: int32 */
+            erc_warnings: number;
+            github_run_attempt: string;
+            github_run_id: string;
+            ref: string;
+            status: string;
+            tree_hash?: string | null;
+        };
+        CheckInfo: {
+            /** Format: int32 */
+            error_count: number;
+            kind: string;
+            /** Format: int32 */
+            notice_count: number;
+            status: string;
+            /** Format: int32 */
+            warning_count: number;
+        };
+        CoordinateMmResponse: {
+            /** Format: double */
+            x: number;
+            /** Format: double */
+            y: number;
+        };
+        CreateApiTokenRequest: {
+            name: string;
+        };
+        CreateApiTokenResponse: {
+            created_at: string;
+            id: string;
+            name: string;
+            token: string;
+        };
+        CreateBoardRunRequest: {
+            board_project_id: string;
+            branch: string;
+            commit_sha: string;
+            github_run_attempt: string;
+            github_run_id: string;
+            project_path: string;
+            ref: string;
+            tree_hash: string;
+        };
+        CreateBoardRunResponse: {
+            artifact_bundle?: null | components["schemas"]["ArtifactBundleInfo"];
+            board_run_id: string;
+            status: string;
+        };
+        DiffMetadataResponse: {
+            artifacts_summary?: unknown;
+            bom_summary?: unknown;
+            checks_summary?: unknown;
+            file_hashes?: unknown;
+            previews?: unknown;
+        };
+        ErrorBody: {
+            code: string;
+            details?: unknown;
+            message: string;
+            request_id: string;
+        };
+        ErrorResponse: {
+            error: components["schemas"]["ErrorBody"];
+        };
+        FailBoardRunRequest: {
+            error: components["schemas"]["FailErrorInfo"];
+            status: string;
+        };
+        FailBoardRunResponse: {
+            board_run_id: string;
+            failed_at: string;
+            status: string;
+        };
+        FailErrorInfo: {
+            details?: unknown;
+            message: string;
+        };
+        FindingListItem: {
+            id: string;
+            message?: string | null;
+            pcb_layer?: string | null;
+            pos_mm?: null | components["schemas"]["CoordinateMmResponse"];
+            rule_code?: string | null;
+            severity: string;
+            sheet_path?: string | null;
+            subject_kind?: string | null;
+            subject_ref?: string | null;
+            title?: string | null;
+        };
+        HealthResponse: {
+            status: string;
+        };
+        ImportArtifactBundleRequest: {
+            bundle_sha256: string;
+            /** Format: int64 */
+            bundle_size_bytes: number;
+            staging_object_key: string;
+        };
+        ImportArtifactBundleResponse: {
+            bundle_id: string;
+            status: string;
+        };
+        MeResponse: {
+            github_avatar_url?: string | null;
+            github_login: string;
+            user_id: string;
+        };
+        PaginatedResponse_BoardProjectListItem: {
+            has_more: boolean;
+            items: {
+                board_project_id: string;
+                display_name: string;
+                issue_url?: string | null;
+                latest_completed_run_id?: string | null;
+                latest_tree_hash?: string | null;
+                project_dir: string;
+                project_path: string;
+                state: string;
+                updated_at: string;
+            }[];
+            next_cursor?: string | null;
+        };
+        PaginatedResponse_BoardRunListItem: {
+            has_more: boolean;
+            items: {
+                board_run_id: string;
+                branch: string;
+                commit_sha: string;
+                completed_at?: string | null;
+                created_at: string;
+                /** Format: int32 */
+                drc_errors: number;
+                drc_status?: string | null;
+                /** Format: int32 */
+                drc_warnings: number;
+                /** Format: int32 */
+                erc_errors: number;
+                erc_status?: string | null;
+                /** Format: int32 */
+                erc_warnings: number;
+                github_run_attempt: string;
+                github_run_id: string;
+                ref: string;
+                status: string;
+                tree_hash?: string | null;
+            }[];
+            next_cursor?: string | null;
+        };
+        PaginatedResponse_FindingListItem: {
+            has_more: boolean;
+            items: {
+                id: string;
+                message?: string | null;
+                pcb_layer?: string | null;
+                pos_mm?: null | components["schemas"]["CoordinateMmResponse"];
+                rule_code?: string | null;
+                severity: string;
+                sheet_path?: string | null;
+                subject_kind?: string | null;
+                subject_ref?: string | null;
+                title?: string | null;
+            }[];
+            next_cursor?: string | null;
+        };
+        PaginatedResponse_RepositoryListItem: {
+            has_more: boolean;
+            items: {
+                /** Format: int64 */
+                board_project_count: number;
+                github_repository_id: string;
+                installation_id: string;
+                latest_run_status?: string | null;
+                name: string;
+                owner: string;
+                updated_at: string;
+            }[];
+            next_cursor?: string | null;
+        };
+        PlanActionInput: {
+            run_attempt: string;
+            run_id: string;
+            workflow: string;
+        };
+        /** @enum {string} */
+        PlanDecision: "build" | "skip" | "error";
+        PlanGitInput: {
+            branch: string;
+            commit_sha: string;
+            event_name: string;
+            ref: string;
+        };
+        /** @enum {string} */
+        PlanMode: "auto" | "all";
+        PlanProjectFile: {
+            path: string;
+            sha256: string;
+        };
+        PlanProjectInput: {
+            config_path: string;
+            files: components["schemas"]["PlanProjectFile"][];
+            project_dir: string;
+            project_path: string;
+            tree_hash: string;
+        };
+        PlanProjectOutput: {
+            board_project_id: string;
+            decision: components["schemas"]["PlanDecision"];
+            latest_completed_run_id?: string | null;
+            project_path: string;
+            reason: components["schemas"]["PlanReason"];
+        };
+        /** @enum {string} */
+        PlanReason: "new_project" | "hash_changed" | "config_changed" | "manual_dispatch" | "unchanged" | "previous_failed" | "no_previous_snapshot" | "duplicate_project_path" | "invalid_project_path" | "invalid_tree_hash" | "invalid_config_path";
+        PlanRepositoryInput: {
+            github_repository_id: string;
+            name: string;
+            owner: string;
+        };
+        PlanRepositoryOutput: {
+            github_repository_id: string;
+            name: string;
+            owner: string;
+        };
+        PlanRequest: {
+            action: components["schemas"]["PlanActionInput"];
+            git: components["schemas"]["PlanGitInput"];
+            mode: components["schemas"]["PlanMode"];
+            projects: components["schemas"]["PlanProjectInput"][];
+            repository: components["schemas"]["PlanRepositoryInput"];
+        };
+        PlanResponse: {
+            projects: components["schemas"]["PlanProjectOutput"][];
+            repository: components["schemas"]["PlanRepositoryOutput"];
+        };
+        RepositoryDetailResponse: {
+            /** Format: int64 */
+            board_project_count: number;
+            created_at: string;
+            github_repository_id: string;
+            html_url: string;
+            installation_id: string;
+            name: string;
+            owner: string;
+            updated_at: string;
+        };
+        RepositoryListItem: {
+            /** Format: int64 */
+            board_project_count: number;
+            github_repository_id: string;
+            installation_id: string;
+            latest_run_status?: string | null;
+            name: string;
+            owner: string;
+            updated_at: string;
+        };
+        RepositoryRef: {
+            github_repository_id: string;
+            name: string;
+            owner: string;
+        };
+        ViewerDownload: {
+            artifact_id?: string | null;
+            artifact_type: string;
+            status: string;
+            status_reason?: string | null;
+            url?: string | null;
+        };
+        ViewerMap: {
+            bom: components["schemas"]["ViewerStatus"];
+            fabrication: components["schemas"]["ViewerStatus"];
+            ibom: components["schemas"]["ViewerStatus"];
+            kicanvas: components["schemas"]["ViewerStatus"];
+            pcb_preview: components["schemas"]["ViewerStatus"];
+            schematic: components["schemas"]["ViewerStatus"];
+        };
+        ViewerSource: {
+            artifact_id?: string | null;
+            artifact_type?: string | null;
+            kind?: string | null;
+            name?: string | null;
+            source_path?: string | null;
+            url?: string | null;
+        };
+        ViewerSourcesResponse: {
+            board_run_id: string;
+            expires_at: string;
+            viewers: components["schemas"]["ViewerMap"];
+        };
+        ViewerStatus: {
+            downloads?: components["schemas"]["ViewerDownload"][] | null;
+            iframe_url?: string | null;
+            primary?: null | components["schemas"]["ViewerSource"];
+            sources?: components["schemas"]["ViewerSource"][] | null;
+            status: string;
+        };
     };
-    ApiTokenListItem: {
-      created_at: string;
-      id: string;
-      last_used_at?: string | null;
-      name: string;
-      revoked_at?: string | null;
-    };
-    ApiTokenListResponse: {
-      has_more: boolean;
-      items: components['schemas']['ApiTokenListItem'][];
-      next_cursor?: string | null;
-    };
-    ArtifactBundleInfo: {
-      expires_at: string;
-      method: string;
-      object_key: string;
-      upload_mode: string;
-      upload_url: string;
-    };
-    ArtifactListItem: {
-      artifact_id?: string | null;
-      content_type?: string | null;
-      created_at?: string | null;
-      filename?: string | null;
-      logical_name?: string | null;
-      sha256?: string | null;
-      /** Format: int64 */
-      size_bytes?: number | null;
-      source_path?: string | null;
-      status: string;
-      status_reason?: string | null;
-      type: string;
-    };
-    ArtifactListResponse: {
-      items: components['schemas']['ArtifactListItem'][];
-    };
-    ArtifactSummary: {
-      /** Format: int64 */
-      available: number;
-      /** Format: int64 */
-      failed: number;
-      /** Format: int64 */
-      missing: number;
-      /** Format: int64 */
-      skipped: number;
-    };
-    BoardProjectDetailResponse: {
-      board_project_id: string;
-      created_at: string;
-      display_name: string;
-      /** Format: int32 */
-      issue_number?: number | null;
-      issue_url?: string | null;
-      latest_completed_run_id?: string | null;
-      latest_tree_hash?: string | null;
-      project_dir: string;
-      project_path: string;
-      recreate_issue_on_update: boolean;
-      repository: components['schemas']['RepositoryRef'];
-      state: string;
-      updated_at: string;
-    };
-    BoardProjectListItem: {
-      board_project_id: string;
-      display_name: string;
-      issue_url?: string | null;
-      latest_completed_run_id?: string | null;
-      latest_tree_hash?: string | null;
-      project_dir: string;
-      project_path: string;
-      state: string;
-      updated_at: string;
-    };
-    BoardRunDetailResponse: {
-      artifact_summary: components['schemas']['ArtifactSummary'];
-      board_project_id: string;
-      board_run_id: string;
-      branch: string;
-      checks: components['schemas']['CheckInfo'][];
-      commit_sha: string;
-      completed_at?: string | null;
-      created_at: string;
-      github_run_attempt: string;
-      github_run_id: string;
-      ref: string;
-      status: string;
-      tree_hash?: string | null;
-    };
-    BoardRunDiffResponse: {
-      base_board_run_id?: string | null;
-      board_run_id: string;
-      created_at: string;
-      error_message?: string | null;
-      metadata?: null | components['schemas']['DiffMetadataResponse'];
-      status: string;
-      summary?: unknown;
-    };
-    BoardRunListItem: {
-      board_run_id: string;
-      branch: string;
-      commit_sha: string;
-      completed_at?: string | null;
-      created_at: string;
-      /** Format: int32 */
-      drc_errors: number;
-      drc_status?: string | null;
-      /** Format: int32 */
-      drc_warnings: number;
-      /** Format: int32 */
-      erc_errors: number;
-      erc_status?: string | null;
-      /** Format: int32 */
-      erc_warnings: number;
-      github_run_attempt: string;
-      github_run_id: string;
-      ref: string;
-      status: string;
-      tree_hash?: string | null;
-    };
-    CheckInfo: {
-      /** Format: int32 */
-      error_count: number;
-      kind: string;
-      /** Format: int32 */
-      notice_count: number;
-      status: string;
-      /** Format: int32 */
-      warning_count: number;
-    };
-    CoordinateMmResponse: {
-      /** Format: double */
-      x: number;
-      /** Format: double */
-      y: number;
-    };
-    CreateApiTokenRequest: {
-      name: string;
-    };
-    CreateApiTokenResponse: {
-      created_at: string;
-      id: string;
-      name: string;
-      token: string;
-    };
-    CreateBoardRunRequest: {
-      board_project_id: string;
-      branch: string;
-      commit_sha: string;
-      github_run_attempt: string;
-      github_run_id: string;
-      project_path: string;
-      ref: string;
-      tree_hash: string;
-    };
-    CreateBoardRunResponse: {
-      artifact_bundle?: null | components['schemas']['ArtifactBundleInfo'];
-      board_run_id: string;
-      status: string;
-    };
-    DiffMetadataResponse: {
-      artifacts_summary?: unknown;
-      bom_summary?: unknown;
-      checks_summary?: unknown;
-      file_hashes?: unknown;
-      previews?: unknown;
-    };
-    ErrorBody: {
-      code: string;
-      details?: unknown;
-      message: string;
-      request_id: string;
-    };
-    ErrorResponse: {
-      error: components['schemas']['ErrorBody'];
-    };
-    FailBoardRunRequest: {
-      error: components['schemas']['FailErrorInfo'];
-      status: string;
-    };
-    FailBoardRunResponse: {
-      board_run_id: string;
-      failed_at: string;
-      status: string;
-    };
-    FailErrorInfo: {
-      details?: unknown;
-      message: string;
-    };
-    FindingListItem: {
-      id: string;
-      message?: string | null;
-      pcb_layer?: string | null;
-      pos_mm?: null | components['schemas']['CoordinateMmResponse'];
-      rule_code?: string | null;
-      severity: string;
-      sheet_path?: string | null;
-      subject_kind?: string | null;
-      subject_ref?: string | null;
-      title?: string | null;
-    };
-    HealthResponse: {
-      status: string;
-    };
-    ImportArtifactBundleRequest: {
-      bundle_sha256: string;
-      /** Format: int64 */
-      bundle_size_bytes: number;
-      staging_object_key: string;
-    };
-    ImportArtifactBundleResponse: {
-      bundle_id: string;
-      status: string;
-    };
-    MeResponse: {
-      github_avatar_url?: string | null;
-      github_login: string;
-      user_id: string;
-    };
-    PaginatedResponse_BoardProjectListItem: {
-      has_more: boolean;
-      items: {
-        board_project_id: string;
-        display_name: string;
-        issue_url?: string | null;
-        latest_completed_run_id?: string | null;
-        latest_tree_hash?: string | null;
-        project_dir: string;
-        project_path: string;
-        state: string;
-        updated_at: string;
-      }[];
-      next_cursor?: string | null;
-    };
-    PaginatedResponse_BoardRunListItem: {
-      has_more: boolean;
-      items: {
-        board_run_id: string;
-        branch: string;
-        commit_sha: string;
-        completed_at?: string | null;
-        created_at: string;
-        /** Format: int32 */
-        drc_errors: number;
-        drc_status?: string | null;
-        /** Format: int32 */
-        drc_warnings: number;
-        /** Format: int32 */
-        erc_errors: number;
-        erc_status?: string | null;
-        /** Format: int32 */
-        erc_warnings: number;
-        github_run_attempt: string;
-        github_run_id: string;
-        ref: string;
-        status: string;
-        tree_hash?: string | null;
-      }[];
-      next_cursor?: string | null;
-    };
-    PaginatedResponse_FindingListItem: {
-      has_more: boolean;
-      items: {
-        id: string;
-        message?: string | null;
-        pcb_layer?: string | null;
-        pos_mm?: null | components['schemas']['CoordinateMmResponse'];
-        rule_code?: string | null;
-        severity: string;
-        sheet_path?: string | null;
-        subject_kind?: string | null;
-        subject_ref?: string | null;
-        title?: string | null;
-      }[];
-      next_cursor?: string | null;
-    };
-    PaginatedResponse_RepositoryListItem: {
-      has_more: boolean;
-      items: {
-        /** Format: int64 */
-        board_project_count: number;
-        github_repository_id: string;
-        installation_id: string;
-        latest_run_status?: string | null;
-        name: string;
-        owner: string;
-        updated_at: string;
-      }[];
-      next_cursor?: string | null;
-    };
-    PlanActionInput: {
-      run_attempt: string;
-      run_id: string;
-      workflow: string;
-    };
-    /** @enum {string} */
-    PlanDecision: 'build' | 'skip' | 'error';
-    PlanGitInput: {
-      branch: string;
-      commit_sha: string;
-      event_name: string;
-      ref: string;
-    };
-    /** @enum {string} */
-    PlanMode: 'auto' | 'all';
-    PlanProjectFile: {
-      path: string;
-      sha256: string;
-    };
-    PlanProjectInput: {
-      config_path: string;
-      files: components['schemas']['PlanProjectFile'][];
-      project_dir: string;
-      project_path: string;
-      tree_hash: string;
-    };
-    PlanProjectOutput: {
-      board_project_id: string;
-      decision: components['schemas']['PlanDecision'];
-      latest_completed_run_id?: string | null;
-      project_path: string;
-      reason: components['schemas']['PlanReason'];
-    };
-    /** @enum {string} */
-    PlanReason:
-      | 'new_project'
-      | 'hash_changed'
-      | 'config_changed'
-      | 'manual_dispatch'
-      | 'unchanged'
-      | 'previous_failed'
-      | 'no_previous_snapshot'
-      | 'duplicate_project_path'
-      | 'invalid_project_path'
-      | 'invalid_tree_hash'
-      | 'invalid_config_path';
-    PlanRepositoryInput: {
-      github_repository_id: string;
-      name: string;
-      owner: string;
-    };
-    PlanRepositoryOutput: {
-      github_repository_id: string;
-      name: string;
-      owner: string;
-    };
-    PlanRequest: {
-      action: components['schemas']['PlanActionInput'];
-      git: components['schemas']['PlanGitInput'];
-      mode: components['schemas']['PlanMode'];
-      projects: components['schemas']['PlanProjectInput'][];
-      repository: components['schemas']['PlanRepositoryInput'];
-    };
-    PlanResponse: {
-      projects: components['schemas']['PlanProjectOutput'][];
-      repository: components['schemas']['PlanRepositoryOutput'];
-    };
-    RepositoryDetailResponse: {
-      /** Format: int64 */
-      board_project_count: number;
-      created_at: string;
-      github_repository_id: string;
-      html_url: string;
-      installation_id: string;
-      name: string;
-      owner: string;
-      updated_at: string;
-    };
-    RepositoryListItem: {
-      /** Format: int64 */
-      board_project_count: number;
-      github_repository_id: string;
-      installation_id: string;
-      latest_run_status?: string | null;
-      name: string;
-      owner: string;
-      updated_at: string;
-    };
-    RepositoryRef: {
-      github_repository_id: string;
-      name: string;
-      owner: string;
-    };
-    ViewerDownload: {
-      artifact_id?: string | null;
-      artifact_type: string;
-      status: string;
-      status_reason?: string | null;
-      url?: string | null;
-    };
-    ViewerMap: {
-      bom: components['schemas']['ViewerStatus'];
-      fabrication: components['schemas']['ViewerStatus'];
-      ibom: components['schemas']['ViewerStatus'];
-      kicanvas: components['schemas']['ViewerStatus'];
-      pcb_preview: components['schemas']['ViewerStatus'];
-      schematic: components['schemas']['ViewerStatus'];
-    };
-    ViewerSource: {
-      artifact_id?: string | null;
-      artifact_type?: string | null;
-      kind?: string | null;
-      name?: string | null;
-      source_path?: string | null;
-      url?: string | null;
-    };
-    ViewerSourcesResponse: {
-      board_run_id: string;
-      expires_at: string;
-      viewers: components['schemas']['ViewerMap'];
-    };
-    ViewerStatus: {
-      downloads?: components['schemas']['ViewerDownload'][] | null;
-      iframe_url?: string | null;
-      primary?: null | components['schemas']['ViewerSource'];
-      sources?: components['schemas']['ViewerSource'][] | null;
-      status: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  callback: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    callback: {
+        parameters: {
+            query: {
+                code: string;
+                state?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Redirect after successful OAuth */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description OAuth failed */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description CSRF state mismatch */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Redirect after successful OAuth */
-      302: {
-        headers: {
-          [name: string]: unknown;
+    login: {
+        parameters: {
+            query?: {
+                redirect_to?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content?: never;
-      };
-      /** @description OAuth failed */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            /** @description Redirect to GitHub OAuth */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-        content?: never;
-      };
-      /** @description CSRF state mismatch */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  login: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    logout: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Logged out */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Redirect to GitHub OAuth */
-      302: {
-        headers: {
-          [name: string]: unknown;
+    me: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content?: never;
-      };
+        requestBody?: never;
+        responses: {
+            /** @description Current user info */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MeResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
     };
-  };
-  logout: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    get_board_project: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description BoardProject ID (bp_ prefix) */
+                board_project_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description BoardProject detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BoardProjectDetailResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Logged out */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    list_board_runs: {
+        parameters: {
+            query?: {
+                limit?: number | null;
+                cursor?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description BoardProject ID (bp_ prefix) */
+                board_project_id: string;
+            };
+            cookie?: never;
         };
-        content?: never;
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            /** @description BoardRun list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_BoardRunListItem"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
-        content?: never;
-      };
     };
-  };
-  me: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    create_board_run: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateBoardRunRequest"];
+            };
+        };
+        responses: {
+            /** @description Board run created or existing returned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateBoardRunResponse"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Current user info */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    get_board_run: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description BoardRun ID (br_ prefix) */
+                board_run_id: string;
+            };
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['MeResponse'];
+        requestBody?: never;
+        responses: {
+            /** @description BoardRun detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BoardRunDetailResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
     };
-  };
-  get_board_project: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description BoardProject ID (bp_ prefix) */
-        board_project_id: string;
-      };
-      cookie?: never;
+    import_artifact_bundle: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Board run ID with br_ prefix */
+                board_run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["ImportArtifactBundleRequest"];
+            };
+        };
+        responses: {
+            /** @description Import queued or existing returned */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ImportArtifactBundleResponse"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Gone */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description BoardProject detail */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    list_artifacts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description BoardRun ID (br_ prefix) */
+                board_run_id: string;
+            };
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['BoardProjectDetailResponse'];
+        requestBody?: never;
+        responses: {
+            /** @description Artifact list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArtifactListResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
     };
-  };
-  list_board_runs: {
-    parameters: {
-      query?: {
-        limit?: number | null;
-        cursor?: string | null;
-      };
-      header?: never;
-      path: {
-        /** @description BoardProject ID (bp_ prefix) */
-        board_project_id: string;
-      };
-      cookie?: never;
+    list_findings: {
+        parameters: {
+            query?: {
+                limit?: number | null;
+                cursor?: string | null;
+                severity?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description BoardRun ID (br_ prefix) */
+                board_run_id: string;
+                /** @description Check kind: erc or drc */
+                check_kind: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Findings list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_FindingListItem"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description BoardRun list */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    get_board_run_diff: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Board run ID (br_<uuid>) */
+                board_run_id: string;
+            };
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['PaginatedResponse_BoardRunListItem'];
+        requestBody?: never;
+        responses: {
+            /** @description Diff details */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BoardRunDiffResponse"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
     };
-  };
-  create_board_run: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    fail_board_run: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Board run ID with br_ prefix */
+                board_run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["FailBoardRunRequest"];
+            };
+        };
+        responses: {
+            /** @description Board run marked as failed */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FailBoardRunResponse"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Gone */
+            410: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['CreateBoardRunRequest'];
-      };
+    get_viewer_sources: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description BoardRun ID (br_ prefix) */
+                board_run_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Viewer sources */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ViewerSourcesResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Board run created or existing returned */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    list_repositories: {
+        parameters: {
+            query?: {
+                limit?: number | null;
+                cursor?: string | null;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['CreateBoardRunResponse'];
+        requestBody?: never;
+        responses: {
+            /** @description Repository list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_RepositoryListItem"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Internal error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
     };
-  };
-  get_board_run: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description BoardRun ID (br_ prefix) */
-        board_run_id: string;
-      };
-      cookie?: never;
+    get_repository: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description GitHub repository ID */
+                github_repository_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Repository detail */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RepositoryDetailResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description BoardRun detail */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    list_api_tokens: {
+        parameters: {
+            query?: {
+                limit?: number | null;
+                cursor?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description GitHub repository ID */
+                github_repository_id: number;
+            };
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['BoardRunDetailResponse'];
+        requestBody?: never;
+        responses: {
+            /** @description Token list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiTokenListResponse"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
     };
-  };
-  import_artifact_bundle: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Board run ID with br_ prefix */
-        board_run_id: string;
-      };
-      cookie?: never;
+    create_api_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description GitHub repository ID */
+                github_repository_id: number;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateApiTokenRequest"];
+            };
+        };
+        responses: {
+            /** @description Token created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateApiTokenResponse"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['ImportArtifactBundleRequest'];
-      };
+    revoke_api_token: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description GitHub repository ID */
+                github_repository_id: number;
+                /** @description API token ID */
+                token_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Token revoked */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ApiTokenDetailResponse"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Import queued or existing returned */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    list_board_projects: {
+        parameters: {
+            query?: {
+                limit?: number | null;
+                cursor?: string | null;
+            };
+            header?: never;
+            path: {
+                /** @description GitHub repository ID */
+                github_repository_id: number;
+            };
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['ImportArtifactBundleResponse'];
+        requestBody?: never;
+        responses: {
+            /** @description BoardProject list */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PaginatedResponse_BoardProjectListItem"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
         };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Gone */
-      410: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Internal error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
     };
-  };
-  list_artifacts: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description BoardRun ID (br_ prefix) */
-        board_run_id: string;
-      };
-      cookie?: never;
+    plan_run: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PlanRequest"];
+            };
+        };
+        responses: {
+            /** @description Plan decisions */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlanResponse"];
+                };
+            };
+            /** @description Validation error */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Unauthorized */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+            /** @description Internal error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorResponse"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Artifact list */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    healthz: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          'application/json': components['schemas']['ArtifactListResponse'];
+        requestBody?: never;
+        responses: {
+            /** @description Service is healthy */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HealthResponse"];
+                };
+            };
+            /** @description Service is unhealthy */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
     };
-  };
-  list_findings: {
-    parameters: {
-      query?: {
-        limit?: number | null;
-        cursor?: string | null;
-        severity?: string | null;
-      };
-      header?: never;
-      path: {
-        /** @description BoardRun ID (br_ prefix) */
-        board_run_id: string;
-        /** @description Check kind: erc or drc */
-        check_kind: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Findings list */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['PaginatedResponse_FindingListItem'];
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  get_board_run_diff: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Board run ID (br_<uuid>) */
-        board_run_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Diff details */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['BoardRunDiffResponse'];
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  fail_board_run: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Board run ID with br_ prefix */
-        board_run_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['FailBoardRunRequest'];
-      };
-    };
-    responses: {
-      /** @description Board run marked as failed */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['FailBoardRunResponse'];
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Conflict */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Gone */
-      410: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Internal error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  get_viewer_sources: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description BoardRun ID (br_ prefix) */
-        board_run_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Viewer sources */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ViewerSourcesResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  list_repositories: {
-    parameters: {
-      query?: {
-        limit?: number | null;
-        cursor?: string | null;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Repository list */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['PaginatedResponse_RepositoryListItem'];
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  get_repository: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description GitHub repository ID */
-        github_repository_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Repository detail */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['RepositoryDetailResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  list_api_tokens: {
-    parameters: {
-      query?: {
-        limit?: number | null;
-        cursor?: string | null;
-      };
-      header?: never;
-      path: {
-        /** @description GitHub repository ID */
-        github_repository_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Token list */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ApiTokenListResponse'];
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  create_api_token: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description GitHub repository ID */
-        github_repository_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['CreateApiTokenRequest'];
-      };
-    };
-    responses: {
-      /** @description Token created */
-      201: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['CreateApiTokenResponse'];
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  revoke_api_token: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description GitHub repository ID */
-        github_repository_id: number;
-        /** @description API token ID */
-        token_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Token revoked */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ApiTokenDetailResponse'];
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  list_board_projects: {
-    parameters: {
-      query?: {
-        limit?: number | null;
-        cursor?: string | null;
-      };
-      header?: never;
-      path: {
-        /** @description GitHub repository ID */
-        github_repository_id: number;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description BoardProject list */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['PaginatedResponse_BoardProjectListItem'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Not found */
-      404: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  plan_run: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['PlanRequest'];
-      };
-    };
-    responses: {
-      /** @description Plan decisions */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['PlanResponse'];
-        };
-      };
-      /** @description Validation error */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-      /** @description Internal error */
-      500: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ErrorResponse'];
-        };
-      };
-    };
-  };
-  healthz: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Service is healthy */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HealthResponse'];
-        };
-      };
-      /** @description Service is unhealthy */
-      503: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
-      };
-    };
-  };
 }

--- a/boardflow/src/middleware.ts
+++ b/boardflow/src/middleware.ts
@@ -16,7 +16,11 @@ export function middleware(request: NextRequest) {
   }
 
   // Public paths always accessible (no session check for /login to prevent redirect loop)
-  if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+  if (
+    PUBLIC_PATHS.some(
+      (p) => pathname === p || pathname.startsWith(`${p}/`),
+    )
+  ) {
     return NextResponse.next();
   }
 

--- a/boardflow/src/middleware.ts
+++ b/boardflow/src/middleware.ts
@@ -15,19 +15,21 @@ export function middleware(request: NextRequest) {
     return NextResponse.redirect(new URL('/login', request.url));
   }
 
-  // Authenticated user accessing login → redirect to repositories
-  if (pathname === '/login' && session) {
-    return NextResponse.redirect(new URL('/repositories', request.url));
-  }
-
-  // Public paths don't require auth
+  // Public paths always accessible (no session check for /login to prevent redirect loop)
   if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
     return NextResponse.next();
   }
 
-  // Unauthenticated → redirect to login
+  // Unauthenticated → redirect to login with redirect_to
   if (!session) {
-    return NextResponse.redirect(new URL('/login', request.url));
+    const loginUrl = new URL('/login', request.url);
+    const redirectTo = pathname + request.nextUrl.search;
+    if (redirectTo !== '/') {
+      loginUrl.searchParams.set('redirect_to', redirectTo);
+    }
+    const response = NextResponse.redirect(loginUrl);
+    response.headers.set('x-middleware-cache', 'no-cache');
+    return response;
   }
 
   return NextResponse.next();

--- a/crates/api/src/routes/auth.rs
+++ b/crates/api/src/routes/auth.rs
@@ -6,7 +6,7 @@ use axum::response::Response;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 use sqlx::PgPool;
-use utoipa::ToSchema;
+use utoipa::{IntoParams, ToSchema};
 use uuid::Uuid;
 
 use crate::error::{AppError, RequestId};
@@ -22,7 +22,7 @@ pub struct OAuthConfig {
 
 // ─── GET /api/v1/auth/login ─────────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
 pub struct LoginQuery {
     pub redirect_to: Option<String>,
 }
@@ -30,6 +30,7 @@ pub struct LoginQuery {
 #[utoipa::path(
     get,
     path = "/api/v1/auth/login",
+    params(LoginQuery),
     responses(
         (status = 302, description = "Redirect to GitHub OAuth"),
     )
@@ -71,7 +72,7 @@ pub async fn login(
 
 // ─── GET /api/v1/auth/callback ──────────────────────────────────────────────
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
 pub struct CallbackQuery {
     pub code: String,
     pub state: Option<String>,
@@ -92,6 +93,7 @@ struct GitHubUserResponse {
 #[utoipa::path(
     get,
     path = "/api/v1/auth/callback",
+    params(CallbackQuery),
     responses(
         (status = 302, description = "Redirect after successful OAuth"),
         (status = 401, description = "OAuth failed"),
@@ -311,6 +313,11 @@ fn validate_redirect_path(path: &str) -> Option<&str> {
     if path.contains('\0') {
         return None;
     }
+    // Reject characters that are invalid in cookie values (RFC 6265)
+    // This prevents cookie injection / header manipulation
+    if path.bytes().any(|b| matches!(b, b';' | b',' | b'"' | b'\r' | b'\n' | b' ')) {
+        return None;
+    }
     if let Ok(decoded) = urlencoding::decode(path) {
         if decoded.starts_with("//") || decoded.contains("://") || decoded.contains('\\') {
             return None;
@@ -382,5 +389,20 @@ mod tests {
     fn test_validate_redirect_path_too_long() {
         let long_path = format!("/{}", "a".repeat(2048));
         assert_eq!(validate_redirect_path(&long_path), None);
+    }
+
+    #[test]
+    fn test_validate_redirect_path_cookie_unsafe_chars() {
+        // Semicolon could inject cookie attributes
+        assert_eq!(validate_redirect_path("/foo;bar"), None);
+        // Comma
+        assert_eq!(validate_redirect_path("/foo,bar"), None);
+        // Double quote
+        assert_eq!(validate_redirect_path("/foo\"bar"), None);
+        // CR/LF (header injection)
+        assert_eq!(validate_redirect_path("/foo\rbar"), None);
+        assert_eq!(validate_redirect_path("/foo\nbar"), None);
+        // Space
+        assert_eq!(validate_redirect_path("/foo bar"), None);
     }
 }

--- a/crates/api/src/routes/auth.rs
+++ b/crates/api/src/routes/auth.rs
@@ -24,7 +24,7 @@ pub struct OAuthConfig {
 
 #[derive(Debug, Deserialize)]
 pub struct LoginQuery {
-    pub redirect_uri: Option<String>,
+    pub redirect_to: Option<String>,
 }
 
 #[utoipa::path(
@@ -36,7 +36,7 @@ pub struct LoginQuery {
 )]
 pub async fn login(
     Extension(oauth_config): Extension<OAuthConfig>,
-    Query(_query): Query<LoginQuery>,
+    Query(query): Query<LoginQuery>,
 ) -> Response {
     let state = Uuid::new_v4().to_string();
     let url = format!(
@@ -50,12 +50,23 @@ pub async fn login(
         state
     );
 
-    Response::builder()
+    let mut builder = Response::builder()
         .status(StatusCode::FOUND)
         .header(header::LOCATION, url)
-        .header(header::SET_COOKIE, oauth_state_cookie)
-        .body(axum::body::Body::empty())
-        .unwrap()
+        .header(header::SET_COOKIE, oauth_state_cookie);
+
+    // Store redirect_to in a cookie if provided and valid
+    if let Some(ref redirect_to) = query.redirect_to {
+        if validate_redirect_path(redirect_to).is_some() {
+            let redirect_cookie = format!(
+                "boardflow_redirect_to={}; Path=/; HttpOnly; SameSite=Lax; Max-Age=300",
+                redirect_to
+            );
+            builder = builder.header(header::SET_COOKIE, redirect_cookie);
+        }
+    }
+
+    builder.body(axum::body::Body::empty()).unwrap()
 }
 
 // ─── GET /api/v1/auth/callback ──────────────────────────────────────────────
@@ -173,19 +184,29 @@ pub async fn callback(
             AppError::internal_error("database error", &request_id)
         })?;
 
-    // Set session cookie, clear oauth_state cookie, and redirect to "/"
+    // Determine redirect location from boardflow_redirect_to cookie
+    let redirect_location = extract_cookie_value(&headers, "boardflow_redirect_to")
+        .as_deref()
+        .and_then(validate_redirect_path)
+        .unwrap_or("/")
+        .to_owned();
+
+    // Set session cookie, clear oauth_state cookie and redirect_to cookie
     let session_cookie = format!(
         "boardflow_session={}; Path=/; HttpOnly; SameSite=Lax; Max-Age=604800",
         session.id
     );
     let clear_oauth_state_cookie =
         "boardflow_oauth_state=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0";
+    let clear_redirect_cookie =
+        "boardflow_redirect_to=; Path=/; HttpOnly; SameSite=Lax; Max-Age=0";
 
     let response = Response::builder()
         .status(StatusCode::FOUND)
-        .header(header::LOCATION, "/")
+        .header(header::LOCATION, &redirect_location)
         .header(header::SET_COOKIE, session_cookie)
         .header(header::SET_COOKIE, clear_oauth_state_cookie)
+        .header(header::SET_COOKIE, clear_redirect_cookie)
         .body(axum::body::Body::empty())
         .unwrap();
 
@@ -267,4 +288,99 @@ fn extract_cookie_value(headers: &HeaderMap, name: &str) -> Option<String> {
                 None
             }
         })
+}
+
+/// Validate that a redirect path is a safe relative path.
+/// Returns the path if valid, None if it should be rejected (fallback to "/").
+fn validate_redirect_path(path: &str) -> Option<&str> {
+    if path.is_empty() {
+        return None;
+    }
+    if !path.starts_with('/') {
+        return None;
+    }
+    if path.starts_with("//") {
+        return None;
+    }
+    if path.contains("://") {
+        return None;
+    }
+    if path.contains('\\') {
+        return None;
+    }
+    if path.contains('\0') {
+        return None;
+    }
+    if let Ok(decoded) = urlencoding::decode(path) {
+        if decoded.starts_with("//") || decoded.contains("://") || decoded.contains('\\') {
+            return None;
+        }
+    }
+    if path.len() > 2048 {
+        return None;
+    }
+    Some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_redirect_path_valid() {
+        assert_eq!(validate_redirect_path("/"), Some("/"));
+        assert_eq!(validate_redirect_path("/repositories"), Some("/repositories"));
+        assert_eq!(
+            validate_redirect_path("/repositories/123?tab=files"),
+            Some("/repositories/123?tab=files")
+        );
+        assert_eq!(validate_redirect_path("/a/b/c"), Some("/a/b/c"));
+    }
+
+    #[test]
+    fn test_validate_redirect_path_empty() {
+        assert_eq!(validate_redirect_path(""), None);
+    }
+
+    #[test]
+    fn test_validate_redirect_path_no_leading_slash() {
+        assert_eq!(validate_redirect_path("repositories"), None);
+        assert_eq!(validate_redirect_path("https://evil.com"), None);
+    }
+
+    #[test]
+    fn test_validate_redirect_path_protocol_relative() {
+        assert_eq!(validate_redirect_path("//evil.com"), None);
+        assert_eq!(validate_redirect_path("//evil.com/path"), None);
+    }
+
+    #[test]
+    fn test_validate_redirect_path_contains_scheme() {
+        assert_eq!(validate_redirect_path("/foo://bar"), None);
+    }
+
+    #[test]
+    fn test_validate_redirect_path_backslash() {
+        assert_eq!(validate_redirect_path("/\\evil.com"), None);
+        assert_eq!(validate_redirect_path("/foo\\bar"), None);
+    }
+
+    #[test]
+    fn test_validate_redirect_path_null_byte() {
+        assert_eq!(validate_redirect_path("/foo\0bar"), None);
+    }
+
+    #[test]
+    fn test_validate_redirect_path_encoded_bypass() {
+        // %2F%2F = //
+        assert_eq!(validate_redirect_path("/%2F%2Fevil.com"), None);
+        // %5C = backslash
+        assert_eq!(validate_redirect_path("/%5Cevil.com"), None);
+    }
+
+    #[test]
+    fn test_validate_redirect_path_too_long() {
+        let long_path = format!("/{}", "a".repeat(2048));
+        assert_eq!(validate_redirect_path(&long_path), None);
+    }
 }

--- a/crates/api/tests/auth_test.rs
+++ b/crates/api/tests/auth_test.rs
@@ -150,3 +150,108 @@ fn request_id_clone() {
     let cloned = id.clone();
     assert_eq!(id.0, cloned.0);
 }
+
+// ─── Login handler redirect_to tests ────────────────────────────────────────
+
+use boardflow_api::routes::auth::{OAuthConfig, login};
+use axum::Extension;
+
+fn login_app() -> Router {
+    Router::new()
+        .route("/api/v1/auth/login", get(login))
+        .layer(Extension(OAuthConfig {
+            client_id: "test_client_id".to_string(),
+            client_secret: "test_client_secret".to_string(),
+        }))
+}
+
+#[tokio::test]
+#[serial]
+async fn login_without_redirect_to_has_no_redirect_cookie() {
+    let app = login_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/auth/login")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FOUND);
+
+    // Should have oauth_state cookie but not redirect_to cookie
+    let cookies: Vec<&str> = response
+        .headers()
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+
+    assert!(cookies.iter().any(|c| c.starts_with("boardflow_oauth_state=")));
+    assert!(!cookies.iter().any(|c| c.starts_with("boardflow_redirect_to=")));
+}
+
+#[tokio::test]
+#[serial]
+async fn login_with_valid_redirect_to_sets_cookie() {
+    let app = login_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/auth/login?redirect_to=/repositories/123")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FOUND);
+
+    let cookies: Vec<&str> = response
+        .headers()
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+
+    let redirect_cookie = cookies
+        .iter()
+        .find(|c| c.starts_with("boardflow_redirect_to="))
+        .expect("redirect_to cookie should be set");
+
+    assert!(redirect_cookie.contains("/repositories/123"));
+    assert!(redirect_cookie.contains("HttpOnly"));
+    assert!(redirect_cookie.contains("SameSite=Lax"));
+    assert!(redirect_cookie.contains("Max-Age=300"));
+}
+
+#[tokio::test]
+#[serial]
+async fn login_with_invalid_redirect_to_does_not_set_cookie() {
+    let app = login_app();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/api/v1/auth/login?redirect_to=//evil.com")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::FOUND);
+
+    let cookies: Vec<&str> = response
+        .headers()
+        .get_all(axum::http::header::SET_COOKIE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+
+    assert!(!cookies.iter().any(|c| c.starts_with("boardflow_redirect_to=")));
+}

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -355,11 +355,14 @@ Web UI の認証は GitHub OAuth を使う。session は HTTP-only cookie で管
 ### 3.0.1 Login
 
 ```http
-GET /api/v1/auth/login
+GET /api/v1/auth/login?redirect_to=/path/to/page
 ```
 
 GitHub OAuth 認証画面へリダイレクトする。
 server 側で CSRF 防御用の `state` (UUID v4) を生成し、`boardflow_oauth_state` cookie に保存する。
+
+Query Parameters:
+- `redirect_to` (optional): ログイン後のリダイレクト先（相対パスのみ）。指定時は `boardflow_redirect_to` cookie に保存される（HttpOnly, SameSite=Lax, Max-Age=300）。
 
 Response: `302 Found` → GitHub OAuth authorize URL
 
@@ -372,11 +375,20 @@ GET /api/v1/auth/callback?code=...&state=...
 GitHub OAuth コールバック。`state` を cookie と照合し、不一致時は `403 forbidden` を返す。
 `code` を GitHub token endpoint で access token に交換し、user 情報を取得、DB upsert、session 作成を行う。
 
-Response: `302 Found` → `/` (固定、open redirect 防止)
+リダイレクト先は `boardflow_redirect_to` cookie から取得し、`validate_redirect_path()` でバリデーションする。バリデーション失敗時またはcookie未設定時は `/` にフォールバック。
+
+Open Redirect 防止バリデーション:
+- `/` で始まる相対パスのみ許可
+- `//`, `://`, `\`, null byte, CR/LF, `;`, `,`, `"`, 空白を拒否
+- URLデコード後の再チェック
+- 2048文字上限
+
+Response: `302 Found` → バリデーション済みリダイレクト先（デフォルト `/`）
 
 Cookie 設定:
 - `boardflow_session`: session ID (HTTP-only, SameSite=Lax)
 - `boardflow_oauth_state`: 削除
+- `boardflow_redirect_to`: 削除
 
 ### 3.0.3 Logout
 

--- a/docs/external/nextjs-middleware-cookie-redirect-loop.md
+++ b/docs/external/nextjs-middleware-cookie-redirect-loop.md
@@ -1,0 +1,232 @@
+# Next.js Middleware: Cookie削除・リダイレクトループ防止・ログイン後リダイレクト
+
+## 要約
+
+Next.js middleware で無効セッションCookie起因のリダイレクトループを解消するための手法と、ログイン後に元ページへリダイレクトするパターンを調査した。middleware 内では `NextResponse.redirect()` で生成したレスポンスに対して `.cookies.delete()` を呼ぶことで Cookie 削除とリダイレクトを同時に実行できる。middleware 内での API 呼び出しはパフォーマンス・Edge Runtime 制約の観点から推奨されず、Cookie の「存在チェック + layout での有効性検証 + 無効時の Cookie クリア」が現実的なアプローチ。
+
+## 確認した情報
+
+### 1. middleware 内での Cookie 削除 + リダイレクトの同時実行
+
+Next.js `NextResponse` API では、`redirect()` で生成した Response オブジェクトに対して `.cookies.delete(name)` を呼べる。これにより `Set-Cookie` ヘッダー付きのリダイレクトレスポンスが生成される。
+
+```typescript
+// Cookie削除 + リダイレクトの同時実行パターン
+const response = NextResponse.redirect(new URL('/login', request.url));
+response.cookies.delete('boardflow_session');
+return response;
+```
+
+**参照**: https://nextjs.org/docs/app/api-reference/functions/next-response
+
+**注意点**:
+- `response.cookies.delete()` は内部的に `Set-Cookie: boardflow_session=; Path=/; Max-Age=0` を設定する
+- Domain 属性が設定されている場合、削除時にも同じ Domain を指定する必要がある（BoardFlow はバックエンドが同一ドメインで `Path=/` のみ設定しているため該当しない）
+- middleware で削除した Cookie は、同一リクエスト内の Server Component からは **次のリクエストから** 反映される（vercel/next.js#49442）
+
+### 2. middleware 内での API 呼び出しによるセッション検証
+
+**推奨されない理由**:
+- middleware は Vercel Edge Runtime（またはデフォルト Edge 互換モード）で実行されるため、外部 API 呼び出しはレイテンシとコストが発生する
+- すべてのリクエストで API コールが発生するため、バックエンドへの負荷が大きい
+- 一般的なベストプラクティス: 「middleware では Cookie の存在チェック（optimistic）のみ。実際のセッション有効性検証は Server Component/layout で行う」
+- Better Auth 公式ドキュメントも「In Next.js middleware, it's recommended to only check for the existence of a session cookie to handle redirection」と明言
+
+**推奨パターン**:
+- middleware: Cookie 存在チェック（軽量・高速）
+- layout/Server Component: API 呼び出しでセッション有効性を検証
+- **無効セッション検出時**: Server Component 側で Cookie をクリアしてリダイレクト
+
+### 3. リダイレクトループの根本原因と対策
+
+BoardFlow のリダイレクトループのメカニズム:
+1. ユーザーが無効な `boardflow_session` Cookie を持っている
+2. middleware: Cookie 存在 → 通過（`/login` アクセス時は `/repositories` にリダイレクト）
+3. layout: `getCurrentUser()` → API 401 → `null` → `redirect('/login')`
+4. middleware: Cookie 存在 + `/login` → `/repositories` にリダイレクト
+5. 2-4 のループ
+
+**対策案（推奨）**: middleware の `/login` ガードで Cookie の「存在」だけでなく、`getCurrentUser()` が失敗した場合に Cookie を削除する仕組みを導入。具体的には:
+
+**案A: layout で Cookie 削除してからリダイレクト（推奨）**
+```typescript
+// (authenticated)/layout.tsx
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+export default async function AuthenticatedLayout({ children }) {
+  const user = await getCurrentUser();
+  if (!user) {
+    // 無効Cookieを削除してからリダイレクト
+    const cookieStore = await cookies();
+    cookieStore.delete('boardflow_session');
+    redirect('/login');
+  }
+  return <AppShell user={user}>{children}</AppShell>;
+}
+```
+
+→ Cookie 削除後のリダイレクトで middleware が Cookie なしの状態で `/login` を処理するのでループしない。
+
+**注意**: `cookies().delete()` は Server Action か Route Handler でのみ使用可能。Server Component（layout.tsx）では `cookies()` は読み取り専用。
+
+**案B: middleware で `/login` の保護条件を変更（よりシンプル・推奨）**
+```typescript
+// middleware.ts
+// /login へのアクセスは常に通す（Cookie有無問わず）
+// Cookie有 + /login の場合にリダイレクトしない
+if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+  return NextResponse.next();
+}
+```
+
+→ `/login` ページ自体が認証済みユーザーの検知とリダイレクトを担当。middleware は `/login` を常にパブリックとして扱う。layout でセッション無効 → `/login` リダイレクト → middleware 通過 → ログインページ表示。
+
+**案C: middleware でレスポンス Cookie を削除してリダイレクト（ハイブリッド）**
+
+layout.tsx の Server Component では `cookies().delete()` が使えないため、以下の流れが現実的:
+
+1. layout.tsx: `getCurrentUser()` が null → クエリパラメータ付きでリダイレクト `redirect('/login?session_expired=1')`
+2. middleware: `/login?session_expired=1` を検出 → Cookie 削除 + `/login` リダイレクト
+3. 以降のリクエストは Cookie なし → ループしない
+
+ただしこれは複雑すぎるため、**案B が最もシンプルで推奨**。
+
+### 4. ログイン後の元ページリダイレクト（redirect_to パターン）
+
+**フロントエンド側（middleware + login ページ）**:
+
+```typescript
+// middleware.ts - 未認証時に元URLをクエリパラメータに付与
+if (!session) {
+  const loginUrl = new URL('/login', request.url);
+  loginUrl.searchParams.set('redirect_to', pathname + request.nextUrl.search);
+  return NextResponse.redirect(loginUrl);
+}
+```
+
+```tsx
+// login/page.tsx - redirect_toをログインリンクに伝播
+export default function LoginPage({ searchParams }) {
+  const redirectTo = searchParams.redirect_to || '/repositories';
+  const loginHref = `/api/v1/auth/login?redirect_to=${encodeURIComponent(redirectTo)}`;
+  return <Link href={loginHref}>Sign in with GitHub</Link>;
+}
+```
+
+**バックエンド側（auth.rs）**:
+
+```rust
+// login handler: redirect_to を OAuth state cookie に埋め込む
+// （または別の Cookie に保存）
+// callback handler: state cookie から redirect_to を取り出してリダイレクト先に使用
+```
+
+**伝搬フロー**:
+1. middleware → `/login?redirect_to=/repositories/123`
+2. login ページ → `/api/v1/auth/login?redirect_to=/repositories/123`
+3. backend login handler → `boardflow_redirect_to` Cookie に保存（HttpOnly, SameSite=Lax, Max-Age=300）
+4. GitHub OAuth → callback
+5. backend callback handler → Cookie から `redirect_to` を読み取り → バリデーション後にリダイレクト
+
+### 5. Open Redirect 防止（redirect_to バリデーション）
+
+**OWASP 推奨**: Open Redirect は OWASP Top 10 2025 の A01:2025 (Broken Access Control) に分類。
+
+**バリデーション手法**:
+
+```typescript
+// フロントエンド側（TypeScript）
+function isValidRedirectPath(path: string): boolean {
+  // 相対パスのみ許可、プロトコル・ドメインを含む URL を拒否
+  if (!path.startsWith('/')) return false;
+  if (path.startsWith('//')) return false;  // protocol-relative URL
+  if (path.includes('://')) return false;   // absolute URL
+  if (path.includes('\\')) return false;    // backslash bypass
+  // 不正な文字を含まないことを確認
+  try {
+    const url = new URL(path, 'http://dummy');
+    return url.pathname === path.split('?')[0]; // パスが変更されていないことを確認
+  } catch {
+    return false;
+  }
+  return true;
+}
+```
+
+```rust
+// バックエンド側（Rust）
+fn validate_redirect_to(path: &str) -> Option<&str> {
+    // 相対パスのみ許可
+    if !path.starts_with('/') { return None; }
+    if path.starts_with("//") { return None; }
+    if path.contains("://") { return None; }
+    if path.contains('\\') { return None; }
+    // URL デコード後の再チェック
+    let decoded = urlencoding::decode(path).ok()?;
+    if decoded.starts_with("//") || decoded.contains("://") { return None; }
+    Some(path)
+}
+```
+
+**重要なバイパス手法（防御すべきもの）**:
+- `//evil.com` — protocol-relative URL
+- `/\evil.com` — backslash bypass
+- `/%2Fevil.com` — URL エンコードによるバイパス
+- `https://evil.com` — 絶対 URL
+- `javascript:alert(1)` — JavaScript scheme
+- `/login@evil.com` — userinfo 部分を使ったバイパス
+
+### 6. middleware リダイレクトキャッシュ問題
+
+`x-middleware-cache: no-cache` ヘッダーを設定してブラウザキャッシュによるリダイレクトループを防ぐパターンが報告されている。Next.js 15 ではデフォルトでキャッシュされないが、念のため設定を推奨。
+
+```typescript
+const response = NextResponse.redirect(new URL('/login', request.url));
+response.headers.set('x-middleware-cache', 'no-cache');
+return response;
+```
+
+## BoardFlow への示唆
+
+### ループ修正（3箇所の修正）
+
+1. **middleware.ts**: `/login` アクセスを常にパブリックとして扱う（Cookie 有無に関わらず通過）。または: Cookie 有 + `/login` 時のリダイレクトを削除し、login ページ側で認証済みユーザーをリダイレクト
+2. **(authenticated)/layout.tsx**: `getCurrentUser()` が null の場合、Server Action 経由で Cookie を削除するか、クエリパラメータ付きでリダイレクト
+3. **login/page.tsx**: 認証済みユーザー（Cookieの有効性確認後）のリダイレクト処理を追加（オプション）
+
+### ログイン後リダイレクト
+
+1. **middleware.ts**: 未認証リダイレクト時に `redirect_to` クエリパラメータを付与
+2. **login/page.tsx**: `redirect_to` を `/api/v1/auth/login` に伝播
+3. **auth.rs login handler**: `redirect_to` を Cookie（`boardflow_redirect_to`）に保存
+4. **auth.rs callback handler**: Cookie から `redirect_to` を読み取り、バリデーション後にリダイレクト先として使用
+
+## 採用/不採用判断
+
+- **案B（middleware で /login を常にパブリック化）**: **採用** — 最もシンプルでリグレッションリスクが低い
+- **redirect_to パターン**: **採用** — middleware → login → backend login → backend callback の 4 段階で伝播
+- **redirect_to の Open Redirect 防止**: **必須** — バックエンド callback で相対パスバリデーション実装
+- **middleware 内 API 呼び出し**: **不採用** — パフォーマンス問題、Edge Runtime 制約
+
+## 制約と pitfall
+
+1. Server Component（layout.tsx）からは `cookies().delete()` が直接使えない（読み取り専用）。Server Action を経由するか、middleware で対処する必要がある
+2. `boardflow_redirect_to` Cookie は短い TTL（300 秒）を設定し、使用後に即削除すること
+3. middleware で削除した Cookie は同一リクエスト内の Server Component には即座に反映されない（次リクエストから）
+4. Next.js の 307 リダイレクトはブラウザにキャッシュされる場合がある — `x-middleware-cache: no-cache` を設定推奨
+5. OAuth state と redirect_to を分離すること（state はCSRF防御用、redirect_to はUX用）
+
+## 未解決の疑問
+
+1. Next.js 15 以降で `cookies().delete()` が Server Component から使えるようになるか（現時点では Server Action/Route Handler のみ）
+2. `boardflow_redirect_to` Cookie をバックエンドで管理するか、フロントエンドで sessionStorage 等で管理するかの選択（Cookie 方式が OAuth フローとの相性で推奨）
+
+## 参照URL
+
+- https://nextjs.org/docs/app/api-reference/functions/next-response
+- https://nextjs.org/docs/app/api-reference/functions/cookies
+- https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html
+- https://github.com/vercel/next.js/issues/49442
+- https://itnext.io/fixing-next-js-authentication-redirects-preserving-deep-links-after-login-1d3118765e31
+- https://richardkovacs.dev/blog/deleting-cookies-in-nextjs-middleware

--- a/docs/logs/75/worklog.md
+++ b/docs/logs/75/worklog.md
@@ -568,6 +568,32 @@ Step 1-3 はバックエンド内で依存関係あり（順序必須）。Step 
 
 ---
 
+## PR/完了結果（2026-05-04 pr エージェント）
+
+### PR作成
+
+- **PR URL**: https://github.com/f0reachARR/boardflow/pull/80
+- **ブランチ**: `fix/75-auth-redirect-loop` → `main`
+- **コミット**:
+  - `82c03ab` — fix(auth): redirect loop fix & post-login redirect to original page (#75)
+  - `2fab618` — docs: update worklog for #75 with implementation results
+  - `1f2ea33` — fix(auth): apply review fixes - authenticated user redirect, boundary check, integration tests, OpenAPI params
+
+### 最終確認
+
+- review: `pr_ready: true`（blocking指摘なし）
+- docs: `docs_ready: true`（実装・仕様書・生成契約の整合確認済み）
+- 未コミット変更なし（PR関連ファイル全てコミット済み）
+- テスト: Rust 11テスト全パス、Next.js build成功
+
+### 残リスク
+
+1. callback 分岐の HTTP レベル統合テスト未追加（非ブロッキング）
+2. 複数タブの `redirect_to` Cookie競合（実用上許容）
+3. `x-middleware-cache: no-cache` は community workaround（公式 guarantee なし）
+
+---
+
 ## ドキュメント確認結果（2026-05-04 docs エージェント）
 
 ### 対象Issue

--- a/docs/logs/75/worklog.md
+++ b/docs/logs/75/worklog.md
@@ -79,6 +79,54 @@
 
 ---
 
+## レビュー結果（2026-05-04 review エージェント）
+
+### 総評
+- ループの主因だった `/login` への middleware リダイレクトは解消できており、`redirect_to` の伝搬方針自体も middleware → login page → backend login → callback で一貫している。
+- 一方で、認証済みユーザーの `/login` 直接アクセスが未処理になっており、計画・research で前提にしていた「login ページ側での認証済みリダイレクト」が欠けている。
+- 加えて、`redirect_to` を未エスケープのまま `Set-Cookie` に埋め込んでおり、Cookie 値として不正な文字を含む入力でヘッダ破損や builder `unwrap()` panic を起こし得る。現状は PR 作成前に修正が必要。
+
+### PR可否
+- `pr_ready: false`
+
+### 指摘事項
+
+#### major
+- [boardflow/src/app/login/page.tsx](boardflow/src/app/login/page.tsx#L4) で認証済みユーザーのリダイレクトが未実装。`middleware.ts` から `/login && session` リダイレクトを外した一方、login page 側には `getCurrentUser()` による復帰導線がないため、正常なセッションを持つユーザーが [boardflow/src/middleware.ts](boardflow/src/middleware.ts#L19) を通ってそのままログイン画面を見られる。Issue のレビュー観点にある「Cookie有効+/login直接アクセス」を満たせておらず、research 文書でも `/login` ページ側が認証済みユーザーを処理する前提になっている。
+
+修正案:
+- login page で `getCurrentUser()` を呼び、認証済みなら `/repositories` もしくは検証済み `redirect_to` に `redirect()` する。
+- 少なくとも既存の「ログイン済みユーザーが `/login` を見ない」挙動は維持する。
+
+#### major
+- [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L59) から [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L64) で、`redirect_to` を生文字列のまま `Set-Cookie` に埋め込んでいる。`validate_redirect_path()` は open redirect の観点では有効だが、Cookie 値として禁止される `;`, `,`, space, DQUOTE, 制御文字 CR/LF などを拒否していないため、`/api/v1/auth/login?redirect_to=/%0d%0a...` や `/%3B Secure` のような入力でヘッダ生成失敗や意図しない cookie 属性混入を招く。`Response::builder().header(...).body(...).unwrap()` のため、無効ヘッダ値は panic に直結する。
+
+修正案:
+- `redirect_to` を Cookie に保存する前に percent-encode するか、専用の Cookie builder を使って安全に serialize する。
+- 併せて `validate_redirect_path()` で cookie-value 不許可文字と制御文字を拒否し、`login` handler の単体/統合テストに `;`, CR/LF, 空白, DQUOTE を追加する。
+
+### 任意改善
+- [boardflow/src/middleware.ts](boardflow/src/middleware.ts#L19) の `pathname.startsWith('/login')` は `/login-foo` も public 扱いする。現状ルート構成では直ちに問題化しないが、将来の保護ルート追加時に踏み抜きやすいので `pathname === '/login' || pathname.startsWith('/login/')` のように境界を切った方が安全。
+- [boardflow/src/app/login/page.tsx](boardflow/src/app/login/page.tsx#L7) の `searchParams` 型は実行時に配列値も来得るため、`string | string[] | undefined` を扱う形の方が Next.js 15 の実態に近い。
+
+### テスト不足
+- backend 側は [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L330) の pure function テストしか増えておらず、`login`/`callback` の Cookie 往復、複数 `Set-Cookie`、不正 `redirect_to` 入力時の挙動を検証する HTTP レベルのテストがない。
+- frontend 側は middleware と login page の回帰を担保するテストが見当たらない。少なくとも「無効 session で protected route → `/login?redirect_to=...`」「有効 session で `/login` → `/repositories`」の導線は E2E か integration で欲しい。
+
+### ドキュメント確認
+- research 成果物の [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L95) は今回の方針と整合している。
+- ただし API 仕様書の [docs/backend/api.md](docs/backend/api.md#L355) から [docs/backend/api.md](docs/backend/api.md#L380) は旧挙動のままで、`GET /api/v1/auth/login` の `redirect_to` クエリ、`boardflow_redirect_to` Cookie、callback の可変リダイレクト先が未反映。
+
+### plan / research / docs との不整合
+- research では `/login` ページが認証済みユーザーのリダイレクトを担当すると整理されているが、実装は未対応。
+- docs/backend/api.md は callback の戻り先を `/` 固定と記載しており、実装後の契約と不一致。
+
+### 残リスク
+- Cookie 値の直列化不備を残したままでは、不正クエリによる login handler の異常系が未管理のまま残る。
+- `/login` の認証済みリダイレクト未実装のままだと、今後 login 画面に説明や副作用を足した際に意図しない再認証導線を開き続ける。
+
+---
+
 ## 実装計画（2026-05-04 plan エージェント）
 
 ### 目的
@@ -433,3 +481,212 @@ Step 1-3 はバックエンド内で依存関係あり（順序必須）。Step 
 2. **ブラウザの 307 キャッシュ**: `x-middleware-cache: no-cache` で対処済み。古いキャッシュはユーザーのキャッシュクリアで解決
 3. **複数タブの redirect_to 競合**: Cookie ベースのため最後の値が勝つ。実用上問題なし
 4. **`config_test.rs` の既存失敗**: 本Issueとは無関係。環境変数未設定時のテスト
+
+---
+
+## レビュー結果（2026-05-04 review エージェント 再レビュー）
+
+### 総評
+- 前回の major 指摘 2 件はコード上いずれも解消されている。`/login` は middleware で常時通過になり、[boardflow/src/app/login/page.tsx](boardflow/src/app/login/page.tsx#L1) で認証済みユーザーを `/repositories` へ戻すため、無効 session のループ回避と有効 session の `/login` 滞留回避は両立できている。
+- [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L295) の `validate_redirect_path()` には cookie unsafe 文字拒否が追加され、少なくとも今回前回指摘していた `Set-Cookie` 破損要因は抑えられている。
+- ただし、auth フローの契約変更に対する API ドキュメント更新と HTTP レベルの回帰テストが未整備で、この Issue の完了条件としてはまだ弱い。
+
+### PR可否
+- `pr_ready: false`
+
+### 指摘事項
+
+#### medium
+- [docs/backend/api.md](docs/backend/api.md#L350) から [docs/backend/api.md](docs/backend/api.md#L380) が実装と一致していない。現行実装では `GET /api/v1/auth/login` が `redirect_to` を受け付け、[crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L20) から [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L58) で `boardflow_redirect_to` cookie を保存し、callback も [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L161) から [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L182) で `/` 固定ではなく検証済みの相対パスへ戻す。仕様書が旧契約のままだと、後続実装と運用判断を誤らせる。
+
+#### medium
+- auth 変更の検証が pure function テストに偏っている。[crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L321) 以降のユニットテストは `validate_redirect_path()` のみで、[crates/api/tests/auth_test.rs](crates/api/tests/auth_test.rs#L1) には `login` と `callback` の cookie 受け渡し、複数 `Set-Cookie`、不正 `redirect_to` 入力時のフォールバックを確認するテストがない。今回の修正は認証導線そのものに触れているため、HTTP レベルで 1 本でも回帰テストが欲しい。
+
+### 必須修正
+- `docs/backend/api.md` を実装後の認証フローに合わせて更新する。
+- `crates/api/tests/auth_test.rs` などで `redirect_to` を含む login/callback フローの統合テストを追加する。
+
+### 任意改善
+- [boardflow/src/app/login/page.tsx](boardflow/src/app/login/page.tsx#L6) の認証済みユーザーリダイレクトは常に `/repositories` 固定だが、`redirect_to` が安全な相対パスならそれを優先しても UX は自然になる。
+
+### テスト結果
+- `mise exec -- cargo test -p boardflow-api routes::auth -- --nocapture` : 10 テスト成功
+- `pnpm --dir /home/f0reach/workspace/boardflow/boardflow build` : 成功
+
+### ドキュメント確認
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L1) との整合は取れている。
+- [docs/backend/api.md](docs/backend/api.md#L350) から [docs/backend/api.md](docs/backend/api.md#L380) は未更新。
+
+### plan / research / docs との不整合
+- research / plan は `redirect_to` の伝搬と callback 側の可変リダイレクトを前提にしているが、API 仕様書だけが `/` 固定のまま残っている。
+
+### 残リスク
+- 文書化されないまま merge すると、今後の auth 実装修正時に旧仕様を前提に戻されるリスクがある。
+- HTTP レベルの回帰テストがないため、cookie の直列化や複数 `Set-Cookie` の将来リグレッションを検知しづらい。
+
+---
+
+## レビュー結果（2026-05-04 review エージェント 最終再レビュー）
+
+### 総評
+- Issue #75 の目的である「無効セッション時の `/login` ループ解消」と「ログイン後の元ページ復帰」は、[boardflow/src/middleware.ts](boardflow/src/middleware.ts#L1)・[boardflow/src/app/login/page.tsx](boardflow/src/app/login/page.tsx#L1)・[crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L1) の実装で一貫して満たせている。
+- 前回レビューで必須だった API 仕様書更新と login handler の HTTP レベル統合テスト追加も反映済みで、実装・research・plan・ドキュメントの不整合は解消された。
+- 今回確認できた範囲では、PR 作成を止める欠陥は見当たらない。
+
+### PR可否
+- `pr_ready: true`
+
+### 指摘事項
+- blocking / major / medium の指摘事項なし。
+
+### 必須修正
+- なし。
+
+### 任意改善
+- [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L82) 以降の callback 分岐は今回変更範囲だが、現状は専用の HTTP レベル回帰テストがない。将来の回帰検知を強めるなら、`boardflow_redirect_to` cookie を与えた callback のフォールバックと cookie 削除を確認するテストを追加するとよい。
+
+### テスト不足
+- 非ブロッキングではあるが、auth 統合テストは login handler 側に寄っており、callback 側の `redirect_to` 利用と cookie clear の end-to-end 検証は未追加。
+
+### テスト結果
+- `mise exec -- cargo test -p boardflow-api --test auth_test` : 11 テスト成功
+- `pnpm --dir /home/f0reach/workspace/boardflow/boardflow build` : 成功
+
+### ドキュメント確認
+- [docs/backend/api.md](docs/backend/api.md#L355) から [docs/backend/api.md](docs/backend/api.md#L394) に `redirect_to` query、`boardflow_redirect_to` cookie、callback の可変リダイレクトと cookie 削除が反映されている。
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L1) の調査内容と現在の実装方針は整合している。
+
+### plan / research / docs との不整合
+- 確認した範囲では不整合なし。
+
+### PR/完了結果
+- review 判定: `pr_ready: true`
+- review フェーズ完了。Issue #75 は PR 作成へ進めてよい。
+
+### 残リスク
+- callback 分岐に専用の統合テストがないため、将来の認証フロー変更時に cookie 削除やリダイレクト先フォールバックの回帰を見逃す可能性がある。
+
+---
+
+## ドキュメント確認結果（2026-05-04 docs エージェント）
+
+### 対象Issue
+- Issue #75: フロントエンド認証リダイレクトループ修正 & ログイン後の元ページリダイレクト
+
+### 総評
+- [docs/backend/api.md](docs/backend/api.md#L355) から [docs/backend/api.md](docs/backend/api.md#L394) の Auth API 記述は、今回の実装である [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L24) から [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L211) と整合している。
+- [docs/spec.md](docs/spec.md#L1619) と [docs/frontend/summary.md](docs/frontend/summary.md#L77) の認証記述は高レベル方針に留まっており、今回の `redirect_to` 追加や `/login` ループ回避の詳細を反映する必然性はない。
+- 一方で、生成済み契約ファイル [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts#L6) と [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts#L22) では `/api/v1/auth/callback` と `/api/v1/auth/login` の query parameter が `never` のままで、実装および API 仕様書と不一致になっている。PR を出す前に OpenAPI 側の注釈または生成物更新が必要。
+
+### docs_ready
+- `docs_ready: false`
+
+### 必須修正
+- OpenAPI 契約を更新し、[boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts#L6) と [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts#L22) に auth query parameter が反映される状態にする。
+  - 現状は `GET /api/v1/auth/login` の `redirect_to` と `GET /api/v1/auth/callback` の `code`, `state` が生成型に現れていない。
+  - ドキュメント本文は更新済みでも、参照される API 契約面が旧仕様のままだと後続実装とレビューで齟齬が残る。
+
+### 任意改善
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L147) の `x-middleware-cache: no-cache` については、現行の Next.js 公式 API ドキュメントでは明示的な保証を確認できなかった。コミュニティ workaround としては妥当だが、「推奨」や「防げる」と断定するより「報告例がある workaround」と明記した方が根拠の強さに見合う。
+
+### 不整合のあるドキュメント
+- なし。`docs/` 配下で今回確認対象にした文書のうち、実装と明確に矛盾するものは見当たらない。
+
+### 不足しているドキュメント
+- 追加の README / CONTRIBUTING 更新は不要。
+- ただし生成契約ファイル [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts) は更新漏れの可能性が高い。
+
+### 外部調査メモに関する指摘
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L11) の「`NextResponse.redirect()` で生成した response に対して `.cookies.delete()` を呼べる」は、現行の Next.js `NextResponse` 公式 docs と整合している。
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L69) の「Server Component では `cookies().delete()` が使えず、読み取り専用」は、現行の Next.js `cookies` 公式 docs と整合している。
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L147) の `x-middleware-cache` に関する記述は、公式 docs ではなく issue / community report ベースのため、根拠レベルを一段下げて表現するのが安全。
+
+### PR/完了結果
+- docs review 判定: `docs_ready: false`
+- blocking 理由: `docs/` 本文は整合しているが、生成済み API 契約が旧仕様のままで参照面に齟齬が残るため。
+
+### 残リスク
+- OpenAPI 生成物を未更新のまま merge すると、frontend 側の将来の API 利用やレビューが旧 auth 契約を前提に進む可能性がある。
+- `x-middleware-cache` の記述を強い断定のまま残すと、Next.js 側の挙動保証と誤認される可能性がある。
+
+---
+
+## ドキュメント確認結果（2026-05-04 docs エージェント 再確認）
+
+### 対象Issue
+- Issue #75: フロントエンド認証リダイレクトループ修正 & ログイン後の元ページリダイレクト
+
+### 総評
+- 前回 blocking としていた OpenAPI 注釈不足は、[crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L22) と [crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L68) で `IntoParams` と `params(...)` が追加されており、ソース側では解消されている。
+- [docs/backend/api.md](docs/backend/api.md#L355) の Auth API 記述と、[boardflow/src/middleware.ts](boardflow/src/middleware.ts#L1)、[boardflow/src/app/login/page.tsx](boardflow/src/app/login/page.tsx#L1)、[crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L24) 以降の実装は整合している。
+- ただし、現時点の生成済み契約ファイル [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts#L6) と [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts#L22) は依然として query parameter が `never` のままで、リポジトリ上の参照契約は旧仕様のまま残っている。現ブランチをそのまま PR 化する前提では docs review はまだ通せない。
+
+### docs_ready
+- `docs_ready: false`
+
+### 必須修正
+- [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts) を、追加済みの utoipa 注釈が反映された状態に再生成する。
+- もし CI または merge 後生成を前提にする運用なら、その前提を PR 本文に明記し、このブランチでは生成物差分が未反映であることをレビューアに共有する。
+
+### 任意改善
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L147) の `x-middleware-cache: no-cache` は公式 guarantee ではなく報告ベースの workaround と分かる表現に寄せると、根拠の強さと文章が揃う。
+
+### 不整合のあるドキュメント
+- [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts): 実装と API 仕様書では auth query parameter が存在するが、生成契約では未反映。
+
+### 不足しているドキュメント
+- README / CONTRIBUTING の追加更新は不要。
+- ただし、生成契約の更新が未反映なため、利用者が参照する API 面の最新化が不足している。
+
+### 外部調査メモに関する指摘
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L1) の採用判断自体は現在の実装方針と矛盾していない。
+- `x-middleware-cache` の説明だけは、公式 docs よりコミュニティ報告への依存が強い点を弱めに表現した方が安全。
+
+### PR/完了結果
+- docs review 判定: `docs_ready: false`
+- blocking 理由: ソース注釈は修正済みだが、現ブランチの生成契約が旧仕様のままで参照面に齟齬が残るため。
+
+### 残リスク
+- 生成物未更新のまま merge されると、frontend の型生成や後続レビューで auth query parameter が存在しない前提が残る。
+
+---
+
+## ドキュメント確認結果（2026-05-04 docs エージェント 最終確認）
+
+### 対象Issue
+- Issue #75: フロントエンド認証リダイレクトループ修正 & ログイン後の元ページリダイレクト
+
+### 総評
+- [docs/backend/api.md](docs/backend/api.md#L355) から [docs/backend/api.md](docs/backend/api.md#L394) の Auth API 記述は、[crates/api/src/routes/auth.rs](crates/api/src/routes/auth.rs#L22) 以降の実装と整合している。
+- 前回 blocking としていた [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts) の query parameter 未反映は、生成ファイル先頭の `paths[...].parameters.query` ではなく `operations.login.parameters.query` / `operations.callback.parameters.query` を参照すべき生成形式の読み違いだった。現行ファイルでは [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts#L768) から [boardflow/src/lib/api/schema.d.ts](boardflow/src/lib/api/schema.d.ts#L813) に `redirect_to` / `code` / `state` が反映されており、`openapi-fetch` の利用形とも整合する。
+- 今回確認対象の docs / docs/external / 生成契約の範囲では、PR 作成を止めるドキュメント不整合は見当たらない。
+
+### docs_ready
+- `docs_ready: true`
+
+### 必須修正
+- なし。
+
+### 任意改善
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L147) の `x-middleware-cache: no-cache` は、公式 guarantee というより報告ベースの workaround と分かる表現に寄せると根拠の強さと記述が揃う。
+
+### 不整合のあるドキュメント
+- なし。
+
+### 不足しているドキュメント
+- なし。README / CONTRIBUTING への今回追記も不要。
+
+### 外部調査メモに関する指摘
+- [docs/external/nextjs-middleware-cookie-redirect-loop.md](docs/external/nextjs-middleware-cookie-redirect-loop.md#L1) の採用判断は、今回の middleware / login page / backend auth の実装方針と矛盾していない。
+- `x-middleware-cache` に関する記述だけは、根拠レベルに合わせて表現を少し弱める余地があるが、Issue #75 の blocking ではない。
+
+### テスト結果
+- ユーザー共有の結果として Rust テストは全通、Next.js build は成功。
+- 端末履歴でも `pnpm build` 成功は確認できる。
+
+### PR/完了結果
+- docs review 判定: `docs_ready: true`
+- docs フェーズ完了。Issue #75 は PR 作成へ進めてよい。
+
+### 残リスク
+- callback 側の `redirect_to` cookie 利用については、将来の回帰検知をさらに強めるなら HTTP レベル統合テストがあるとより堅い。

--- a/docs/logs/75/worklog.md
+++ b/docs/logs/75/worklog.md
@@ -1,0 +1,435 @@
+# Issue #75: フロントエンド認証リダイレクトループ修正 & ログイン後の元ページリダイレクト
+
+## 経緯
+- ユーザー要望1: 認証情報が無効でAPIが403を返す場合にリダイレクトループが発生
+- ユーザー要望2: ログイン後に元のページにリダイレクトしたい
+- 両者は認証フローの同一箇所に関わるため1つのIssueに統合
+
+## ユーザー要望
+- 無効セッションによるリダイレクトループの解消
+- ログイン前のページURLを保持し、ログイン後にリダイレクト
+
+## 調査結果
+- `middleware.ts`: `boardflow_session` Cookieの存在のみでチェック、有効性は未検証
+- `auth.ts`: `getCurrentUser()` がAPIを呼び出し、失敗時は `null` を返すがCookieクリアなし
+- `routes/auth.rs`: callback後のリダイレクト先が `"/"` 固定
+- Next.js middleware の 307 リダイレクトはブラウザキャッシュされる可能性あり
+
+## Issue作成内容
+- タイトル: フロントエンド認証リダイレクトループ修正 & ログイン後の元ページリダイレクト
+- ラベル: bug, frontend
+- 新規作成
+
+## 後続処理タイプ
+`implementation_required`
+
+## 外部調査（2026-05-04 research エージェント）
+
+### 調査対象
+1. Next.js 15 middleware でのCookie削除 + リダイレクト同時実行
+2. middleware 内でのAPI呼び出しによるセッション検証の是非
+3. ログイン後リダイレクト（redirect_to パターン）
+4. Open Redirect 防止（OWASP ベストプラクティス）
+
+### 調査結果サマリ
+
+#### リダイレクトループの解消方針
+- **根本原因**: middleware が Cookie の「存在」のみで `/login` → `/repositories` にリダイレクトするため、無効 Cookie 保持ユーザーが layout の `getCurrentUser()` → null → `/login` → middleware → `/repositories` のループに陥る
+- **推奨修正（案B）**: middleware の `/login` ガードを削除し、`/login` を常にパブリックページとして扱う。login ページ側で認証済みユーザーのリダイレクト処理を行う。これにより layout → `/login` リダイレクトが常に成功する
+- **Cookie 削除**: `NextResponse.redirect()` + `.cookies.delete()` で同時実行可能。ただし Server Component(layout.tsx) からは `cookies().delete()` は使えない（読み取り専用）
+
+#### middleware での API 呼び出し
+- **不採用**: Edge Runtime 制約、全リクエストへの API コール負荷、Better Auth 公式の「middleware では Cookie 存在チェックのみ推奨」の方針
+- middleware は「楽観的チェック」、layout/Server Component で「悲観的チェック」の二層構造が推奨
+
+#### ログイン後リダイレクト
+- **伝搬フロー**: middleware(`redirect_to` クエリ付与) → login ページ（リンクに伝播）→ backend login handler（`boardflow_redirect_to` Cookie に保存, TTL=300s）→ GitHub OAuth → backend callback（Cookie から読み取り、バリデーション後にリダイレクト）
+- OAuth state とは分離して管理
+
+#### Open Redirect 防止
+- OWASP A01:2025 (Broken Access Control) に分類
+- **必須バリデーション**: 相対パスのみ許可、`//`, `://`, `\`, URL エンコードバイパスを拒否
+- バックエンド callback handler で最終バリデーション実装が必須
+
+### 更新ファイル
+- `docs/external/nextjs-middleware-cookie-redirect-loop.md` — 新規作成
+
+### 結論ステータス
+`implementation_required`
+
+### 推奨実装方針（3箇所の修正）
+
+#### フロントエンド（2ファイル）
+1. **`middleware.ts`**: (a) `/login` を常にパブリック化（Cookie 有無問わず通過）、(b) 未認証リダイレクト時に `redirect_to` クエリ付与
+2. **`login/page.tsx`**: `redirect_to` パラメータを `/api/v1/auth/login` リンクに伝播
+
+#### バックエンド（1ファイル）
+3. **`routes/auth.rs`**: (a) login handler で `redirect_to` を `boardflow_redirect_to` Cookie に保存（HttpOnly, SameSite=Lax, Max-Age=300）、(b) callback handler で Cookie から読み取り → `validate_redirect_to()` → リダイレクト先に使用、(c) デフォルトは `"/"` のまま
+
+### 後続エージェントへの注意点
+- Server Component（layout.tsx）からの `cookies().delete()` は不可。layout 自体の変更は不要（middleware でループを断ち切る）
+- `boardflow_redirect_to` Cookie は使用後に必ず削除すること（callback handler 内で `Max-Age=0`）
+- Open Redirect バリデーションは必ずバックエンド（Rust）側で実装すること（フロントエンドのみでは不十分）
+- `x-middleware-cache: no-cache` ヘッダーの設定を推奨
+
+## 残リスク
+- Open Redirecter 脆弱性対策（redirect_to のバリデーション必須）
+- Server Component からの Cookie 削除制約（Next.js の仕様変更に注視）
+- middleware リダイレクトのブラウザキャッシュ問題（`x-middleware-cache: no-cache` で対処）
+
+---
+
+## 実装計画（2026-05-04 plan エージェント）
+
+### 目的
+1. 無効セッションCookie保持時のリダイレクトループを解消する
+2. ログイン前にアクセスしていたページのURLを保持し、ログイン完了後にそのページへリダイレクトする
+
+### 非目的
+- セッションの有効期限管理の変更
+- ログインUI/UXの変更（レイアウト・デザイン）
+- 新規認証方式の追加
+- バックエンドのセッション管理ロジックの変更
+
+### 受け入れ条件
+- [ ] 無効なセッションCookieを持つユーザーが保護ページにアクセスした場合、ループせずログインページに到達する
+- [ ] 未認証ユーザーが `/repositories/123` にアクセス → ログイン → `/repositories/123` にリダイレクトされる
+- [ ] `redirect_to` に外部URLや不正なパスを指定した場合、デフォルト(`/`)にリダイレクトされる（Open Redirect防止）
+- [ ] 既存の正常な認証フロー（Cookie有効時）が壊れていない
+- [ ] `redirect_to` なしでログインした場合は `/` にリダイレクトされる（既存挙動維持）
+
+### 詳細要件
+
+#### 要件1: リダイレクトループ解消
+- middleware で `/login` へのアクセスはCookie有無に関わらず常に通過させる
+- middleware の `/login && session` → `/repositories` リダイレクトを削除する
+- layout.tsx の `getCurrentUser()` が null を返した場合、middleware を経由して `/login` に到達できるようにする
+
+#### 要件2: ログイン後リダイレクト
+- middleware: 未認証リダイレクト時に `redirect_to={pathname+search}` クエリパラメータを付与
+- login/page.tsx: `searchParams.redirect_to` を `/api/v1/auth/login` リンクに伝播
+- backend login handler: `redirect_to` クエリパラメータを `boardflow_redirect_to` Cookieに保存（HttpOnly, SameSite=Lax, Max-Age=300）
+- backend callback handler: `boardflow_redirect_to` Cookieを読み取り → バリデーション → リダイレクト先に使用 → Cookie削除
+
+#### 要件3: Open Redirect防止
+- バリデーションはバックエンド（Rust）のcallback handlerで実装
+- 許可条件: `/` で始まる相対パスのみ
+- 拒否条件: `//`, `://`, `\`, URLデコード後の再チェック
+- バリデーション失敗時: デフォルトの `/` にリダイレクト
+
+### 影響範囲
+- **フロントエンド**: `middleware.ts`, `login/page.tsx`
+- **バックエンド**: `crates/api/src/routes/auth.rs`
+- **変更なし**: `(authenticated)/layout.tsx`, `lib/auth.ts`
+
+### 設計方針
+
+#### アーキテクチャ: 2層認証チェック維持
+- middleware: 楽観的チェック（Cookie存在のみ）→ 高速
+- layout/Server Component: 悲観的チェック（API呼び出し）→ 正確
+- ループ防止: `/login` を常にパブリックとして扱う
+
+#### redirect_to 伝搬フロー
+```
+[Browser] → /protected/page
+  ↓ middleware (no session)
+[Browser] ← 307 /login?redirect_to=/protected/page
+  ↓
+[Browser] → /login?redirect_to=/protected/page
+  ↓ middleware (PUBLIC_PATHS → next)
+[Login Page] ← render with redirect_to in login link
+  ↓ user clicks "Sign in with GitHub"
+[Browser] → /api/v1/auth/login?redirect_to=/protected/page
+  ↓ backend login handler
+  ↓ Set-Cookie: boardflow_redirect_to=/protected/page; Max-Age=300
+[Browser] ← 302 → GitHub OAuth
+  ↓ user authorizes
+[Browser] → /api/v1/auth/callback?code=xxx&state=yyy
+  ↓ backend callback handler
+  ↓ read boardflow_redirect_to cookie → validate → use as redirect
+  ↓ Set-Cookie: boardflow_session=xxx
+  ↓ Set-Cookie: boardflow_redirect_to=; Max-Age=0 (clear)
+[Browser] ← 302 → /protected/page
+```
+
+---
+
+### 変更ファイル一覧
+
+#### 1. `boardflow/src/middleware.ts` — フロントエンド middleware
+**変更内容**:
+- `/login && session` のリダイレクト削除（ループ原因）
+- PUBLIC_PATHS チェックを先頭近くに移動
+- 未認証リダイレクト時に `redirect_to` クエリパラメータ付与
+
+**Before (概念)**:
+```typescript
+// Authenticated user accessing login → redirect to repositories
+if (pathname === '/login' && session) {
+  return NextResponse.redirect(new URL('/repositories', request.url));
+}
+// Public paths don't require auth
+if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+  return NextResponse.next();
+}
+// Unauthenticated → redirect to login
+if (!session) {
+  return NextResponse.redirect(new URL('/login', request.url));
+}
+```
+
+**After (概念)**:
+```typescript
+// Public paths always accessible (login page handles authenticated user redirect)
+if (PUBLIC_PATHS.some((p) => pathname.startsWith(p))) {
+  return NextResponse.next();
+}
+// Unauthenticated → redirect to login with redirect_to
+if (!session) {
+  const loginUrl = new URL('/login', request.url);
+  if (pathname !== '/') {
+    loginUrl.searchParams.set('redirect_to', pathname + request.nextUrl.search);
+  }
+  const response = NextResponse.redirect(loginUrl);
+  response.headers.set('x-middleware-cache', 'no-cache');
+  return response;
+}
+```
+
+#### 2. `boardflow/src/app/login/page.tsx` — ログインページ
+**変更内容**:
+- `searchParams` から `redirect_to` を取得
+- ログインリンクに `redirect_to` クエリパラメータを伝播
+
+**Before (概念)**:
+```tsx
+export default function LoginPage() {
+  return <Link href='/api/v1/auth/login'>Sign in</Link>;
+}
+```
+
+**After (概念)**:
+```tsx
+export default async function LoginPage({ searchParams }: { searchParams: Promise<{ redirect_to?: string }> }) {
+  const params = await searchParams;
+  const redirectTo = params.redirect_to;
+  const loginHref = redirectTo
+    ? `/api/v1/auth/login?redirect_to=${encodeURIComponent(redirectTo)}`
+    : '/api/v1/auth/login';
+  return <Link href={loginHref}>Sign in</Link>;
+}
+```
+
+#### 3. `crates/api/src/routes/auth.rs` — バックエンド認証ルート
+**変更内容 (login handler)**:
+- `LoginQuery.redirect_uri` を `redirect_to` にリネーム
+- `redirect_to` が有効な場合、`boardflow_redirect_to` Cookieに保存
+
+**変更内容 (callback handler)**:
+- `boardflow_redirect_to` Cookieを読み取り
+- `validate_redirect_path()` でバリデーション
+- バリデーション通過時: そのパスにリダイレクト
+- バリデーション失敗/未設定時: `/` にリダイレクト
+- `boardflow_redirect_to` Cookieをクリア
+
+**変更内容 (新規ヘルパー)**:
+- `validate_redirect_path(path: &str) -> Option<&str>` を追加
+
+---
+
+### Open Redirect バリデーション — 具体的ロジック
+
+```rust
+/// redirect_to パスのバリデーション。安全な相対パスのみ許可。
+fn validate_redirect_path(path: &str) -> Option<&str> {
+    // 空文字は無効
+    if path.is_empty() {
+        return None;
+    }
+    // `/` で始まる必要がある
+    if !path.starts_with('/') {
+        return None;
+    }
+    // protocol-relative URL を拒否
+    if path.starts_with("//") {
+        return None;
+    }
+    // absolute URL scheme を拒否
+    if path.contains("://") {
+        return None;
+    }
+    // backslash bypass を拒否
+    if path.contains('\\') {
+        return None;
+    }
+    // null byte を拒否
+    if path.contains('\0') {
+        return None;
+    }
+    // URL デコード後の再チェック（%2F%2F → // など）
+    if let Ok(decoded) = urlencoding::decode(path) {
+        if decoded.starts_with("//") || decoded.contains("://") || decoded.contains('\\') {
+            return None;
+        }
+    }
+    // 長すぎるパスを拒否（DoS防止）
+    if path.len() > 2048 {
+        return None;
+    }
+    Some(path)
+}
+```
+
+---
+
+### テスト計画
+
+#### バックエンド（Rust）— 新規テスト
+
+**1. `validate_redirect_path` ユニットテスト** (`crates/api/src/routes/auth.rs` 内 `#[cfg(test)]` モジュール)
+
+| ケース | 入力 | 期待結果 |
+|--------|------|----------|
+| 正常な相対パス | `/repositories` | `Some("/repositories")` |
+| クエリ付きパス | `/repositories/123?tab=files` | `Some(...)` |
+| ルート | `/` | `Some("/")` |
+| 空文字 | `""` | `None` |
+| 相対パスでない | `repositories` | `None` |
+| protocol-relative | `//evil.com` | `None` |
+| absolute URL | `https://evil.com` | `None` |
+| backslash bypass | `/\evil.com` | `None` |
+| URL encoded bypass | `/%2F%2Fevil.com` | `None` |
+| URL encoded backslash | `/%5Cevil.com` | `None` |
+| contains scheme | `/foo://bar` | `None` |
+| null byte | `/foo\0bar` | `None` |
+| 長すぎるパス | `/` + "a" * 2048 | `None` |
+
+**2. login handler テスト**: `redirect_to` クエリパラメータ付きリクエスト → `boardflow_redirect_to` Cookieがレスポンスに含まれること
+
+**3. callback handler テスト**: `boardflow_redirect_to` Cookie付きリクエスト → バリデーション通過時にそのパスにリダイレクト、Cookie削除
+
+#### フロントエンド — 手動テスト観点
+
+| シナリオ | 手順 | 期待結果 |
+|----------|------|----------|
+| ループ解消 | 無効Cookie手動設定 → `/repositories` アクセス | ログインページ表示（ループなし） |
+| redirect_to 正常系 | 未認証で `/repositories/123` アクセス → ログイン | `/repositories/123` にリダイレクト |
+| redirect_to なし | 直接 `/login` アクセス → ログイン | `/` にリダイレクト |
+| Cookie有効+/login | 有効セッションで `/login` アクセス | ログインページ表示（login ページ側で処理） |
+| Open Redirect | `redirect_to=//evil.com` を手動設定 → ログイン | `/` にリダイレクト |
+
+---
+
+### 実装順序（依存関係考慮）
+
+1. **Step 1**: `crates/api/src/routes/auth.rs` に `validate_redirect_path()` ヘルパー追加 + ユニットテスト
+2. **Step 2**: `crates/api/src/routes/auth.rs` の login handler を修正（`redirect_to` Cookie 保存）
+3. **Step 3**: `crates/api/src/routes/auth.rs` の callback handler を修正（Cookie 読み取り → バリデーション → リダイレクト）
+4. **Step 4**: `boardflow/src/middleware.ts` を修正（ループ解消 + `redirect_to` 付与）
+5. **Step 5**: `boardflow/src/app/login/page.tsx` を修正（`redirect_to` 伝播）
+6. **Step 6**: 統合テスト（手動）
+
+Step 1-3 はバックエンド内で依存関係あり（順序必須）。Step 4-5 はフロントエンド内で独立に実施可能だが、E2Eテストには Step 1-3 完了が必要。
+
+---
+
+### エッジケース一覧
+
+| # | エッジケース | 対応 |
+|---|-------------|------|
+| 1 | Cookie有効 + `/login` アクセス | login ページ表示。ページ内で`getCurrentUser()`成功なら`/repositories`リダイレクト（将来改善。今回のスコープではページ表示のみ）|
+| 2 | `redirect_to` に日本語パス含む | URLエンコードされるため問題なし |
+| 3 | `redirect_to` が `/login` 自身 | バリデーションは通過するが実害なし（再度ログインフロー） |
+| 4 | OAuth 中に `boardflow_redirect_to` Cookie の Max-Age(300s) が切れる | Cookie 消失 → callback がデフォルト `/` にリダイレクト → 許容動作 |
+| 5 | 複数タブで異なる redirect_to | 最後の Cookie 値が使われる。許容動作（完璧な解決にはstate連携が必要だが過剰） |
+| 6 | `redirect_to` の値が非常に長い | 2048文字制限で拒否 |
+| 7 | middleware matcher に含まれない `/api/` パスへのリダイレクト | matcher除外のため middleware 未処理。バックエンドが直接 401 返却 |
+| 8 | `redirect_to` に `#fragment` 含む | フラグメントはサーバーに送信されないためクライアント側で維持不可。許容動作 |
+
+---
+
+### ドキュメント更新対象
+
+| ファイル | 更新内容 |
+|----------|----------|
+| `docs/spec.md` | 認証フローのリダイレクトループ修正、redirect_to 仕様の追記（もし認証セクションがあれば） |
+| `docs/backend/api.md` | `/api/v1/auth/login` の `redirect_to` パラメータ追加、callback のリダイレクト挙動更新 |
+
+---
+
+### 実装要否
+
+`implementation_required`
+
+### 未解決の疑問
+
+なし。research エージェントの調査で技術的疑問は解消済み。設計判断（案B: `/login` を常にパブリック化）も研究結果で裏付けられている。
+
+### 残リスク
+
+1. **Cookie有効ユーザーの `/login` 表示**: middleware でガードしなくなるため、有効セッション保持ユーザーが `/login` を直接アクセスした場合にログインページが表示される。ただし既にログイン済みなので実害は軽微。将来的に login ページ内で認証チェック → `/repositories` リダイレクトを追加可能。
+2. **ブラウザの 307 キャッシュ**: `x-middleware-cache: no-cache` で対処するが、一部ブラウザで古いキャッシュが残る可能性がある。ユーザーがキャッシュクリアで解決可能。
+3. **複数タブの redirect_to 競合**: Cookie ベースのため最後の値が勝つ。実用上は問題にならない。
+
+### 作業ログパス
+
+`docs/logs/75/worklog.md`
+
+---
+
+## 実装結果（2026-05-04 impl エージェント）
+
+### 実装内容
+
+#### 1. `crates/api/src/routes/auth.rs`
+- `LoginQuery.redirect_uri` → `redirect_to` にリネーム
+- `login` handler: `redirect_to` クエリパラメータが有効な場合、`boardflow_redirect_to` Cookieに保存（HttpOnly, SameSite=Lax, Max-Age=300）
+- `callback` handler: `boardflow_redirect_to` Cookieを読み取り → `validate_redirect_path()` でバリデーション → リダイレクト先に使用 → Cookie削除（Max-Age=0）
+- `validate_redirect_path()` ヘルパー関数を追加（Open Redirect防止）
+- `#[cfg(test)]` ユニットテストモジュール追加（10テストケース）
+
+#### 2. `boardflow/src/middleware.ts`
+- `/login && session` → `/repositories` リダイレクト削除（ループ原因）
+- PUBLIC_PATHS チェックをセッションチェックの前に移動
+- 未認証リダイレクト時に `redirect_to={pathname+search}` クエリパラメータ付与
+- `x-middleware-cache: no-cache` ヘッダー設定
+
+#### 3. `boardflow/src/app/login/page.tsx`
+- `async function` に変更（Server Component の searchParams は Promise）
+- `searchParams.redirect_to` を取得
+- ログインリンクに `redirect_to` パラメータを `encodeURIComponent()` で伝播
+
+### テスト結果
+
+#### Rust ユニットテスト（`cargo test -p boardflow-api`）
+- **24テスト全パス**（auth関連10テスト + 既存14テスト）
+- `test_validate_redirect_path_valid` — 正常パス（/、/repositories、クエリ付き）
+- `test_validate_redirect_path_empty` — 空文字拒否
+- `test_validate_redirect_path_no_leading_slash` — 相対パス・外部URL拒否
+- `test_validate_redirect_path_protocol_relative` — `//evil.com` 拒否
+- `test_validate_redirect_path_contains_scheme` — `://` 含むパス拒否
+- `test_validate_redirect_path_backslash` — バックスラッシュ拒否
+- `test_validate_redirect_path_null_byte` — ヌルバイト拒否
+- `test_validate_redirect_path_encoded_bypass` — URLエンコードバイパス拒否
+- `test_validate_redirect_path_too_long` — 2048文字超拒否
+
+#### 既存統合テスト
+- `auth_test.rs`: 8テスト全パス（request_id関連、影響なし）
+- `api_token_test.rs`: 15テスト全パス
+- `board_run_test.rs`: 19テスト全パス
+- `config_test.rs`: 1テスト失敗（pre-existing、DATABASE_URL未設定時のテスト。本変更とは無関係）
+
+#### Next.js ビルド
+- `pnpm build` 成功（TypeScriptエラーなし、全ページ正常生成）
+
+### コミット
+- `abf6c5b` — `fix(auth): redirect loop fix & post-login redirect to original page (#75)`
+
+### 更新ドキュメント
+- `docs/logs/75/worklog.md`（本ファイル）
+
+### 残リスク
+1. **Cookie有効ユーザーの `/login` 表示**: middleware でガードしなくなるため表示される。実害は軽微（将来改善可能）
+2. **ブラウザの 307 キャッシュ**: `x-middleware-cache: no-cache` で対処済み。古いキャッシュはユーザーのキャッシュクリアで解決
+3. **複数タブの redirect_to 競合**: Cookie ベースのため最後の値が勝つ。実用上問題なし
+4. **`config_test.rs` の既存失敗**: 本Issueとは無関係。環境変数未設定時のテスト


### PR DESCRIPTION
## 要件

Closes #75

- 無効なセッションCookieを持つユーザーが保護ページにアクセスした場合、ループせずログインページに到達する
- 未認証ユーザーが `/repositories/123` にアクセス → ログイン → `/repositories/123` にリダイレクトされる
- `redirect_to` に外部URLや不正なパスを指定した場合、デフォルト(`/`)にリダイレクトされる（Open Redirect防止）
- 認証済みユーザーが `/login` を直接アクセスした場合、`/repositories` にリダイレクトされる

## 調査結果

- **根本原因**: middleware が `boardflow_session` Cookieの「存在」のみで `/login → /repositories` にリダイレクトするため、無効Cookie保持ユーザーが layout の `getCurrentUser()` → null → `/login` → middleware → `/repositories` のループに陥っていた
- **修正方針**: `/login` を常にパブリック化し、login ページ側で認証済みユーザーのリダイレクトを処理する（2層認証チェック維持）
- 外部調査: `docs/external/nextjs-middleware-cookie-redirect-loop.md`

## 実装概要

### redirect_to 伝搬フロー

```
[Browser] → /protected/page
  ↓ middleware (no session) → 307 /login?redirect_to=/protected/page
[Login Page] ← render with redirect_to in login link
  ↓ user clicks "Sign in with GitHub"
[Browser] → /api/v1/auth/login?redirect_to=/protected/page
  ↓ backend: Set-Cookie: boardflow_redirect_to=/protected/page; Max-Age=300
[Browser] ← 302 → GitHub OAuth → callback
  ↓ backend: read boardflow_redirect_to cookie → validate → redirect
  ↓ Set-Cookie: boardflow_session=xxx; boardflow_redirect_to=; Max-Age=0
[Browser] ← 302 → /protected/page
```

### 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `boardflow/src/middleware.ts` | `/login` 常時パブリック化（ループ解消）、未認証リダイレクト時に `redirect_to` 付与、境界チェック改善 |
| `boardflow/src/app/login/page.tsx` | `getCurrentUser()` による認証済みリダイレクト追加、`redirect_to` のログインリンクへの伝播 |
| `crates/api/src/routes/auth.rs` | `validate_redirect_path()` ヘルパー追加（Open Redirect + Cookie injection防止）、login handler で `boardflow_redirect_to` Cookie保存、callback handler でCookie読み取り→バリデーション→リダイレクト→Cookie削除、`IntoParams` derive追加 |
| `crates/api/tests/auth_test.rs` | login handler の統合テスト3件追加（redirect_to付き・なし・無効値） |
| `docs/backend/api.md` | Auth API仕様書をredirect_to機能に対応して更新 |
| `boardflow/src/lib/api/schema.d.ts` | OpenAPI スキーマ再生成（login/callbackのクエリパラメータ反映） |
| `docs/external/nextjs-middleware-cookie-redirect-loop.md` | 調査ドキュメント新規作成 |

## テスト結果

- **Rust ユニットテスト** (`routes::auth::tests`): 10テスト全パス
  - `validate_redirect_path` の正常系・異常系（protocol-relative, scheme, backslash, null byte, URL encoded bypass, 長すぎるパス）
- **Rust 統合テスト** (`auth_test.rs`): 11テスト全パス（新規3件含む）
  - `test_login_with_redirect_to`: `redirect_to` 付きloginで `boardflow_redirect_to` Cookieが設定される
  - `test_login_without_redirect_to`: `redirect_to` なしでCookieが設定されない
  - `test_login_with_invalid_redirect_to`: 無効な `redirect_to` でCookieが設定されない
- **Next.js ビルド**: `pnpm build` 成功

## セキュリティ考慮事項

### Open Redirect防止 (OWASP A01:2025)

`validate_redirect_path()` で以下をすべて拒否:
- `//` から始まるprotocol-relative URL
- `://` を含むabsolute URL scheme
- バックスラッシュ (`\`)
- ヌルバイト (`\0`)
- URLデコード後の再チェック（`%2F%2F` → `//` などのバイパス防止）
- 2048文字超のパス（DoS防止）

### Cookie Injection防止

`boardflow_redirect_to` Cookie保存時:
- `validate_redirect_path()` でCookie value不正文字（`;`, `,`, space, CR/LF, DQUOTE等）を含むパスを事前拒否
- Max-Age=300（5分）でTTLを限定
- callback後にMax-Age=0でCookieをクリア

## 更新ドキュメント

- `docs/backend/api.md` — Auth API仕様書更新（`redirect_to` クエリ、`boardflow_redirect_to` Cookie、callback可変リダイレクト）
- `docs/external/nextjs-middleware-cookie-redirect-loop.md` — 調査メモ新規作成

## 外部調査メモ

- Next.js middleware の `NextResponse.redirect()` + `.cookies.delete()` 同時実行可能
- middleware での API呼び出しは Edge Runtime 制約・負荷から不採用（楽観的チェックのみ）
- Server Component（layout.tsx）からの `cookies().delete()` は不可（読み取り専用）
- `x-middleware-cache: no-cache` はブラウザキャッシュ問題への workaround（community報告ベース）

## 残リスク

- callback 分岐の HTTP レベル統合テスト（`boardflow_redirect_to` cookie利用と cookie clear の検証）は未追加（非ブロッキング）
- 複数タブで異なる `redirect_to` がある場合、最後のCookie値が使われる（実用上許容）

## review/docs 判定

- review: `pr_ready: true`（blocking指摘なし）
- docs: `docs_ready: true`（実装・仕様書・生成契約の整合確認済み）
