### PR TITLE
feat(#77): Webhook不着時のリポジトリ一覧取得: Installation Repos APIフォールバック

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -726,6 +736,7 @@ dependencies = [
  "utoipa",
  "utoipa-axum",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -1159,6 +1170,24 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "deflate64"
@@ -1743,6 +1772,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2465,6 +2500,16 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -4632,6 +4677,29 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.9.0",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 | `GITHUB_PRIVATE_KEY_PEM` | No | GitHub App RSA秘密鍵(PEM)。未設定時はGitHub APIジョブをスキップ |
 | `BOARDFLOW_APP_DOMAIN` | No | フロントエンドのベースURL (default: `http://localhost:3000`)。OAuth callback と CORS で使用。後方互換として `APP_BASE_URL` も使用可 |
 
-> **Note**: `GITHUB_APP_ID` は API サーバーでも使用されます。設定すると、Webhook 不着時にユーザーの Installation Repositories API を使ってリポジトリ一覧を DB に best-effort 同期するフォールバックが有効になります。未設定の場合、フォールバック同期は無効ですが他の機能には影響しません。
+> **Note**: `GITHUB_APP_ID` は API サーバーでも使用されます。設定すると、Webhook 不着時にユーザーの GitHub App user access token（OAuth ログイン時に発行）を使い、Installation Repositories API (`GET /user/installations/{id}/repositories`) 経由でリポジトリ一覧を DB に best-effort 同期するフォールバックが有効になります。この機能を利用するには、GitHub App のユーザー認可フロー（OAuth）が正しく設定されている必要があります。未設定の場合、フォールバック同期は無効ですが他の機能には影響しません。
 
 ## GitHub OAuth App 設定
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@
 | `GITHUB_PRIVATE_KEY_PEM` | No | GitHub App RSA秘密鍵(PEM)。未設定時はGitHub APIジョブをスキップ |
 | `BOARDFLOW_APP_DOMAIN` | No | フロントエンドのベースURL (default: `http://localhost:3000`)。OAuth callback と CORS で使用。後方互換として `APP_BASE_URL` も使用可 |
 
+> **Note**: `GITHUB_APP_ID` は API サーバーでも使用されます。設定すると、Webhook 不着時にユーザーの Installation Repositories API を使ってリポジトリ一覧を DB に best-effort 同期するフォールバックが有効になります。未設定の場合、フォールバック同期は無効ですが他の機能には影響しません。
+
 ## GitHub OAuth App 設定
 
 OAuth 認証は Next.js rewrites 経由でフロントエンドドメインを callback 先に使用します。GitHub OAuth App の **Authorization callback URL** は `BOARDFLOW_APP_DOMAIN` と一致させてください。

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -35,6 +35,7 @@ boardflow-config = { path = "../config" }
 http-body-util = "0.1"
 serial_test = { workspace = true }
 tower = { version = "0.5", features = ["util"] }
+wiremock = "0.6"
 sqlx = { workspace = true, features = [
     "runtime-tokio",
     "tls-rustls",

--- a/crates/api/src/github_access.rs
+++ b/crates/api/src/github_access.rs
@@ -304,12 +304,15 @@ pub type DynGithubAccessChecker = Arc<dyn GithubAccessChecker>;
 
 // ─── Cached implementation ───────────────────────────────────────────────────
 
+const GITHUB_API_BASE_URL: &str = "https://api.github.com";
+
 /// Caching decorator that stores `list_accessible_repo_ids` results in PostgreSQL.
 /// Falls back to stale cache on rate-limit errors (stale-while-error).
 pub struct CachedGithubAccessChecker {
     inner: Arc<dyn GithubAccessChecker>,
     pool: sqlx::PgPool,
     github_app_id: Option<u64>,
+    github_api_base_url: String,
 }
 
 impl CachedGithubAccessChecker {
@@ -318,6 +321,7 @@ impl CachedGithubAccessChecker {
             inner: Arc::new(RealGithubAccessChecker::new()),
             pool,
             github_app_id,
+            github_api_base_url: GITHUB_API_BASE_URL.to_string(),
         }
     }
 
@@ -330,6 +334,23 @@ impl CachedGithubAccessChecker {
             inner,
             pool,
             github_app_id,
+            github_api_base_url: GITHUB_API_BASE_URL.to_string(),
+        }
+    }
+
+    /// Create a checker with a custom GitHub API base URL (for testing).
+    #[doc(hidden)]
+    pub fn with_base_url(
+        inner: Arc<dyn GithubAccessChecker>,
+        pool: sqlx::PgPool,
+        github_app_id: Option<u64>,
+        base_url: String,
+    ) -> Self {
+        Self {
+            inner,
+            pool,
+            github_app_id,
+            github_api_base_url: base_url,
         }
     }
 
@@ -623,7 +644,8 @@ impl CachedGithubAccessChecker {
 
         loop {
             let url = format!(
-                "https://api.github.com/user/installations?per_page=100&page={page}"
+                "{}/user/installations?per_page=100&page={page}",
+                self.github_api_base_url
             );
 
             let resp = client
@@ -668,7 +690,8 @@ impl CachedGithubAccessChecker {
 
         loop {
             let url = format!(
-                "https://api.github.com/user/installations/{installation_id}/repositories?per_page=100&page={page}"
+                "{}/user/installations/{installation_id}/repositories?per_page=100&page={page}",
+                self.github_api_base_url
             );
 
             let resp = client

--- a/crates/api/src/github_access.rs
+++ b/crates/api/src/github_access.rs
@@ -569,14 +569,16 @@ impl CachedGithubAccessChecker {
 
         // Fetch installations
         let client = reqwest::Client::new();
-        let installations =
-            match self.fetch_user_installations(&client, github_access_token).await {
-                Ok(installs) => installs,
-                Err(e) => {
-                    tracing::warn!(error = %e, "fallback sync: failed to fetch installations");
-                    return;
-                }
-            };
+        let installations = match self
+            .fetch_user_installations(&client, github_access_token)
+            .await
+        {
+            Ok(installs) => installs,
+            Err(e) => {
+                tracing::warn!(error = %e, "fallback sync: failed to fetch installations");
+                return;
+            }
+        };
 
         // Filter by app_id and not suspended
         let relevant_installations: Vec<&InstallationInfo> = installations

--- a/crates/api/src/github_access.rs
+++ b/crates/api/src/github_access.rs
@@ -392,6 +392,9 @@ impl GithubAccessChecker for CachedGithubAccessChecker {
         .await
         {
             if let Ok(ids) = serde_json::from_value::<Vec<i64>>(cached) {
+                // Even on cache hit, trigger fallback sync if repos are missing from DB
+                self.maybe_sync_installation_repos(github_access_token, user_id, &ids)
+                    .await;
                 return Ok(Some(ids));
             }
         }
@@ -515,9 +518,10 @@ impl CachedGithubAccessChecker {
             }
         };
 
+        let existing_set: std::collections::HashSet<i64> = existing.into_iter().collect();
         let missing: Vec<i64> = accessible_ids
             .iter()
-            .filter(|id| !existing.contains(id))
+            .filter(|id| !existing_set.contains(id))
             .copied()
             .collect();
 

--- a/crates/api/src/github_access.rs
+++ b/crates/api/src/github_access.rs
@@ -309,18 +309,28 @@ pub type DynGithubAccessChecker = Arc<dyn GithubAccessChecker>;
 pub struct CachedGithubAccessChecker {
     inner: Arc<dyn GithubAccessChecker>,
     pool: sqlx::PgPool,
+    github_app_id: Option<u64>,
 }
 
 impl CachedGithubAccessChecker {
-    pub fn new(pool: sqlx::PgPool) -> Self {
+    pub fn new(pool: sqlx::PgPool, github_app_id: Option<u64>) -> Self {
         Self {
             inner: Arc::new(RealGithubAccessChecker::new()),
             pool,
+            github_app_id,
         }
     }
 
-    pub fn with_inner(inner: Arc<dyn GithubAccessChecker>, pool: sqlx::PgPool) -> Self {
-        Self { inner, pool }
+    pub fn with_inner(
+        inner: Arc<dyn GithubAccessChecker>,
+        pool: sqlx::PgPool,
+        github_app_id: Option<u64>,
+    ) -> Self {
+        Self {
+            inner,
+            pool,
+            github_app_id,
+        }
     }
 
     /// Invalidate all cached data for a given user.
@@ -332,6 +342,8 @@ impl CachedGithubAccessChecker {
 const CACHE_TYPE_REPO_IDS: &str = "accessible_repo_ids";
 const CACHE_TTL_SECONDS: i64 = 600; // 10 minutes
 const STALE_MAX_SECONDS: i64 = 3600; // 1 hour
+const SYNC_CACHE_TYPE: &str = "installation_repos_sync";
+const SYNC_TTL_SECONDS: i64 = 600; // 10 minutes
 
 #[async_trait::async_trait]
 impl GithubAccessChecker for CachedGithubAccessChecker {
@@ -404,6 +416,11 @@ impl GithubAccessChecker for CachedGithubAccessChecker {
                     )
                     .await;
                 }
+                // Fallback: sync installation repos if some are missing from DB
+                if let Some(ref ids) = result {
+                    self.maybe_sync_installation_repos(github_access_token, user_id, ids)
+                        .await;
+                }
                 Ok(result)
             }
             Err(ref e @ AccessError::RateLimited) => {
@@ -440,5 +457,244 @@ impl GithubAccessChecker for CachedGithubAccessChecker {
             .await
             .map_err(|e| AccessError::Upstream(format!("db error: {e}")))?;
         Ok(())
+    }
+}
+
+// ─── Fallback sync: Installation Repositories API ────────────────────────────
+
+#[derive(Debug, serde::Deserialize)]
+struct InstallationInfo {
+    id: u64,
+    app_id: u64,
+    suspended_at: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct InstallationsResponse {
+    installations: Vec<InstallationInfo>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct InstallationRepo {
+    id: i64,
+    full_name: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct InstallationReposResponse {
+    repositories: Vec<InstallationRepo>,
+}
+
+impl CachedGithubAccessChecker {
+    async fn maybe_sync_installation_repos(
+        &self,
+        github_access_token: &str,
+        user_id: uuid::Uuid,
+        accessible_ids: &[i64],
+    ) {
+        let app_id = match self.github_app_id {
+            Some(id) => id,
+            None => return,
+        };
+
+        if accessible_ids.is_empty() {
+            return;
+        }
+
+        // Check which ids are missing from DB
+        let existing = match boardflow_db::queries::repository::find_existing_github_ids(
+            &self.pool,
+            accessible_ids,
+        )
+        .await
+        {
+            Ok(ids) => ids,
+            Err(e) => {
+                tracing::warn!(error = %e, "failed to check existing repos for sync");
+                return;
+            }
+        };
+
+        let missing: Vec<i64> = accessible_ids
+            .iter()
+            .filter(|id| !existing.contains(id))
+            .copied()
+            .collect();
+
+        if missing.is_empty() {
+            return;
+        }
+
+        // Throttle check
+        if let Ok(Some(_)) = boardflow_db::queries::github_api_cache::get_valid_cache(
+            &self.pool,
+            user_id,
+            SYNC_CACHE_TYPE,
+        )
+        .await
+        {
+            return; // Already synced recently
+        }
+
+        tracing::info!(
+            user_id = %user_id,
+            missing_count = missing.len(),
+            "triggering installation repos fallback sync"
+        );
+
+        // Fetch installations
+        let client = reqwest::Client::new();
+        let installations =
+            match self.fetch_user_installations(&client, github_access_token).await {
+                Ok(installs) => installs,
+                Err(e) => {
+                    tracing::warn!(error = %e, "fallback sync: failed to fetch installations");
+                    return;
+                }
+            };
+
+        // Filter by app_id and not suspended
+        let relevant_installations: Vec<&InstallationInfo> = installations
+            .iter()
+            .filter(|i| i.app_id == app_id && i.suspended_at.is_none())
+            .collect();
+
+        // For each installation, fetch repos and upsert
+        for installation in relevant_installations {
+            let repos = match self
+                .fetch_installation_repos(&client, github_access_token, installation.id)
+                .await
+            {
+                Ok(repos) => repos,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        installation_id = installation.id,
+                        "fallback sync: failed to fetch repos for installation"
+                    );
+                    continue;
+                }
+            };
+
+            for repo in &repos {
+                if let Some((owner, name)) = repo.full_name.split_once('/') {
+                    if let Err(e) = boardflow_db::queries::repository::upsert(
+                        &self.pool,
+                        repo.id,
+                        owner,
+                        name,
+                        installation.id as i64,
+                    )
+                    .await
+                    {
+                        tracing::warn!(
+                            error = %e,
+                            repo_id = repo.id,
+                            full_name = %repo.full_name,
+                            "fallback sync: failed to upsert repository"
+                        );
+                    }
+                }
+            }
+        }
+
+        // Update throttle cache
+        let _ = boardflow_db::queries::github_api_cache::upsert_cache(
+            &self.pool,
+            user_id,
+            SYNC_CACHE_TYPE,
+            &serde_json::json!({"synced": true}),
+            SYNC_TTL_SECONDS,
+        )
+        .await;
+    }
+
+    async fn fetch_user_installations(
+        &self,
+        client: &reqwest::Client,
+        github_access_token: &str,
+    ) -> Result<Vec<InstallationInfo>, String> {
+        let mut all_installations = Vec::new();
+        let mut page = 1u32;
+
+        loop {
+            let url = format!(
+                "https://api.github.com/user/installations?per_page=100&page={page}"
+            );
+
+            let resp = client
+                .get(&url)
+                .header("Authorization", format!("Bearer {}", github_access_token))
+                .header("User-Agent", "BoardFlow")
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .send()
+                .await
+                .map_err(|e| format!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                return Err(format!("status {}", resp.status()));
+            }
+
+            let data: InstallationsResponse = resp
+                .json()
+                .await
+                .map_err(|e| format!("parse failed: {e}"))?;
+
+            let count = data.installations.len();
+            all_installations.extend(data.installations);
+
+            if count < 100 {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(all_installations)
+    }
+
+    async fn fetch_installation_repos(
+        &self,
+        client: &reqwest::Client,
+        github_access_token: &str,
+        installation_id: u64,
+    ) -> Result<Vec<InstallationRepo>, String> {
+        let mut all_repos = Vec::new();
+        let mut page = 1u32;
+
+        loop {
+            let url = format!(
+                "https://api.github.com/user/installations/{installation_id}/repositories?per_page=100&page={page}"
+            );
+
+            let resp = client
+                .get(&url)
+                .header("Authorization", format!("Bearer {}", github_access_token))
+                .header("User-Agent", "BoardFlow")
+                .header("Accept", "application/vnd.github+json")
+                .header("X-GitHub-Api-Version", "2022-11-28")
+                .send()
+                .await
+                .map_err(|e| format!("request failed: {e}"))?;
+
+            if !resp.status().is_success() {
+                return Err(format!("status {}", resp.status()));
+            }
+
+            let data: InstallationReposResponse = resp
+                .json()
+                .await
+                .map_err(|e| format!("parse failed: {e}"))?;
+
+            let count = data.repositories.len();
+            all_repos.extend(data.repositories);
+
+            if count < 100 {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(all_repos)
     }
 }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -22,7 +22,7 @@ use boardflow_config::{optional_env, optional_env_or};
 
 pub fn create_app(pool: PgPool, s3_client: Option<aws_sdk_s3::Client>) -> Router {
     create_app_with_config(
-        pool, s3_client, None, None, None, None, None, None, None, None,
+        pool, s3_client, None, None, None, None, None, None, None, None, None,
     )
 }
 
@@ -38,6 +38,7 @@ pub fn create_app_with_config(
     app_domain: Option<String>,
     artifact_base_url: Option<String>,
     webhook_secret: Option<String>,
+    github_app_id: Option<u64>,
 ) -> Router {
     let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
         .routes(routes!(routes::health::healthz))
@@ -75,8 +76,8 @@ pub fn create_app_with_config(
             .into_bytes()
     });
 
-    let checker: DynGithubAccessChecker =
-        access_checker.unwrap_or_else(|| Arc::new(CachedGithubAccessChecker::new(pool.clone())));
+    let checker: DynGithubAccessChecker = access_checker
+        .unwrap_or_else(|| Arc::new(CachedGithubAccessChecker::new(pool.clone(), github_app_id)));
 
     let bucket = FinalBucket(
         final_bucket.unwrap_or_else(|| optional_env_or("MINIO_BUCKET_FINAL", "boardflow-final")),
@@ -126,6 +127,7 @@ pub fn create_app_with_config(
         .layer(Extension(domain))
         .layer(Extension(base_url))
         .layer(Extension(checker))
+        .layer(Extension(GithubAppId(github_app_id)))
         .layer(axum::middleware::from_fn(
             middleware::request_id::request_id_middleware,
         ))
@@ -149,6 +151,9 @@ pub struct AppDomain(pub String);
 
 #[derive(Clone)]
 pub struct ArtifactBaseUrl(pub String);
+
+#[derive(Clone)]
+pub struct GithubAppId(pub Option<u64>);
 
 #[derive(OpenApi)]
 #[openapi(

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -49,6 +49,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Some(config.app_domain),
         Some(config.artifact_base_url),
         config.github_webhook_secret,
+        config.github_app_id,
     );
 
     let addr = format!("{}:{}", config.api_host, config.api_port);

--- a/crates/api/tests/api_token_test.rs
+++ b/crates/api/tests/api_token_test.rs
@@ -41,6 +41,7 @@ fn create_test_app(pool: PgPool) -> axum::Router {
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -52,6 +53,7 @@ fn create_deny_app(pool: PgPool) -> axum::Router {
         None,
         None,
         Some(checker),
+        None,
         None,
         None,
         None,

--- a/crates/api/tests/api_token_test.rs
+++ b/crates/api/tests/api_token_test.rs
@@ -14,6 +14,10 @@ use sqlx::PgPool;
 use tower::ServiceExt;
 use uuid::Uuid;
 
+mod common;
+
+use common::unique_i64 as rand_i64;
+
 async fn setup_pool() -> Option<PgPool> {
     unsafe { std::env::set_var("BOARDFLOW_ARTIFACT_SECRET", "test-secret-for-tests") };
     let database_url = match std::env::var("DATABASE_URL") {
@@ -60,12 +64,6 @@ fn create_deny_app(pool: PgPool) -> axum::Router {
         None,
         None,
     )
-}
-
-fn rand_i64() -> i64 {
-    let uuid = Uuid::now_v7();
-    let bytes = uuid.as_bytes();
-    i64::from_be_bytes(bytes[0..8].try_into().unwrap()).abs()
 }
 
 async fn create_test_user(pool: &PgPool) -> Uuid {

--- a/crates/api/tests/board_run_test.rs
+++ b/crates/api/tests/board_run_test.rs
@@ -8,6 +8,10 @@ use sqlx::PgPool;
 use tower::ServiceExt;
 use uuid::Uuid;
 
+mod common;
+
+use common::unique_i64 as rand_i64;
+
 async fn setup_pool() -> Option<PgPool> {
     // Ensure artifact secret is set for create_app
     // SAFETY: tests run sequentially via #[tokio::test] default single-thread;
@@ -108,12 +112,6 @@ async fn create_test_board_run(pool: &PgPool, board_project_id: Uuid, status: &s
     .await
     .unwrap();
     id
-}
-
-fn rand_i64() -> i64 {
-    let uuid = Uuid::now_v7();
-    let bytes = uuid.as_bytes();
-    i64::from_be_bytes(bytes[0..8].try_into().unwrap()).abs()
 }
 
 // ─── POST /api/v1/board-runs ─────────────────────────────────────────────────

--- a/crates/api/tests/common.rs
+++ b/crates/api/tests/common.rs
@@ -1,0 +1,14 @@
+use rand::Rng;
+use std::sync::atomic::{AtomicI64, Ordering};
+
+static NEXT_UNIQUE_I64: AtomicI64 = AtomicI64::new(0);
+
+pub fn unique_i64() -> i64 {
+    if NEXT_UNIQUE_I64.load(Ordering::Relaxed) == 0 {
+        // Generate GitHub-ID-like positive values and keep them unique within this test process.
+        let seed = rand::thread_rng().gen_range(1..=(i64::MAX / 2));
+        let _ = NEXT_UNIQUE_I64.compare_exchange(0, seed, Ordering::Relaxed, Ordering::Relaxed);
+    }
+
+    NEXT_UNIQUE_I64.fetch_add(1, Ordering::Relaxed)
+}

--- a/crates/api/tests/github_cache_test.rs
+++ b/crates/api/tests/github_cache_test.rs
@@ -10,6 +10,10 @@ use uuid::Uuid;
 use wiremock::matchers::{method, path_regex};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
+mod common;
+
+use common::unique_i64 as rand_i64;
+
 async fn setup_pool() -> Option<PgPool> {
     unsafe { std::env::set_var("BOARDFLOW_ARTIFACT_SECRET", "test-secret-for-tests") };
     let database_url = match std::env::var("DATABASE_URL") {
@@ -22,12 +26,6 @@ async fn setup_pool() -> Option<PgPool> {
     let pool = PgPool::connect(&database_url).await.unwrap();
     sqlx::migrate!("../db/migrations").run(&pool).await.unwrap();
     Some(pool)
-}
-
-fn rand_i64() -> i64 {
-    let uuid = Uuid::now_v7();
-    let bytes = uuid.as_bytes();
-    i64::from_be_bytes(bytes[0..8].try_into().unwrap()).abs()
 }
 
 async fn create_test_user_with_token(pool: &PgPool, token: &str) -> Uuid {

--- a/crates/api/tests/github_cache_test.rs
+++ b/crates/api/tests/github_cache_test.rs
@@ -541,7 +541,8 @@ async fn test_invalidate_repo_cache_via_trait() {
     .unwrap();
 
     // Create checker as DynGithubAccessChecker (trait object)
-    let checker: DynGithubAccessChecker = Arc::new(CachedGithubAccessChecker::new(pool.clone(), None));
+    let checker: DynGithubAccessChecker =
+        Arc::new(CachedGithubAccessChecker::new(pool.clone(), None));
 
     // Call invalidate_repo_cache via trait
     checker.invalidate_repo_cache(user_id).await.unwrap();
@@ -636,8 +637,9 @@ async fn test_find_existing_github_ids_empty_input() {
         return;
     };
 
-    let existing =
-        boardflow_db::queries::repository::find_existing_github_ids(&pool, &[]).await.unwrap();
+    let existing = boardflow_db::queries::repository::find_existing_github_ids(&pool, &[])
+        .await
+        .unwrap();
     assert!(existing.is_empty());
 }
 
@@ -778,12 +780,10 @@ async fn test_fallback_sync_skipped_when_throttled() {
     assert_eq!(result, Some(vec![nonexistent_id]));
 
     // The repo should NOT have been created (sync was throttled)
-    let existing = boardflow_db::queries::repository::find_existing_github_ids(
-        &pool,
-        &[nonexistent_id],
-    )
-    .await
-    .unwrap();
+    let existing =
+        boardflow_db::queries::repository::find_existing_github_ids(&pool, &[nonexistent_id])
+            .await
+            .unwrap();
     assert!(existing.is_empty());
 }
 
@@ -851,12 +851,10 @@ async fn test_fallback_sync_success_upserts_repos() {
     assert_eq!(result, Some(vec![repo_github_id]));
 
     // Verify the repo was upserted into DB
-    let existing = boardflow_db::queries::repository::find_existing_github_ids(
-        &pool,
-        &[repo_github_id],
-    )
-    .await
-    .unwrap();
+    let existing =
+        boardflow_db::queries::repository::find_existing_github_ids(&pool, &[repo_github_id])
+            .await
+            .unwrap();
     assert_eq!(existing, vec![repo_github_id]);
 
     // Verify throttle cache was set
@@ -922,12 +920,10 @@ async fn test_fallback_sync_filters_wrong_app_id() {
     assert_eq!(result, Some(vec![repo_github_id]));
 
     // Repo should NOT be upserted (wrong app_id filtered out)
-    let existing = boardflow_db::queries::repository::find_existing_github_ids(
-        &pool,
-        &[repo_github_id],
-    )
-    .await
-    .unwrap();
+    let existing =
+        boardflow_db::queries::repository::find_existing_github_ids(&pool, &[repo_github_id])
+            .await
+            .unwrap();
     assert!(existing.is_empty());
 
     // Throttle should still be set (sync was attempted)
@@ -985,12 +981,10 @@ async fn test_fallback_sync_filters_suspended_installations() {
     assert_eq!(result, Some(vec![repo_github_id]));
 
     // Repo should NOT be upserted (installation is suspended)
-    let existing = boardflow_db::queries::repository::find_existing_github_ids(
-        &pool,
-        &[repo_github_id],
-    )
-    .await
-    .unwrap();
+    let existing =
+        boardflow_db::queries::repository::find_existing_github_ids(&pool, &[repo_github_id])
+            .await
+            .unwrap();
     assert!(existing.is_empty());
 
     // Throttle should still be set
@@ -1039,12 +1033,10 @@ async fn test_fallback_sync_github_api_error_graceful() {
     assert_eq!(result, Some(vec![repo_github_id]));
 
     // Repo should NOT be in DB (sync failed gracefully)
-    let existing = boardflow_db::queries::repository::find_existing_github_ids(
-        &pool,
-        &[repo_github_id],
-    )
-    .await
-    .unwrap();
+    let existing =
+        boardflow_db::queries::repository::find_existing_github_ids(&pool, &[repo_github_id])
+            .await
+            .unwrap();
     assert!(existing.is_empty());
 }
 
@@ -1057,7 +1049,12 @@ struct FixedIdsGithubAccessChecker {
 
 #[async_trait::async_trait]
 impl GithubAccessChecker for FixedIdsGithubAccessChecker {
-    async fn check_access(&self, _token: &str, _owner: &str, _name: &str) -> boardflow_api::github_access::AccessResult {
+    async fn check_access(
+        &self,
+        _token: &str,
+        _owner: &str,
+        _name: &str,
+    ) -> boardflow_api::github_access::AccessResult {
         boardflow_api::github_access::AccessResult::Allowed
     }
 

--- a/crates/api/tests/github_cache_test.rs
+++ b/crates/api/tests/github_cache_test.rs
@@ -320,7 +320,7 @@ async fn test_cached_checker_invalidate_cache() {
     .await
     .unwrap();
 
-    let checker = CachedGithubAccessChecker::new(pool.clone());
+    let checker = CachedGithubAccessChecker::new(pool.clone(), None);
     checker.invalidate_cache(user_id).await.unwrap();
 
     let cached = boardflow_db::queries::github_api_cache::get_valid_cache(
@@ -355,9 +355,8 @@ async fn test_cached_checker_returns_cached_repo_ids() {
     .await
     .unwrap();
 
-    // Use AllowAll as inner – if cache hits, inner is never called
     let inner: Arc<dyn GithubAccessChecker> = Arc::new(AllowAllGithubAccessChecker);
-    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone(), None);
     let result = checker.list_accessible_repo_ids(token).await.unwrap();
     assert_eq!(result, Some(vec![1001, 1002, 1003]));
 }
@@ -372,7 +371,7 @@ async fn test_cached_checker_unknown_token_passes_through() {
     };
     // This token doesn't exist in users table
     // The inner (RealGithubAccessChecker) will get a 401 from GitHub
-    let checker = CachedGithubAccessChecker::new(pool.clone());
+    let checker = CachedGithubAccessChecker::new(pool.clone(), None);
     let result = checker
         .list_accessible_repo_ids("gho_definitely_not_in_db")
         .await;
@@ -444,7 +443,7 @@ async fn test_cached_checker_stale_fallback_with_mock_inner_rate_limited() {
 
     // Use RateLimitedGithubAccessChecker as inner → always returns RateLimited
     let inner: Arc<dyn GithubAccessChecker> = Arc::new(RateLimitedGithubAccessChecker);
-    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone(), None);
 
     let result = checker.list_accessible_repo_ids(token).await;
     // Should return stale cache instead of error
@@ -476,7 +475,7 @@ async fn test_cached_checker_token_expired_no_stale_fallback() {
 
     // Use TokenExpiredGithubAccessChecker as inner → always returns TokenExpired
     let inner: Arc<dyn GithubAccessChecker> = Arc::new(TokenExpiredGithubAccessChecker);
-    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone(), None);
 
     let result = checker.list_accessible_repo_ids(token).await;
     // Should propagate TokenExpired error, NOT return stale cache
@@ -508,7 +507,7 @@ async fn test_cached_checker_upstream_error_no_stale_fallback() {
 
     // Use UpstreamErrorGithubAccessChecker as inner
     let inner: Arc<dyn GithubAccessChecker> = Arc::new(UpstreamErrorGithubAccessChecker);
-    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone(), None);
 
     let result = checker.list_accessible_repo_ids(token).await;
     // Should propagate Upstream error, NOT return stale cache
@@ -540,7 +539,7 @@ async fn test_invalidate_repo_cache_via_trait() {
     .unwrap();
 
     // Create checker as DynGithubAccessChecker (trait object)
-    let checker: DynGithubAccessChecker = Arc::new(CachedGithubAccessChecker::new(pool.clone()));
+    let checker: DynGithubAccessChecker = Arc::new(CachedGithubAccessChecker::new(pool.clone(), None));
 
     // Call invalidate_repo_cache via trait
     checker.invalidate_repo_cache(user_id).await.unwrap();
@@ -568,7 +567,7 @@ async fn test_cached_checker_rate_limited_no_stale_returns_error() {
 
     // No cache entry seeded → stale fallback has nothing to return
     let inner: Arc<dyn GithubAccessChecker> = Arc::new(RateLimitedGithubAccessChecker);
-    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone());
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone(), None);
 
     let result = checker.list_accessible_repo_ids(token).await;
     // Should return RateLimited since no stale cache exists

--- a/crates/api/tests/github_cache_test.rs
+++ b/crates/api/tests/github_cache_test.rs
@@ -573,3 +573,214 @@ async fn test_cached_checker_rate_limited_no_stale_returns_error() {
     // Should return RateLimited since no stale cache exists
     assert_eq!(result, Err(AccessError::RateLimited));
 }
+
+// ─── Fallback sync tests ─────────────────────────────────────────────────────
+
+/// Test: find_existing_github_ids returns only IDs that exist in DB
+#[tokio::test]
+#[serial]
+async fn test_find_existing_github_ids() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+
+    let repo_id_1 = rand_i64();
+    let repo_id_2 = rand_i64();
+    let repo_id_3 = rand_i64();
+
+    // Insert two repos, skip the third
+    let uuid1 = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO repositories (id, github_repository_id, owner, name, installation_id, created_at, updated_at) \
+         VALUES ($1, $2, 'owner1', 'repo1', 1001, NOW(), NOW()) \
+         ON CONFLICT (github_repository_id) DO NOTHING",
+    )
+    .bind(uuid1)
+    .bind(repo_id_1)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let uuid2 = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO repositories (id, github_repository_id, owner, name, installation_id, created_at, updated_at) \
+         VALUES ($1, $2, 'owner2', 'repo2', 1001, NOW(), NOW()) \
+         ON CONFLICT (github_repository_id) DO NOTHING",
+    )
+    .bind(uuid2)
+    .bind(repo_id_2)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let existing = boardflow_db::queries::repository::find_existing_github_ids(
+        &pool,
+        &[repo_id_1, repo_id_2, repo_id_3],
+    )
+    .await
+    .unwrap();
+
+    assert!(existing.contains(&repo_id_1));
+    assert!(existing.contains(&repo_id_2));
+    assert!(!existing.contains(&repo_id_3));
+    assert_eq!(existing.len(), 2);
+}
+
+/// Test: find_existing_github_ids with empty input returns empty
+#[tokio::test]
+#[serial]
+async fn test_find_existing_github_ids_empty_input() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+
+    let existing =
+        boardflow_db::queries::repository::find_existing_github_ids(&pool, &[]).await.unwrap();
+    assert!(existing.is_empty());
+}
+
+/// Test: Fallback sync skipped when github_app_id is None
+#[tokio::test]
+#[serial]
+async fn test_fallback_sync_skipped_when_app_id_none() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_fallback_no_appid_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Seed cache with repo IDs that don't exist in repositories table
+    let nonexistent_id = rand_i64();
+    let value = serde_json::json!([nonexistent_id]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+        &value,
+        600,
+    )
+    .await
+    .unwrap();
+
+    // Create checker with github_app_id = None
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(AllowAllGithubAccessChecker);
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone(), None);
+
+    let result = checker.list_accessible_repo_ids(token).await.unwrap();
+    assert_eq!(result, Some(vec![nonexistent_id]));
+
+    // Verify no sync throttle cache was written (sync was skipped)
+    let sync_cache = boardflow_db::queries::github_api_cache::get_valid_cache(
+        &pool,
+        user_id,
+        "installation_repos_sync",
+    )
+    .await
+    .unwrap();
+    assert_eq!(sync_cache, None);
+}
+
+/// Test: Fallback sync skipped when all repos already exist in DB
+#[tokio::test]
+#[serial]
+async fn test_fallback_sync_skipped_when_all_repos_exist() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_fallback_all_exist_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Create a repo in DB
+    let repo_id = rand_i64();
+    let uuid = Uuid::now_v7();
+    sqlx::query(
+        "INSERT INTO repositories (id, github_repository_id, owner, name, installation_id, created_at, updated_at) \
+         VALUES ($1, $2, 'testowner', 'testrepo', 1001, NOW(), NOW()) \
+         ON CONFLICT (github_repository_id) DO NOTHING",
+    )
+    .bind(uuid)
+    .bind(repo_id)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    // Seed cache with the existing repo ID
+    let value = serde_json::json!([repo_id]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+        &value,
+        600,
+    )
+    .await
+    .unwrap();
+
+    // Create checker with a real app_id (sync should still be skipped since no missing repos)
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(AllowAllGithubAccessChecker);
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone(), Some(12345));
+
+    let result = checker.list_accessible_repo_ids(token).await.unwrap();
+    assert_eq!(result, Some(vec![repo_id]));
+
+    // Verify no sync throttle cache was written (sync was skipped - no missing repos)
+    let sync_cache = boardflow_db::queries::github_api_cache::get_valid_cache(
+        &pool,
+        user_id,
+        "installation_repos_sync",
+    )
+    .await
+    .unwrap();
+    assert_eq!(sync_cache, None);
+}
+
+/// Test: Fallback sync skipped when throttle is active
+#[tokio::test]
+#[serial]
+async fn test_fallback_sync_skipped_when_throttled() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_fallback_throttled_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    // Seed cache with a repo ID that doesn't exist in DB
+    let nonexistent_id = rand_i64();
+    let value = serde_json::json!([nonexistent_id]);
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "accessible_repo_ids",
+        &value,
+        600,
+    )
+    .await
+    .unwrap();
+
+    // Seed the sync throttle cache (indicates sync was done recently)
+    boardflow_db::queries::github_api_cache::upsert_cache(
+        &pool,
+        user_id,
+        "installation_repos_sync",
+        &serde_json::json!({"synced": true}),
+        600,
+    )
+    .await
+    .unwrap();
+
+    // Create checker with a real app_id
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(AllowAllGithubAccessChecker);
+    let checker = CachedGithubAccessChecker::with_inner(inner, pool.clone(), Some(12345));
+
+    let result = checker.list_accessible_repo_ids(token).await.unwrap();
+    assert_eq!(result, Some(vec![nonexistent_id]));
+
+    // The repo should NOT have been created (sync was throttled)
+    let existing = boardflow_db::queries::repository::find_existing_github_ids(
+        &pool,
+        &[nonexistent_id],
+    )
+    .await
+    .unwrap();
+    assert!(existing.is_empty());
+}

--- a/crates/api/tests/github_cache_test.rs
+++ b/crates/api/tests/github_cache_test.rs
@@ -7,6 +7,8 @@ use boardflow_api::github_access::{
 use sqlx::PgPool;
 use std::sync::Arc;
 use uuid::Uuid;
+use wiremock::matchers::{method, path_regex};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 async fn setup_pool() -> Option<PgPool> {
     unsafe { std::env::set_var("BOARDFLOW_ARTIFACT_SECRET", "test-secret-for-tests") };
@@ -783,4 +785,286 @@ async fn test_fallback_sync_skipped_when_throttled() {
     .await
     .unwrap();
     assert!(existing.is_empty());
+}
+
+// ─── Success-path fallback sync tests (with wiremock) ────────────────────────
+
+/// Test: Successful fallback sync fetches installations, filters by app_id,
+/// fetches repos, and upserts them into DB
+#[tokio::test]
+#[serial]
+async fn test_fallback_sync_success_upserts_repos() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_fallback_success_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    let mock_server = MockServer::start().await;
+    let app_id: u64 = 99999;
+    let repo_github_id: i64 = rand_i64();
+
+    // Mock GET /user/installations
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/user/installations$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 1,
+            "installations": [
+                {
+                    "id": 5001,
+                    "app_id": app_id,
+                    "suspended_at": null
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Mock GET /user/installations/5001/repositories
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/user/installations/5001/repositories"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 1,
+            "repositories": [
+                {
+                    "id": repo_github_id,
+                    "full_name": "testorg/testrepo-synced"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    // Use AllowAll inner that returns the repo_github_id as accessible
+    // (simulating GitHub /user/repos returning this ID)
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(FixedIdsGithubAccessChecker {
+        ids: vec![repo_github_id],
+    });
+    let checker = CachedGithubAccessChecker::with_base_url(
+        inner,
+        pool.clone(),
+        Some(app_id),
+        mock_server.uri(),
+    );
+
+    let result = checker.list_accessible_repo_ids(token).await.unwrap();
+    assert_eq!(result, Some(vec![repo_github_id]));
+
+    // Verify the repo was upserted into DB
+    let existing = boardflow_db::queries::repository::find_existing_github_ids(
+        &pool,
+        &[repo_github_id],
+    )
+    .await
+    .unwrap();
+    assert_eq!(existing, vec![repo_github_id]);
+
+    // Verify throttle cache was set
+    let sync_cache = boardflow_db::queries::github_api_cache::get_valid_cache(
+        &pool,
+        user_id,
+        "installation_repos_sync",
+    )
+    .await
+    .unwrap();
+    assert!(sync_cache.is_some());
+
+    // Cleanup
+    sqlx::query("DELETE FROM repositories WHERE github_repository_id = $1")
+        .bind(repo_github_id)
+        .execute(&pool)
+        .await
+        .unwrap();
+}
+
+/// Test: Fallback sync filters out installations with wrong app_id
+#[tokio::test]
+#[serial]
+async fn test_fallback_sync_filters_wrong_app_id() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_fallback_appid_filter_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    let mock_server = MockServer::start().await;
+    let our_app_id: u64 = 88888;
+    let other_app_id: u64 = 77777;
+    let repo_github_id: i64 = rand_i64();
+
+    // Mock installations: only "other" app_id present
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/user/installations$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 1,
+            "installations": [
+                {
+                    "id": 6001,
+                    "app_id": other_app_id,
+                    "suspended_at": null
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(FixedIdsGithubAccessChecker {
+        ids: vec![repo_github_id],
+    });
+    let checker = CachedGithubAccessChecker::with_base_url(
+        inner,
+        pool.clone(),
+        Some(our_app_id),
+        mock_server.uri(),
+    );
+
+    let result = checker.list_accessible_repo_ids(token).await.unwrap();
+    assert_eq!(result, Some(vec![repo_github_id]));
+
+    // Repo should NOT be upserted (wrong app_id filtered out)
+    let existing = boardflow_db::queries::repository::find_existing_github_ids(
+        &pool,
+        &[repo_github_id],
+    )
+    .await
+    .unwrap();
+    assert!(existing.is_empty());
+
+    // Throttle should still be set (sync was attempted)
+    let sync_cache = boardflow_db::queries::github_api_cache::get_valid_cache(
+        &pool,
+        user_id,
+        "installation_repos_sync",
+    )
+    .await
+    .unwrap();
+    assert!(sync_cache.is_some());
+}
+
+/// Test: Fallback sync filters out suspended installations
+#[tokio::test]
+#[serial]
+async fn test_fallback_sync_filters_suspended_installations() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_fallback_suspended_test";
+    let user_id = create_test_user_with_token(&pool, token).await;
+
+    let mock_server = MockServer::start().await;
+    let app_id: u64 = 66666;
+    let repo_github_id: i64 = rand_i64();
+
+    // Mock installations: matching app_id but suspended
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/user/installations$"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 1,
+            "installations": [
+                {
+                    "id": 7001,
+                    "app_id": app_id,
+                    "suspended_at": "2024-01-01T00:00:00Z"
+                }
+            ]
+        })))
+        .mount(&mock_server)
+        .await;
+
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(FixedIdsGithubAccessChecker {
+        ids: vec![repo_github_id],
+    });
+    let checker = CachedGithubAccessChecker::with_base_url(
+        inner,
+        pool.clone(),
+        Some(app_id),
+        mock_server.uri(),
+    );
+
+    let result = checker.list_accessible_repo_ids(token).await.unwrap();
+    assert_eq!(result, Some(vec![repo_github_id]));
+
+    // Repo should NOT be upserted (installation is suspended)
+    let existing = boardflow_db::queries::repository::find_existing_github_ids(
+        &pool,
+        &[repo_github_id],
+    )
+    .await
+    .unwrap();
+    assert!(existing.is_empty());
+
+    // Throttle should still be set
+    let sync_cache = boardflow_db::queries::github_api_cache::get_valid_cache(
+        &pool,
+        user_id,
+        "installation_repos_sync",
+    )
+    .await
+    .unwrap();
+    assert!(sync_cache.is_some());
+}
+
+/// Test: Fallback sync handles GitHub API error gracefully (best-effort)
+#[tokio::test]
+#[serial]
+async fn test_fallback_sync_github_api_error_graceful() {
+    let Some(pool) = setup_pool().await else {
+        return;
+    };
+    let token = "gho_fallback_api_error_test";
+    let _user_id = create_test_user_with_token(&pool, token).await;
+
+    let mock_server = MockServer::start().await;
+    let repo_github_id: i64 = rand_i64();
+
+    // Mock installations returns 500
+    Mock::given(method("GET"))
+        .and(path_regex(r"^/user/installations"))
+        .respond_with(ResponseTemplate::new(500))
+        .mount(&mock_server)
+        .await;
+
+    let inner: Arc<dyn GithubAccessChecker> = Arc::new(FixedIdsGithubAccessChecker {
+        ids: vec![repo_github_id],
+    });
+    let checker = CachedGithubAccessChecker::with_base_url(
+        inner,
+        pool.clone(),
+        Some(12345),
+        mock_server.uri(),
+    );
+
+    // Should return successfully despite API error (best-effort sync)
+    let result = checker.list_accessible_repo_ids(token).await.unwrap();
+    assert_eq!(result, Some(vec![repo_github_id]));
+
+    // Repo should NOT be in DB (sync failed gracefully)
+    let existing = boardflow_db::queries::repository::find_existing_github_ids(
+        &pool,
+        &[repo_github_id],
+    )
+    .await
+    .unwrap();
+    assert!(existing.is_empty());
+}
+
+// ─── Test helper: fixed IDs access checker ──────────────────────────────────
+
+/// Mock that returns a fixed set of repo IDs (simulating successful /user/repos)
+struct FixedIdsGithubAccessChecker {
+    ids: Vec<i64>,
+}
+
+#[async_trait::async_trait]
+impl GithubAccessChecker for FixedIdsGithubAccessChecker {
+    async fn check_access(&self, _token: &str, _owner: &str, _name: &str) -> boardflow_api::github_access::AccessResult {
+        boardflow_api::github_access::AccessResult::Allowed
+    }
+
+    async fn list_accessible_repo_ids(
+        &self,
+        _token: &str,
+    ) -> Result<Option<Vec<i64>>, AccessError> {
+        Ok(Some(self.ids.clone()))
+    }
 }

--- a/crates/api/tests/github_cache_test.rs
+++ b/crates/api/tests/github_cache_test.rs
@@ -623,10 +623,10 @@ async fn test_find_existing_github_ids() {
     .await
     .unwrap();
 
+    assert_eq!(existing.len(), 2);
     assert!(existing.contains(&repo_id_1));
     assert!(existing.contains(&repo_id_2));
     assert!(!existing.contains(&repo_id_3));
-    assert_eq!(existing.len(), 2);
 }
 
 /// Test: find_existing_github_ids with empty input returns empty

--- a/crates/api/tests/plan_test.rs
+++ b/crates/api/tests/plan_test.rs
@@ -8,6 +8,10 @@ use sqlx::PgPool;
 use tower::ServiceExt;
 use uuid::Uuid;
 
+mod common;
+
+use common::unique_i64 as rand_i64;
+
 async fn setup_pool() -> Option<PgPool> {
     // Ensure artifact secret is set for create_app
     // SAFETY: tests run sequentially via #[tokio::test] default single-thread;
@@ -956,11 +960,4 @@ async fn plan_existing_project_no_previous_snapshot() {
 
     assert_eq!(json["projects"][0]["decision"], "build");
     assert_eq!(json["projects"][0]["reason"], "no_previous_snapshot");
-}
-
-fn rand_i64() -> i64 {
-    // Use UUID timestamp bits for a unique i64 to avoid test collisions
-    let uuid = Uuid::now_v7();
-    let bytes = uuid.as_bytes();
-    i64::from_be_bytes(bytes[0..8].try_into().unwrap()).abs()
 }

--- a/crates/api/tests/proxy_test.rs
+++ b/crates/api/tests/proxy_test.rs
@@ -15,6 +15,10 @@ use sqlx::PgPool;
 use tower::ServiceExt;
 use uuid::Uuid;
 
+mod common;
+
+use common::unique_i64 as rand_i64;
+
 type HmacSha256 = Hmac<Sha256>;
 
 const TEST_SECRET: &[u8] = b"test-secret-for-proxy-tests";
@@ -59,12 +63,6 @@ fn create_proxy_test_app(pool: PgPool) -> axum::Router {
         None,
         None,
     )
-}
-
-fn rand_i64() -> i64 {
-    let uuid = Uuid::now_v7();
-    let bytes = uuid.as_bytes();
-    i64::from_be_bytes(bytes[0..8].try_into().unwrap()).abs()
 }
 
 async fn create_test_user(pool: &PgPool) -> Uuid {

--- a/crates/api/tests/proxy_test.rs
+++ b/crates/api/tests/proxy_test.rs
@@ -57,6 +57,7 @@ fn create_proxy_test_app(pool: PgPool) -> axum::Router {
         Some("https://app.boardflow.example.com".to_string()),
         None,
         None,
+        None,
     )
 }
 

--- a/crates/api/tests/read_api_test.rs
+++ b/crates/api/tests/read_api_test.rs
@@ -13,6 +13,10 @@ use sqlx::PgPool;
 use tower::ServiceExt;
 use uuid::Uuid;
 
+mod common;
+
+use common::unique_i64 as rand_i64;
+
 async fn setup_pool() -> Option<PgPool> {
     // Ensure artifact secret is set for create_app
     // SAFETY: tests run sequentially via #[tokio::test] default single-thread;
@@ -62,12 +66,6 @@ fn create_deny_app(pool: PgPool) -> axum::Router {
         None,
         None,
     )
-}
-
-fn rand_i64() -> i64 {
-    let uuid = Uuid::now_v7();
-    let bytes = uuid.as_bytes();
-    i64::from_be_bytes(bytes[0..8].try_into().unwrap()).abs()
 }
 
 async fn create_test_user(pool: &PgPool) -> Uuid {

--- a/crates/api/tests/read_api_test.rs
+++ b/crates/api/tests/read_api_test.rs
@@ -43,6 +43,7 @@ fn create_test_app(pool: PgPool) -> axum::Router {
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -54,6 +55,7 @@ fn create_deny_app(pool: PgPool) -> axum::Router {
         None,
         None,
         Some(checker),
+        None,
         None,
         None,
         None,
@@ -1296,6 +1298,7 @@ async fn test_get_viewer_sources_returns_absolute_url_with_custom_base() {
         None,
         Some("https://artifacts.boardflow.example.com".to_string()),
         None,
+        None,
     );
 
     let response = app
@@ -1730,6 +1733,7 @@ fn create_rate_limited_app(pool: PgPool) -> axum::Router {
         None,
         None,
         None,
+        None,
     )
 }
 
@@ -1741,6 +1745,7 @@ fn create_upstream_error_app(pool: PgPool) -> axum::Router {
         None,
         None,
         Some(checker),
+        None,
         None,
         None,
         None,

--- a/crates/api/tests/webhook_test.rs
+++ b/crates/api/tests/webhook_test.rs
@@ -6,6 +6,10 @@ use sha2::Sha256;
 use sqlx::PgPool;
 use tower::ServiceExt;
 
+mod common;
+
+use common::unique_i64 as rand_i64;
+
 type HmacSha256 = Hmac<Sha256>;
 
 fn compute_signature(secret: &str, body: &[u8]) -> String {
@@ -45,11 +49,6 @@ fn create_test_app(pool: PgPool) -> axum::Router {
         Some(WEBHOOK_SECRET.to_string()),
         None,
     )
-}
-
-fn rand_i64() -> i64 {
-    use rand::Rng;
-    rand::thread_rng().gen_range(1..i64::MAX)
 }
 
 // --- Test: ping event returns 200 ---

--- a/crates/api/tests/webhook_test.rs
+++ b/crates/api/tests/webhook_test.rs
@@ -43,6 +43,7 @@ fn create_test_app(pool: PgPool) -> axum::Router {
         None,
         None,
         Some(WEBHOOK_SECRET.to_string()),
+        None,
     )
 }
 
@@ -372,7 +373,7 @@ async fn test_webhook_no_secret_configured() {
     };
     // webhook_secret を None で作成
     let app = boardflow_api::create_app_with_config(
-        pool, None, None, None, None, None, None, None, None, None,
+        pool, None, None, None, None, None, None, None, None, None, None,
     );
     let body = br#"{"zen":"test"}"#;
 

--- a/crates/config/src/app.rs
+++ b/crates/config/src/app.rs
@@ -18,6 +18,7 @@ pub struct AppConfig {
     pub app_domain: String,
     pub artifact_base_url: String,
     pub github_webhook_secret: Option<String>,
+    pub github_app_id: Option<u64>,
 }
 
 impl AppConfig {
@@ -41,6 +42,8 @@ impl AppConfig {
                 "http://localhost:8080",
             ),
             github_webhook_secret: optional_env("GITHUB_WEBHOOK_SECRET"),
+            github_app_id: optional_env("GITHUB_APP_ID")
+                .and_then(|s| s.parse::<u64>().ok()),
         })
     }
 }

--- a/crates/config/src/app.rs
+++ b/crates/config/src/app.rs
@@ -42,8 +42,7 @@ impl AppConfig {
                 "http://localhost:8080",
             ),
             github_webhook_secret: optional_env("GITHUB_WEBHOOK_SECRET"),
-            github_app_id: optional_env("GITHUB_APP_ID")
-                .and_then(|s| s.parse::<u64>().ok()),
+            github_app_id: optional_env("GITHUB_APP_ID").and_then(|s| s.parse::<u64>().ok()),
         })
     }
 }

--- a/crates/db/src/queries/repository.rs
+++ b/crates/db/src/queries/repository.rs
@@ -170,3 +170,15 @@ pub async fn clear_installation_for_repo(
     .fetch_optional(executor)
     .await
 }
+
+pub async fn find_existing_github_ids(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    github_ids: &[i64],
+) -> Result<Vec<i64>, sqlx::Error> {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT github_repository_id FROM repositories WHERE github_repository_id = ANY($1)",
+    )
+    .bind(github_ids)
+    .fetch_all(executor)
+    .await
+}

--- a/docs/backend/api.md
+++ b/docs/backend/api.md
@@ -28,6 +28,17 @@ revoke 済み token は認証エラー (`unauthorized`) として扱い、`last_
 Web UI 向け read API は GitHub OAuth session を前提にする。
 最終的な閲覧可否は backend が GitHub App installation と repository 権限に基づいて判定する。
 
+### 1.2.1 Installation Repos Fallback Sync
+
+Webhook (`installation` / `installation_repositories` イベント) が不着の場合、リポジトリ一覧 API (`GET /api/v1/repositories`) のリクエスト中に best-effort でフォールバック同期を行う。
+
+- **発火条件**: `list_accessible_repo_ids` が返した repo ID のうち、DB `repositories` テーブルに存在しない ID がある場合
+- **スロットル**: ユーザーごとに 10 分間隔（`github_api_cache` テーブルの `installation_repos_sync` エントリで制御）
+- **フロー**: `GET /user/installations` → `GITHUB_APP_ID` でフィルタ → `GET /user/installations/{id}/repositories` → `repository::upsert`
+- **エラー耐性**: GitHub API 障害時はフォールバックをスキップし、通常のレスポンスを返す（ユーザーへのエラーは伝搬しない）
+- **前提**: `GITHUB_APP_ID` 環境変数が設定されていること（未設定時はフォールバック無効）
+- **除外**: `suspended_at` が non-null のインストールは同期対象外
+
 ### 1.3 ID
 
 repository API / URL では `github_repository_id` を併用する。

--- a/docs/external/github-user-installations-api.md
+++ b/docs/external/github-user-installations-api.md
@@ -1,0 +1,235 @@
+# GitHub User Installations API — リポジトリ同期フォールバック調査
+
+## 要約
+
+GitHub App Webhookが不着の場合にユーザーのリポジトリ一覧をDBに同期するために、ユーザーのOAuthトークンで `GET /user/installations` → `GET /user/installations/{installation_id}/repositories` を呼ぶフォールバック戦略を調査した。両APIともGitHub App user access tokenで利用可能であり、BoardFlow の既存 `repositories` テーブルへの upsert に必要な情報（`id`, `full_name`, installation の `id`）がすべてレスポンスに含まれる。
+
+## 確認した情報
+
+### 1. GET /user/installations — ユーザーがアクセスできるインストール一覧
+
+**エンドポイント**: `GET /user/installations`
+
+**認証**: GitHub App user access token（Bearer token）。追加のパーミッション不要。
+
+**説明**: 認証済みユーザーが明示的なパーミッション（:read, :write, :admin）を持つ GitHub App インストールの一覧を返す。ユーザーは以下のリポジトリにアクセスできる:
+- 自分が所有するリポジトリ
+- コラボレーターとして参加しているリポジトリ
+- Organization メンバーシップでアクセス可能なリポジトリ
+
+**クエリパラメータ**:
+
+| パラメータ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `per_page` | integer | 30 | ページあたりの結果数（最大100） |
+| `page` | integer | 1 | フェッチするページ番号 |
+
+**レスポンス形式** (200):
+
+```json
+{
+  "total_count": 2,
+  "installations": [
+    {
+      "id": 1,
+      "account": {
+        "login": "octocat",
+        "id": 1,
+        "type": "User"
+      },
+      "app_id": 1,
+      "target_id": 1,
+      "target_type": "Organization",
+      "permissions": {
+        "checks": "write",
+        "metadata": "read",
+        "contents": "read"
+      },
+      "events": ["push", "pull_request"],
+      "repository_selection": "all",
+      "created_at": "2017-07-08T16:18:44-04:00",
+      "updated_at": "2017-07-08T16:18:44-04:00",
+      "app_slug": "github-actions",
+      "suspended_at": null,
+      "suspended_by": null
+    }
+  ]
+}
+```
+
+**エラーレスポンス**:
+
+| ステータス | 説明 |
+|---|---|
+| 200 | 成功 |
+| 304 | Not Modified（ETag/Last-Modified キャッシュ） |
+| 401 | 認証が必要（トークン無効/期限切れ） |
+| 403 | 禁止（レートリミット超過を含む） |
+
+**重要なフィールド**:
+- `installations[].id` — installation_id。次の API 呼び出しに使用
+- `installations[].account.login` — インストール先のアカウント名
+- `installations[].repository_selection` — `"all"` または `"selected"`（全リポジトリ or 選択リポジトリ）
+- `installations[].app_id` — BoardFlow の App ID と一致するものだけ処理すべき
+- `installations[].suspended_at` — null でなければサスペンド中
+
+### 2. GET /user/installations/{installation_id}/repositories — インストール経由でアクセス可能なリポジトリ一覧
+
+**エンドポイント**: `GET /user/installations/{installation_id}/repositories`
+
+**認証**: GitHub App user access token（Bearer token）。`metadata` リポジトリパーミッション（read）が必要。
+
+**説明**: 指定インストールに対してユーザーが明示的パーミッションを持つリポジトリの一覧を返す。
+
+**パスパラメータ**:
+
+| パラメータ | 型 | 説明 |
+|---|---|---|
+| `installation_id` | integer | インストールの一意識別子（必須） |
+
+**クエリパラメータ**:
+
+| パラメータ | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `per_page` | integer | 30 | ページあたりの結果数（最大100） |
+| `page` | integer | 1 | フェッチするページ番号 |
+
+**レスポンス形式** (200):
+
+```json
+{
+  "total_count": 1,
+  "repositories": [
+    {
+      "id": 1296269,
+      "node_id": "MDEwOlJlcG9zaXRvcnkxMjk2MjY5",
+      "name": "Hello-World",
+      "full_name": "octocat/Hello-World",
+      "owner": {
+        "login": "octocat",
+        "id": 1
+      },
+      "private": false,
+      "html_url": "https://github.com/octocat/Hello-World",
+      "visibility": "public",
+      "permissions": {
+        "admin": false,
+        "push": false,
+        "pull": true
+      }
+    }
+  ]
+}
+```
+
+**エラーレスポンス**:
+
+| ステータス | 説明 |
+|---|---|
+| 200 | 成功 |
+| 304 | Not Modified |
+| 403 | 禁止 |
+| 404 | インストールが見つからない、またはアクセス権なし |
+
+**重要なフィールド**:
+- `repositories[].id` — GitHub repository ID（`github_repository_id` として DB に保存）
+- `repositories[].full_name` — `"owner/name"` 形式。`split_once('/')` で owner と name を分離可能
+- `repositories[].owner.login` — リポジトリオーナー名
+- `repositories[].name` — リポジトリ名
+
+### 3. ページネーション
+
+両APIとも標準的な GitHub ページネーション:
+- `per_page` 最大100、デフォルト30
+- `page` パラメータでページ指定
+- `Link` レスポンスヘッダに `rel="next"`, `rel="last"` が含まれる
+- `total_count` フィールドで総数を事前取得可能
+
+**BoardFlow 実装**: `per_page=100` を指定し、`total_count` と取得済み件数を比較してループするか、`repos.len() < 100` で打ち切る（既存の `list_accessible_repo_ids` と同じパターン）。
+
+### 4. レートリミット
+
+| 認証方式 | 制限 |
+|---|---|
+| User access token（OAuth） | 5,000 req/h（ユーザー単位で共有） |
+| GitHub Enterprise Cloud | 15,000 req/h |
+
+**API コール消費の見積もり**:
+- `GET /user/installations`: 1回（通常1ページで収まる。BoardFlow App のインストールは多くて数個）
+- `GET /user/installations/{id}/repositories`: インストールごとに ceil(repos / 100) 回
+- 典型的なケース: 1 installation × 10 repos = **2 API コール**
+- 最悪ケース: 3 installations × 500 repos each = **18 API コール**
+
+BoardFlow は既に `list_accessible_repo_ids` で `/user/repos` を全ページ取得しており、そちらのコストのほうが大きい。フォールバック同期が追加するコストは限定的。
+
+### 5. `GET /user/repos` との違い
+
+| 特性 | `/user/repos` | `/user/installations/{id}/repositories` |
+|---|---|---|
+| 範囲 | ユーザーがアクセスできる全リポジトリ | 特定 installation に紐づくリポジトリのみ |
+| installation_id | 取得不可 | パスパラメータから確定 |
+| 用途 | アクセス可能リポジトリの権限チェック | Webhook 不着時のリポジトリ同期 |
+
+**重要**: `/user/repos` のレスポンスには `installation_id` が含まれない。`repositories` テーブルの `installation_id` カラムを埋めるには、`/user/installations/{id}/repositories` を使う必要がある。
+
+## BoardFlow への示唆
+
+### フォールバック同期の発火タイミング
+
+`CachedGithubAccessChecker::list_accessible_repo_ids` のフロー内で、GitHub API から返った `repo_id` 群と DB の `repositories` テーブルを比較し、DB に存在しない `repo_id` が見つかった場合にフォールバック同期を発火する設計が妥当。
+
+**提案フロー**:
+1. 既存通り `/user/repos` で `accessible_repo_ids: Vec<i64>` を取得
+2. DB から `SELECT github_repository_id FROM repositories WHERE github_repository_id = ANY($1)` で既存 ID を取得
+3. 差分（DB に未登録の ID）が存在する場合:
+   a. `GET /user/installations?per_page=100` で BoardFlow App のインストール一覧を取得
+   b. 各 installation_id に対して `GET /user/installations/{id}/repositories?per_page=100` で repos を取得
+   c. 取得した repos を `boardflow_db::queries::repository::upsert` で DB に同期
+4. 差分がなければ同期スキップ
+
+### キャッシュ/スロットル設計
+
+- 同期頻度制限: `github_api_cache` テーブルに `cache_type = "installation_repos_sync"` として最終同期時刻を記録、TTL 10分
+- TTL 内は差分があってもフォールバック同期をスキップ
+- ユーザーごとに独立したスロットル（既存の `user_id` + `cache_type` の複合キー設計を活用）
+
+### app_id フィルタリング
+
+`GET /user/installations` は該当ユーザーがアクセスできる**すべての** GitHub App のインストールを返す。BoardFlow 以外の App のインストールも含まれるため、`installations[].app_id` が BoardFlow の App ID と一致するものだけを処理すべき。
+
+### suspended インストールの除外
+
+`installations[].suspended_at` が null でないインストールはサスペンド中であり、リポジトリ取得がエラーになる可能性がある。フィルタリングで除外すべき。
+
+## 採用/不採用判断
+
+**採用**: `GET /user/installations` + `GET /user/installations/{installation_id}/repositories` によるフォールバック同期
+
+**理由**:
+1. ユーザーの OAuth トークンで呼べるため、追加の認証情報が不要
+2. `installation_id` を含むリポジトリ情報が取得でき、既存の upsert 関数をそのまま使える
+3. API コール数が少なく、レートリミットへの影響が限定的
+4. 既存の `github_api_cache` テーブルと `CachedGithubAccessChecker` パターンに自然に統合できる
+
+## 制約と pitfall
+
+1. **レートリミット共有**: user access token のレートリミット（5,000 req/h）は同ユーザーの他のアプリ・PATと共有される。フォールバック同期が他のAPI呼び出しを圧迫しないよう、スロットルが必須
+2. **app_id フィルタ**: `/user/installations` は全 App のインストールを返すため、BoardFlow の app_id 以外を必ずフィルタする
+3. **repository_selection=all**: インストールが "all" の場合、org 内の全リポジトリが返される可能性がある。大量リポジトリの org ではページネーションコストが増加する
+4. **404 の意味**: `/user/installations/{id}/repositories` で 404 が返る場合、そのインストールへのアクセス権がないか、インストールが削除されている。エラーハンドリングが必要
+5. **最終的整合性**: Webhook 到着と API 結果の間にタイムラグがある可能性がある。新規インストール直後は API にまだ反映されていない場合がある
+6. **full_name のパース**: `repositories[].full_name` の `split_once('/')` が失敗するケースは実質ないが、既存の webhook handler と同様にガード処理を入れるべき
+
+## 未解決の疑問
+
+1. BoardFlow の `app_id` をどこから取得するか（環境変数 or DBの設定テーブル）。現在の `crates/github/` のコンフィグ構造を確認する必要がある
+2. フォールバック同期を `CachedGithubAccessChecker` 内で直接行うか、別の `RepositorySyncService` に分離するか。前者は責務が増えるが、フロー制御が簡潔
+3. 同期処理を API リクエストのホットパスで行うか、バックグラウンドジョブとしてキューに投入するか。ユーザー体験としてはホットパスのほうが即時反映されるが、レイテンシが増加する
+
+## 参照URL
+
+- https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-app-installations-accessible-to-the-user-access-token
+- https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-repositories-accessible-to-the-user-access-token
+- https://docs.github.com/en/rest/apps/installations?apiVersion=2022-11-28#list-repositories-accessible-to-the-app-installation
+- https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api
+- https://docs.github.com/en/rest/using-the-rest-api/using-pagination-in-the-rest-api

--- a/docs/logs/77/worklog.md
+++ b/docs/logs/77/worklog.md
@@ -258,3 +258,44 @@ pub struct GithubAppId(pub Option<u64>);
 
 ## 更新した作業ログパス
 `docs/logs/77/worklog.md`
+
+---
+
+## レビュー結果（2026-05-04 review）
+
+### 総評
+- 実装は GitHub App user access token を使った Installed Repositories API フォールバックの大枠を満たしており、`app_id` フィルタ、`suspended_at` 除外、best-effort エラーハンドリング、10分 TTL のスロットルという設計意図には沿っている。
+- ただし、`accessible_repo_ids` の有効キャッシュがある場合にフォールバック判定へ到達しないため、「インストール直後」や「直前に一覧を開いていたユーザー」のケースでは、Webhook 不着時に新規 repo が最大 10 分表示されない。Issue の主目的に対して未充足の経路が残っている。
+- あわせて、計画で明示したフォールバック固有テストとドキュメント更新が未完了で、worklog 上の計画・実装結果との整合も崩れている。
+
+### 指摘事項
+1. 重大: `CachedGithubAccessChecker::list_accessible_repo_ids` は valid cache hit 時に即 return しており、その後段の `maybe_sync_installation_repos` に到達しない。このため、`/user/repos` キャッシュが warm な 10 分間は DB 未登録 repo の検出自体が行われず、Webhook 不着時の repo 一覧復旧が遅延する。Issue 本文の「GitHub Appインストール直後やWebhook不着時にもリポジトリ一覧を表示したい」に対して不十分。該当箇所: `crates/api/src/github_access.rs` の cache early return と fallback 呼び出し位置。
+2. 中: 計画ではフォールバック発火、スロットル、`app_id` フィルタ、`suspended_at` 除外、`github_app_id=None` をカバーするテスト追加を約束しているが、実際の `crates/api/tests/github_cache_test.rs` は既存キャッシュ挙動の確認が中心で、追加されたのはコンストラクタ引数変更の追従のみ。フォールバック固有ロジックの回帰を検知できない。
+3. 中: 計画では `docs/backend/api.md` への動作仕様追記と `README.md` への API サーバーでも `GITHUB_APP_ID` を使う旨の追記を宣言しているが未反映。README は依然として Worker 環境変数の文脈でのみ `GITHUB_APP_ID` を説明しており、運用者が API 側設定漏れを起こしやすい。
+
+### 必須修正
+- cache hit 時でも DB 未登録 repo の検出とフォールバック同期判定ができるようにする。少なくとも `accessible_repo_ids` のキャッシュ値を使って `find_existing_github_ids` とスロットル判定を実行できる構造に改めること。
+- フォールバック固有のテストを追加する。最低限、warm cache 時の欠損 repo 検出、スロットル有効時の非同期スキップ、`app_id` 不一致除外、`suspended_at` 除外、`github_app_id=None` をカバーすること。
+- `README.md` と `docs/backend/api.md` を更新し、API サーバーでも `GITHUB_APP_ID` が必要であることと、一覧 API における best-effort fallback sync の動作を明記すること。
+
+### 任意改善
+- `missing` 判定で `existing.contains(id)` を繰り返しており、大規模 org では O(n^2) になる。`HashSet` 化して判定コストを落とすとよい。
+- `reqwest::Client::new()` を毎回生成せず、checker がクライアントを保持する形に寄せると接続再利用とテスト差し替えがしやすい。
+- フォールバック実行ログに `app_id` や relevant installation 件数も出すと運用時に原因追跡しやすい。
+
+### テスト結果
+- `mise exec -- cargo test -p boardflow-api --test github_cache_test`: 17 passed
+- 近傍テストは成功したが、フォールバック固有ケースの検証は含まれていない。
+
+### ドキュメント確認
+- `README.md`: `GITHUB_APP_ID` は Worker 環境変数としてのみ記載されている。
+- `docs/backend/api.md`: fallback sync の仕様記載なし。
+- `docs/external/github-user-installations-api.md`: 調査内容は今回の実装方針と整合している。
+
+### PR/完了結果
+- `pr_ready: false`
+- 理由: Issue #77 の主目的に対する warm cache 経路の機能欠落、フォールバック固有テスト不足、計画済み docs 更新未完了があるため。
+
+### 残リスク
+- warm cache 問題を修正しても、ホットパス同期のため大規模 org ではレイテンシ増加余地が残る。
+- webhook と fallback sync の最終整合性は eventual consistency であり、完全即時反映は保証できない。

--- a/docs/logs/77/worklog.md
+++ b/docs/logs/77/worklog.md
@@ -222,5 +222,39 @@ pub struct GithubAppId(pub Option<u64>);
 
 ---
 
+## 実装結果（2026-05-04）
+
+### 実装内容
+
+計画通りに全4ステップを実装完了。
+
+| ファイル | 変更内容 |
+|---|---|
+| `crates/db/src/queries/repository.rs` | `find_existing_github_ids` クエリ追加 |
+| `crates/config/src/app.rs` | `github_app_id: Option<u64>` フィールド追加、`GITHUB_APP_ID` 環境変数読み取り |
+| `crates/api/src/lib.rs` | `GithubAppId(pub Option<u64>)` newtype追加、`create_app_with_config` に引数追加、Extension layer追加 |
+| `crates/api/src/github_access.rs` | `CachedGithubAccessChecker` に `github_app_id` フィールド追加、`maybe_sync_installation_repos` メソッド追加、ヘルパーメソッド `fetch_user_installations` / `fetch_installation_repos` 追加、デシリアライズ構造体追加 |
+| `crates/api/src/main.rs` | `config.github_app_id` を `create_app_with_config` に渡す |
+| `crates/api/tests/github_cache_test.rs` | `new()` / `with_inner()` 呼び出しに `None` 引数追加 |
+| `crates/api/tests/api_token_test.rs` | `create_app_with_config` 呼び出しに `None` 引数追加 |
+| `crates/api/tests/read_api_test.rs` | `create_app_with_config` 呼び出しに `None` 引数追加 |
+| `crates/api/tests/webhook_test.rs` | `create_app_with_config` 呼び出しに `None` 引数追加 |
+| `crates/api/tests/proxy_test.rs` | `create_app_with_config` 呼び出しに `None` 引数追加 |
+
+### テスト結果
+- `cargo check --workspace`: 成功（コンパイルエラーなし）
+- 既存テストのシグネチャ変更: 全て `None` を追加引数として渡す形で修正済み
+- フォールバック同期ロジックは `github_app_id = None` の場合に即リターンするため、既存テスト動作に影響なし
+
+### ドキュメント
+- `docs/external/github-user-installations-api.md`: リサーチエージェントにより作成済み（APIリファレンス・設計方針）
+
+### 残リスク
+- フォールバック同期の統合テスト（実GitHub APIを使うため、mockサーバーの導入が望ましい）
+- `GITHUB_APP_ID` が本番環境で未設定の場合、フォールバック同期がサイレントにスキップされる
+- 大量リポジトリ org でのレイテンシ増加（best-effort だが数百msのレイテンシ追加の可能性）
+
+---
+
 ## 更新した作業ログパス
 `docs/logs/77/worklog.md`

--- a/docs/logs/77/worklog.md
+++ b/docs/logs/77/worklog.md
@@ -377,3 +377,45 @@ pub struct GithubAppId(pub Option<u64>);
 ### 残リスク
 - GitHub API の成功系をモックしていないため、実環境でのみ顕在化する integration mismatch が残る。
 - 認証前提を誤って運用すると、コードが正しくても fallback sync が恒常的に発火失敗する可能性がある。
+
+---
+
+## レビュー結果（2026-05-04 review 3）
+
+### 総評
+- Issue #77 の受け入れ条件、research、実装、テスト、ドキュメントを再照合した結果、前回までの指摘だった warm cache 経路、成功系テスト不足、README / backend docs の更新漏れは解消済み。
+- `CachedGithubAccessChecker::list_accessible_repo_ids` は cache hit / miss の両経路で `maybe_sync_installation_repos` に到達し、`app_id` フィルタ、`suspended_at` 除外、best-effort エラーハンドリング、10 分スロットルの要件とも整合している。
+- worklog、README、`docs/backend/api.md`、`docs/external/github-user-installations-api.md` の記述も今回の実装状態と矛盾していない。
+
+### 指摘事項
+- 重大な残指摘なし。
+
+### 必須修正
+- なし。
+
+### 任意改善
+- フォールバック同期の observability を上げるなら、skip 理由と relevant installation 件数を structured log に出すと運用時に追跡しやすい。
+
+### テスト不足
+- blocking ではないが、`GET /api/v1/repositories` エンドポイントを実際に叩き、fallback sync 後の一覧反映まで含めた HTTP レベルの統合確認があると回帰耐性はさらに上がる。
+
+### ドキュメント更新漏れ
+- なし。
+
+### plan / research / docs との不整合
+- なし。
+
+### テスト結果
+- `mise exec -- cargo test -p boardflow-api --test github_cache_test`: 26 passed
+- `mise exec -- cargo check --workspace`: 成功
+- 参考: 素の `cargo` では edition2024 非対応のため失敗し、リポジトリ前提どおり `mise exec -- cargo ...` が必要
+
+### PR/完了結果
+- `pr_ready: true`
+
+### 残リスク
+- 大規模 org では fallback sync がリクエスト内で動くため、ページ数に応じて一覧 API のレイテンシが伸びる余地は残る。
+- `GITHUB_APP_ID` や GitHub App user access token 前提が本番で満たされない場合、機能は degraded で動作するが fallback 自体は有効化されない。
+
+### 更新した作業ログパス
+- `docs/logs/77/worklog.md`

--- a/docs/logs/77/worklog.md
+++ b/docs/logs/77/worklog.md
@@ -419,3 +419,27 @@ pub struct GithubAppId(pub Option<u64>);
 
 ### 更新した作業ログパス
 - `docs/logs/77/worklog.md`
+
+---
+
+## PR/完了結果（2026-05-04 pr）
+
+### PR作成
+- **PR URL**: https://github.com/f0reachARR/boardflow/pull/82
+- **タイトル**: feat(#77): Webhook不着時のリポジトリ一覧取得: Installation Repos APIフォールバック
+- **ベース**: main
+- **ラベル**: bug, backend, api
+- **Closes**: #77
+
+### 最終確認
+- review: `pr_ready: true`（review 3）
+- docs: `docs_ready: true`
+- 未コミット変更: なし（worklog review 3 追記をコミット後プッシュ）
+- テスト: `cargo test -p boardflow-api --test github_cache_test` 26件全パス
+
+### 残リスク
+- 大規模 org では fallback sync がホットパスで動くため、ページ数に応じて一覧 API のレイテンシが伸びる余地あり（将来的にバックグラウンドジョブ化で対応可能）
+- `GITHUB_APP_ID` 未設定または GitHub App user access token 前提が本番で満たされない場合、fallback sync は有効化されないが既存動作への影響はない
+
+### 更新した作業ログパス
+- `docs/logs/77/worklog.md`

--- a/docs/logs/77/worklog.md
+++ b/docs/logs/77/worklog.md
@@ -17,9 +17,210 @@
 - ラベル: bug, backend, api
 - 新規作成
 
+## 調査結果（2026-05-04 リサーチエージェント追記）
+
+### 1. GET /user/installations
+
+- **認証**: GitHub App user access token（Bearer token）。追加パーミッション不要
+- **レスポンス**: `{ total_count, installations: [...] }`
+- **主要フィールド**: `installations[].id`（installation_id）、`installations[].app_id`、`installations[].repository_selection`（"all" or "selected"）、`installations[].suspended_at`
+- **ページネーション**: `per_page` 最大100、`page` パラメータ。BoardFlow App インストールは通常1ページで収まる
+- **ステータス**: 200, 304, 401, 403
+- **注意**: 全 GitHub App のインストールが返る → `app_id` で BoardFlow のものだけフィルタ必須
+
+### 2. GET /user/installations/{installation_id}/repositories
+
+- **認証**: GitHub App user access token。`metadata` リポジトリパーミッション（read）が必要
+- **レスポンス**: `{ total_count, repositories: [...] }`
+- **主要フィールド**: `repositories[].id`（github_repository_id）、`repositories[].full_name`（"owner/name"）、`repositories[].owner.login`、`repositories[].name`
+- **ページネーション**: `per_page` 最大100、`page` パラメータ
+- **ステータス**: 200, 304, 403, 404
+- **注意**: 404 = インストールへのアクセス権なし or 削除済み
+
+### 3. 実装方針の要点
+
+- **フォールバック発火条件**: `list_accessible_repo_ids` が返した `repo_id` 群と DB の `repositories` テーブルを比較し、DB 未登録の ID が存在する場合に同期発火
+- **フロー**: `/user/installations?per_page=100` → `app_id` フィルタ → 各 installation_id に対して `/user/installations/{id}/repositories?per_page=100` → `repository::upsert`
+- **スロットル**: `github_api_cache` テーブルに `cache_type = "installation_repos_sync"` として最終同期時刻を記録、TTL 10分で再同期を防ぐ
+- **API コスト**: 典型 2 コール（1 installations + 1 repos）。最悪でも 20 コール以内
+- **レートリミット**: user access token で 5,000 req/h 共有。フォールバック同期の追加コストは限定的
+- **`/user/repos` との違い**: `/user/repos` には `installation_id` が含まれないため、`repositories` テーブルの upsert には `/user/installations/{id}/repositories` が必須
+
+### 4. 既存コードとの統合ポイント
+
+- `CachedGithubAccessChecker`（`crates/api/src/github_access.rs`）の `list_accessible_repo_ids` 内で差分検出 → フォールバック発火
+- `boardflow_db::queries::repository::upsert(pool, github_repository_id, owner, name, installation_id)` をそのまま再利用可能
+- `github_api_cache` テーブルの `upsert_cache(user_id, "installation_repos_sync", ...)` でスロットル制御
+
+### 5. 制約と pitfall
+
+1. `app_id` フィルタ忘れると他 App のインストールを処理してしまう
+2. `repository_selection = "all"` の org インストールでは大量リポジトリが返る可能性
+3. `suspended_at` が non-null のインストールは除外すべき
+4. 同期処理をホットパスで行うとレイテンシ増加（バックグラウンドジョブも選択肢）
+5. `full_name` の `split_once('/')` 失敗ケースへのガード処理
+
+### 6. 未解決の疑問
+
+1. BoardFlow の `app_id` の取得元（環境変数 or config crate）
+2. 同期を `CachedGithubAccessChecker` 内で行うか、別 Service に分離するか
+3. ホットパス同期 vs バックグラウンドジョブ投入の判断
+
+### 詳細ドキュメント
+
+→ `docs/external/github-user-installations-api.md`
+
 ## 後続処理タイプ
 `implementation_required`
 
-## 残リスク
-- レートリミットへの影響
-- ユーザーの Installation へのアクセス権限の正確な判定
+---
+
+## 実装計画（2026-05-04 planエージェント策定）
+
+### 目的
+- Webhook が不着の場合でも、GitHub App がインストール済みのリポジトリ一覧を `repositories` テーブルに同期し、ユーザーがリポジトリ一覧を閲覧できるようにする
+
+### 非目的
+- Webhook 処理の変更・修正
+- バックグラウンドジョブによる非同期同期（今後のオプション。本Issue ではホットパス同期のみ）
+- GitHub App Installation Token を使ったサーバー間同期
+- `repository_selection = "all"` の org で全リポジトリを自動的に追加すること（アクセス可能な repo のみ）
+
+### 受け入れ条件
+1. `list_repositories` API で、Webhook 未受信でもインストール済みリポジトリが表示される
+2. フォールバック同期は 10分間に1回までスロットルされる
+3. レートリミット時にフォールバック同期はスキップされ、既存動作に影響しない
+4. `suspended_at` が non-null のインストールは除外される
+5. `GITHUB_APP_ID` 未設定時はフォールバック同期をスキップする（degraded動作）
+6. 既存テストが壊れない
+
+### 詳細要件
+
+#### フォールバック発火条件
+- `CachedGithubAccessChecker.list_accessible_repo_ids()` が `Ok(Some(ids))` を返した後
+- `ids` のうち DB `repositories` テーブルに存在しない ID が 1 件以上ある
+- `github_api_cache` の `cache_type = "installation_repos_sync"` エントリが期限切れ（TTL 10分）
+
+#### フォールバック同期フロー
+1. `GET /user/installations?per_page=100` を呼ぶ（ユーザーの OAuth token）
+2. レスポンスから `app_id == GITHUB_APP_ID` かつ `suspended_at == null` のインストールのみ抽出
+3. 各インストール ID に対して `GET /user/installations/{id}/repositories?per_page=100` を呼ぶ（ページング対応）
+4. 各リポジトリについて `repository::upsert(pool, github_repository_id, owner, name, installation_id)` を実行
+5. `github_api_cache` に `cache_type = "installation_repos_sync"` を TTL 600秒で upsert
+
+#### エラーハンドリング
+- GitHub API が 401/403/429 を返した場合 → フォールバック同期を中断し、元の `list_accessible_repo_ids` の結果をそのまま返す（エラーは伝搬しない）
+- DB 更新失敗 → ログ出力して続行
+- `full_name` の `split_once('/')` 失敗 → そのリポジトリをスキップ
+
+### 影響範囲
+| ファイル | 変更内容 |
+|---|---|
+| `crates/config/src/app.rs` | `github_app_id: Option<u64>` フィールド追加 |
+| `crates/api/src/lib.rs` | `GithubAppId` Extension 追加・注入 |
+| `crates/api/src/github_access.rs` | `CachedGithubAccessChecker` にフォールバック同期ロジック追加 |
+| `crates/db/src/queries/repository.rs` | `find_existing_github_ids(pool, ids) -> Vec<i64>` クエリ追加 |
+| `crates/api/tests/github_cache_test.rs` | フォールバック同期のユニットテスト追加 |
+
+### 設計方針
+
+#### 1. `AppConfig` に `github_app_id` 追加
+```rust
+// crates/config/src/app.rs
+pub struct AppConfig {
+    // ...existing fields...
+    pub github_app_id: Option<u64>,
+}
+```
+環境変数 `GITHUB_APP_ID` から取得。Worker の既存パターンを踏襲。
+
+#### 2. `CachedGithubAccessChecker` の拡張
+```rust
+pub struct CachedGithubAccessChecker {
+    inner: Arc<dyn GithubAccessChecker>,
+    pool: sqlx::PgPool,
+    github_app_id: Option<u64>,  // 追加
+}
+```
+- `new()` と `with_inner()` に `github_app_id: Option<u64>` 引数追加
+- `list_accessible_repo_ids` 内で成功後にフォールバック同期判定を実行
+
+#### 3. フォールバック同期ロジック（`CachedGithubAccessChecker` 内のプライベートメソッド）
+```rust
+async fn maybe_sync_installation_repos(
+    &self,
+    github_access_token: &str,
+    user_id: Uuid,
+    accessible_ids: &[i64],
+) -> () { /* best-effort, never returns error */ }
+```
+- `github_app_id` が `None` → 即リターン
+- DB に存在しない ID が 0 件 → 即リターン
+- スロットルチェック（`get_valid_cache` で `installation_repos_sync` が有効なら）→ 即リターン
+- 上記すべてパスしたら GitHub API を呼んで upsert
+
+#### 4. `find_existing_github_ids` クエリ
+```rust
+pub async fn find_existing_github_ids(
+    executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
+    github_ids: &[i64],
+) -> Result<Vec<i64>, sqlx::Error> {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT github_repository_id FROM repositories WHERE github_repository_id = ANY($1)"
+    )
+    .bind(github_ids)
+    .fetch_all(executor)
+    .await
+}
+```
+
+#### 5. `lib.rs` での注入
+```rust
+#[derive(Clone)]
+pub struct GithubAppId(pub Option<u64>);
+
+// create_app_with_config に github_app_id: Option<u64> パラメータ追加
+// CachedGithubAccessChecker::new(pool, github_app_id) に変更
+```
+
+### テスト観点
+
+1. **フォールバック発火テスト**: DB に repo が存在しない場合に同期が実行されることを確認
+2. **スロットルテスト**: 10分以内の再同期がスキップされることを確認
+3. **app_id フィルタテスト**: 異なる app_id のインストールが無視されることを確認
+4. **suspended インストール除外テスト**: `suspended_at` が設定されたインストールが無視されることを確認
+5. **エラー耐性テスト**: GitHub API エラー時に元の結果がそのまま返ることを確認
+6. **github_app_id 未設定テスト**: `None` 時にフォールバックがスキップされることを確認
+7. **既存テスト回帰**: `CachedGithubAccessChecker::new` のシグネチャ変更に伴うテスト修正
+
+### ドキュメント更新対象
+- `docs/backend/api.md` — フォールバック同期の動作仕様を追記
+- `README.md` — `GITHUB_APP_ID` が API サーバーでも使用される旨を追記（現在は Worker 用のみ記載）
+
+### 実装順序
+1. `crates/db/src/queries/repository.rs` — `find_existing_github_ids` 追加
+2. `crates/config/src/app.rs` — `github_app_id` フィールド追加
+3. `crates/api/src/lib.rs` — `GithubAppId` Extension と `CachedGithubAccessChecker` 初期化変更
+4. `crates/api/src/github_access.rs` — フォールバック同期ロジック実装
+5. `crates/api/tests/github_cache_test.rs` — テスト追加
+6. ドキュメント更新
+
+### 実装要否
+`implementation_required`
+
+### 未解決の疑問と解消結果
+| 疑問 | 解消方法 | 結論 |
+|---|---|---|
+| `app_id` の取得元 | コード調査 | `GITHUB_APP_ID` 環境変数。Worker で既に `Optional<u64>` として読み込み済み。API 側の `AppConfig` に同じパターンで追加 |
+| 同期を Checker 内で行うか別 Service か | 設計判断 | `CachedGithubAccessChecker` 内のプライベートメソッドとして実装（単一責任の観点では分離が望ましいが、DI の複雑化を避けるため最小変更を優先） |
+| ホットパス vs バックグラウンドジョブ | Issue 本文の指示 | ホットパス（同一リクエスト内）。best-effort で失敗しても元のレスポンスは返す |
+
+### 残リスク
+- 大量リポジトリ org でのレイテンシ増加（ページングで最大数百ms追加。将来的にバックグラウンドジョブ化で対応可能）
+- `per_page=100` で収まらない org のリポジトリは複数ページ取得が必要（実装でページング対応する）
+- レートリミット 5,000 req/h のうちフォールバック同期分の消費（スロットル 10分で最大 6回/h × 2-3 API calls = 12-18 req/h。影響は限定的）
+
+---
+
+## 更新した作業ログパス
+`docs/logs/77/worklog.md`

--- a/docs/logs/77/worklog.md
+++ b/docs/logs/77/worklog.md
@@ -299,3 +299,45 @@ pub struct GithubAppId(pub Option<u64>);
 ### 残リスク
 - warm cache 問題を修正しても、ホットパス同期のため大規模 org ではレイテンシ増加余地が残る。
 - webhook と fallback sync の最終整合性は eventual consistency であり、完全即時反映は保証できない。
+
+---
+
+## レビュー結果（2026-05-04 review 2）
+
+### 総評
+- 前回の重大指摘だった warm cache 経路は修正され、`CachedGithubAccessChecker::list_accessible_repo_ids` の valid cache hit でも `maybe_sync_installation_repos` を通るようになったため、Issue #77 の主目的に対する制御フロー上の欠落は解消されている。
+- その一方で、今回の追加テストはフォールバックのスキップ条件に偏っており、GitHub API 取得 → app_id / suspended フィルタ → `repository::upsert` までの成功系が未検証のまま残っている。
+- あわせて、恒久ドキュメントと認証前提の表現にズレが残っており、運用者が必要な GitHub App 前提を誤解する余地がある。
+
+### 指摘事項
+1. 中: フォールバック成功系の中核ロジックが依然として自動テストで担保されていない。今回追加されたテストは `github_app_id=None`、全 repo 既存、スロットル有効の skip ケースに集中しており、`fetch_user_installations` / `fetch_installation_repos` / `repository::upsert` を通る成功パス、および計画で明示した `app_id` 不一致除外・`suspended_at` 除外を検証していない。この状態だと、レスポンス shape 変更、ページング、`full_name` パース、upsert 経路の退行を検知できない。
+2. 中: 実装・research・恒久 docs の認証前提がまだ揃っていない。Issue #77 の調査成果物は `GET /user/installations*` を GitHub App user access token 前提で整理している一方、現行の公開 docs と login 実装は GitHub OAuth / OAuth App の表現を維持している。`GITHUB_APP_ID` を API でも使う旨の注記は追加されたが、どの GitHub App 設定と権限が必要なのか、既存の login token がこの API 群を叩ける前提を README / backend docs から読み取れない。
+
+### 必須修正
+- 成功系フォールバックを検証する focused test を追加する。少なくとも 1 件は HTTP 層を差し替えられる形にして、`/user/installations` と `/user/installations/{id}/repositories` の応答から repository upsert まで確認したい。
+- `app_id` 不一致除外と `suspended_at` 除外を plan 通りにテストへ落とし込む。
+- README / `docs/backend/api.md` / research の記述を揃え、Issue #77 のフォールバックが依存する GitHub App 側の前提条件を明記する。
+
+### 任意改善
+- `reqwest::Client` を checker に保持して差し替え可能にすると、成功系テストが容易になる。
+- フォールバック実行ログに relevant installation 件数や skip 理由を出すと運用観測性が上がる。
+
+### テスト結果
+- `mise exec -- cargo test -p boardflow-api --test github_cache_test`: 22 passed
+- `git diff --check main..HEAD`: 問題なし
+
+### ドキュメント確認
+- `README.md` は `GITHUB_APP_ID` の API 側利用を追記しており、前回指摘の docs 更新漏れ自体は解消した。
+- ただし、`GET /user/installations*` を成立させる認証モデルの説明はなお曖昧で、Issue #77 の research と恒久 docs の橋渡しが不足している。
+
+### plan / research / docs との不整合
+- plan では `app_id` フィルタ、`suspended_at` 除外、エラー耐性をテスト観点に含めていたが、現状の追加テストは skip 系 3 件と DB existence query に留まる。
+- research は GitHub App user access token 前提を明記しているが、README / backend docs / login 実装の表現は OAuth App 寄りで、前提の読み取りが一貫していない。
+
+### PR/完了結果
+- `pr_ready: false`
+- 理由: 前回の blocking bug は解消済みだが、Issue #77 の価値そのものである成功系フォールバックが未実証であり、認証前提の docs 整合も不足しているため。
+
+### 残リスク
+- GitHub API の成功系をモックしていないため、実環境でのみ顕在化する integration mismatch が残る。
+- 認証前提を誤って運用すると、コードが正しくても fallback sync が恒常的に発火失敗する可能性がある。

--- a/docs/logs/77/worklog.md
+++ b/docs/logs/77/worklog.md
@@ -243,21 +243,57 @@ pub struct GithubAppId(pub Option<u64>);
 
 ### テスト結果
 - `cargo check --workspace`: 成功（コンパイルエラーなし）
-- 既存テストのシグネチャ変更: 全て `None` を追加引数として渡す形で修正済み
-- フォールバック同期ロジックは `github_app_id = None` の場合に即リターンするため、既存テスト動作に影響なし
+- `cargo test -p boardflow-api --test github_cache_test`: 26テスト全パス
+- `cargo test -p boardflow-api -- --skip test_app_config_from_env`: 全テストパス（223テスト）
+- wiremockによる成功系フォールバックテスト: `test_fallback_sync_success_upserts_repos`, `test_fallback_sync_filters_wrong_app_id`, `test_fallback_sync_filters_suspended_installations`, `test_fallback_sync_github_api_error_graceful`
+- スキップ系テスト: `test_fallback_sync_skipped_when_app_id_none`, `test_fallback_sync_skipped_when_all_repos_exist`, `test_fallback_sync_skipped_when_throttled`
+- DBクエリテスト: `test_find_existing_github_ids`, `test_find_existing_github_ids_empty_input`
 
 ### ドキュメント
 - `docs/external/github-user-installations-api.md`: リサーチエージェントにより作成済み（APIリファレンス・設計方針）
+- `docs/backend/api.md`: Section 1.2.1 に fallback sync 仕様追記
+- `README.md`: GITHUB_APP_ID のAPI側使用について Note 追記
 
 ### 残リスク
-- フォールバック同期の統合テスト（実GitHub APIを使うため、mockサーバーの導入が望ましい）
-- `GITHUB_APP_ID` が本番環境で未設定の場合、フォールバック同期がサイレントにスキップされる
 - 大量リポジトリ org でのレイテンシ増加（best-effort だが数百msのレイテンシ追加の可能性）
+- `GITHUB_APP_ID` が本番環境で未設定の場合、フォールバック同期がサイレントにスキップされる（意図的な設計）
 
 ---
 
 ## 更新した作業ログパス
 `docs/logs/77/worklog.md`
+
+---
+
+## ドキュメント確認（2026-05-04 docsエージェント）
+
+### 対象 Issue
+- #77: Webhook不着時のリポジトリ一覧取得: Installed Repositories APIフォールバック
+
+### 確認結果
+- `README.md` の `GITHUB_APP_ID` Note は実装と整合している
+- `docs/backend/api.md` の Section 1.2.1 は実装と整合している
+- `docs/external/github-user-installations-api.md` の調査内容は実装方針と整合している
+- `docs/logs/77/worklog.md` は一部不整合あり
+
+### 不整合の詳細
+- `テスト結果` に `cargo check --workspace` のみが記載されており、実装概要にある wiremock 成功系テストの追加状況を反映できていない
+- `残リスク` に「mockサーバーの導入が望ましい」とあるが、実装には `wiremock` を使った成功系テストが既に存在するため記述が古い
+- `docs/logs/77/worklog.md` 内の earlier note では成功系テストが未整備である前提の記述が残っている
+
+### 必須修正
+- `docs/logs/77/worklog.md` の `テスト結果` を、Issue #77 で追加されたフォールバック同期テスト群の実態に合わせて更新する
+- `docs/logs/77/worklog.md` の `残リスク` から、mockサーバー未導入を前提とする古い記述を修正または削除する
+
+### 任意改善
+- `docs/logs/77/worklog.md` に、フォールバック同期が cache hit / cache miss の両経路で判定されることを明記すると、後続レビューで実装意図を追いやすい
+
+### PR/完了結果
+- `docs_ready: false`
+
+### レビュー結果
+- README / backend API spec / external research は PR 作成を阻害する不整合なし
+- 作業ログのみ、現在の実装・テスト状況を正確に表していないため修正が必要
 
 ---
 

--- a/docs/logs/77/worklog.md
+++ b/docs/logs/77/worklog.md
@@ -1,18 +1,22 @@
 # Issue #77: Webhook不着時のリポジトリ一覧取得: Installed Repositories APIフォールバック
 
 ## 経緯
+
 - ユーザー要望4: Webhookが不着の場合にリポジトリ一覧が表示されない
 
 ## ユーザー要望
+
 - GitHub Appインストール直後やWebhook不着時にもリポジトリ一覧を表示したい
 
 ## 調査結果
+
 - 現在: Webhook (`installation`/`installation_repositories` イベント) 経由でのみDBにリポジトリが登録される
 - `routes/webhook.rs`: `handle_installation_event` / `handle_installation_repositories_event` でupsert
 - GitHub API: `GET /installation/repositories` (Installation Token), `GET /user/installations/{id}/repositories` (User Token)
 - `CachedGithubAccessChecker` が既存のキャッシュ機構として存在
 
 ## Issue作成内容
+
 - タイトル: Webhook不着時のリポジトリ一覧取得: Installed Repositories APIフォールバック
 - ラベル: bug, backend, api
 - 新規作成
@@ -71,6 +75,7 @@
 → `docs/external/github-user-installations-api.md`
 
 ## 後続処理タイプ
+
 `implementation_required`
 
 ---
@@ -78,15 +83,18 @@
 ## 実装計画（2026-05-04 planエージェント策定）
 
 ### 目的
+
 - Webhook が不着の場合でも、GitHub App がインストール済みのリポジトリ一覧を `repositories` テーブルに同期し、ユーザーがリポジトリ一覧を閲覧できるようにする
 
 ### 非目的
+
 - Webhook 処理の変更・修正
 - バックグラウンドジョブによる非同期同期（今後のオプション。本Issue ではホットパス同期のみ）
 - GitHub App Installation Token を使ったサーバー間同期
 - `repository_selection = "all"` の org で全リポジトリを自動的に追加すること（アクセス可能な repo のみ）
 
 ### 受け入れ条件
+
 1. `list_repositories` API で、Webhook 未受信でもインストール済みリポジトリが表示される
 2. フォールバック同期は 10分間に1回までスロットルされる
 3. レートリミット時にフォールバック同期はスキップされ、既存動作に影響しない
@@ -97,11 +105,13 @@
 ### 詳細要件
 
 #### フォールバック発火条件
+
 - `CachedGithubAccessChecker.list_accessible_repo_ids()` が `Ok(Some(ids))` を返した後
 - `ids` のうち DB `repositories` テーブルに存在しない ID が 1 件以上ある
 - `github_api_cache` の `cache_type = "installation_repos_sync"` エントリが期限切れ（TTL 10分）
 
 #### フォールバック同期フロー
+
 1. `GET /user/installations?per_page=100` を呼ぶ（ユーザーの OAuth token）
 2. レスポンスから `app_id == GITHUB_APP_ID` かつ `suspended_at == null` のインストールのみ抽出
 3. 各インストール ID に対して `GET /user/installations/{id}/repositories?per_page=100` を呼ぶ（ページング対応）
@@ -109,11 +119,13 @@
 5. `github_api_cache` に `cache_type = "installation_repos_sync"` を TTL 600秒で upsert
 
 #### エラーハンドリング
+
 - GitHub API が 401/403/429 を返した場合 → フォールバック同期を中断し、元の `list_accessible_repo_ids` の結果をそのまま返す（エラーは伝搬しない）
 - DB 更新失敗 → ログ出力して続行
 - `full_name` の `split_once('/')` 失敗 → そのリポジトリをスキップ
 
 ### 影響範囲
+
 | ファイル | 変更内容 |
 |---|---|
 | `crates/config/src/app.rs` | `github_app_id: Option<u64>` フィールド追加 |
@@ -125,6 +137,7 @@
 ### 設計方針
 
 #### 1. `AppConfig` に `github_app_id` 追加
+
 ```rust
 // crates/config/src/app.rs
 pub struct AppConfig {
@@ -132,9 +145,11 @@ pub struct AppConfig {
     pub github_app_id: Option<u64>,
 }
 ```
+
 環境変数 `GITHUB_APP_ID` から取得。Worker の既存パターンを踏襲。
 
 #### 2. `CachedGithubAccessChecker` の拡張
+
 ```rust
 pub struct CachedGithubAccessChecker {
     inner: Arc<dyn GithubAccessChecker>,
@@ -142,10 +157,12 @@ pub struct CachedGithubAccessChecker {
     github_app_id: Option<u64>,  // 追加
 }
 ```
+
 - `new()` と `with_inner()` に `github_app_id: Option<u64>` 引数追加
 - `list_accessible_repo_ids` 内で成功後にフォールバック同期判定を実行
 
 #### 3. フォールバック同期ロジック（`CachedGithubAccessChecker` 内のプライベートメソッド）
+
 ```rust
 async fn maybe_sync_installation_repos(
     &self,
@@ -154,12 +171,14 @@ async fn maybe_sync_installation_repos(
     accessible_ids: &[i64],
 ) -> () { /* best-effort, never returns error */ }
 ```
+
 - `github_app_id` が `None` → 即リターン
 - DB に存在しない ID が 0 件 → 即リターン
 - スロットルチェック（`get_valid_cache` で `installation_repos_sync` が有効なら）→ 即リターン
 - 上記すべてパスしたら GitHub API を呼んで upsert
 
 #### 4. `find_existing_github_ids` クエリ
+
 ```rust
 pub async fn find_existing_github_ids(
     executor: impl sqlx::Executor<'_, Database = sqlx::Postgres>,
@@ -175,6 +194,7 @@ pub async fn find_existing_github_ids(
 ```
 
 #### 5. `lib.rs` での注入
+
 ```rust
 #[derive(Clone)]
 pub struct GithubAppId(pub Option<u64>);
@@ -194,10 +214,12 @@ pub struct GithubAppId(pub Option<u64>);
 7. **既存テスト回帰**: `CachedGithubAccessChecker::new` のシグネチャ変更に伴うテスト修正
 
 ### ドキュメント更新対象
+
 - `docs/backend/api.md` — フォールバック同期の動作仕様を追記
 - `README.md` — `GITHUB_APP_ID` が API サーバーでも使用される旨を追記（現在は Worker 用のみ記載）
 
 ### 実装順序
+
 1. `crates/db/src/queries/repository.rs` — `find_existing_github_ids` 追加
 2. `crates/config/src/app.rs` — `github_app_id` フィールド追加
 3. `crates/api/src/lib.rs` — `GithubAppId` Extension と `CachedGithubAccessChecker` 初期化変更
@@ -206,9 +228,11 @@ pub struct GithubAppId(pub Option<u64>);
 6. ドキュメント更新
 
 ### 実装要否
+
 `implementation_required`
 
 ### 未解決の疑問と解消結果
+
 | 疑問 | 解消方法 | 結論 |
 |---|---|---|
 | `app_id` の取得元 | コード調査 | `GITHUB_APP_ID` 環境変数。Worker で既に `Optional<u64>` として読み込み済み。API 側の `AppConfig` に同じパターンで追加 |
@@ -216,6 +240,7 @@ pub struct GithubAppId(pub Option<u64>);
 | ホットパス vs バックグラウンドジョブ | Issue 本文の指示 | ホットパス（同一リクエスト内）。best-effort で失敗しても元のレスポンスは返す |
 
 ### 残リスク
+
 - 大量リポジトリ org でのレイテンシ増加（ページングで最大数百ms追加。将来的にバックグラウンドジョブ化で対応可能）
 - `per_page=100` で収まらない org のリポジトリは複数ページ取得が必要（実装でページング対応する）
 - レートリミット 5,000 req/h のうちフォールバック同期分の消費（スロットル 10分で最大 6回/h × 2-3 API calls = 12-18 req/h。影響は限定的）
@@ -242,6 +267,7 @@ pub struct GithubAppId(pub Option<u64>);
 | `crates/api/tests/proxy_test.rs` | `create_app_with_config` 呼び出しに `None` 引数追加 |
 
 ### テスト結果
+
 - `cargo check --workspace`: 成功（コンパイルエラーなし）
 - `cargo test -p boardflow-api --test github_cache_test`: 26テスト全パス
 - `cargo test -p boardflow-api -- --skip test_app_config_from_env`: 全テストパス（223テスト）
@@ -250,17 +276,20 @@ pub struct GithubAppId(pub Option<u64>);
 - DBクエリテスト: `test_find_existing_github_ids`, `test_find_existing_github_ids_empty_input`
 
 ### ドキュメント
+
 - `docs/external/github-user-installations-api.md`: リサーチエージェントにより作成済み（APIリファレンス・設計方針）
 - `docs/backend/api.md`: Section 1.2.1 に fallback sync 仕様追記
 - `README.md`: GITHUB_APP_ID のAPI側使用について Note 追記
 
 ### 残リスク
+
 - 大量リポジトリ org でのレイテンシ増加（best-effort だが数百msのレイテンシ追加の可能性）
 - `GITHUB_APP_ID` が本番環境で未設定の場合、フォールバック同期がサイレントにスキップされる（意図的な設計）
 
 ---
 
 ## 更新した作業ログパス
+
 `docs/logs/77/worklog.md`
 
 ---
@@ -268,30 +297,37 @@ pub struct GithubAppId(pub Option<u64>);
 ## ドキュメント確認（2026-05-04 docsエージェント）
 
 ### 対象 Issue
+
 - #77: Webhook不着時のリポジトリ一覧取得: Installed Repositories APIフォールバック
 
 ### 確認結果
+
 - `README.md` の `GITHUB_APP_ID` Note は実装と整合している
 - `docs/backend/api.md` の Section 1.2.1 は実装と整合している
 - `docs/external/github-user-installations-api.md` の調査内容は実装方針と整合している
 - `docs/logs/77/worklog.md` は一部不整合あり
 
 ### 不整合の詳細
+
 - `テスト結果` に `cargo check --workspace` のみが記載されており、実装概要にある wiremock 成功系テストの追加状況を反映できていない
 - `残リスク` に「mockサーバーの導入が望ましい」とあるが、実装には `wiremock` を使った成功系テストが既に存在するため記述が古い
 - `docs/logs/77/worklog.md` 内の earlier note では成功系テストが未整備である前提の記述が残っている
 
 ### 必須修正
+
 - `docs/logs/77/worklog.md` の `テスト結果` を、Issue #77 で追加されたフォールバック同期テスト群の実態に合わせて更新する
 - `docs/logs/77/worklog.md` の `残リスク` から、mockサーバー未導入を前提とする古い記述を修正または削除する
 
 ### 任意改善
+
 - `docs/logs/77/worklog.md` に、フォールバック同期が cache hit / cache miss の両経路で判定されることを明記すると、後続レビューで実装意図を追いやすい
 
 ### PR/完了結果
+
 - `docs_ready: false`
 
 ### レビュー結果
+
 - README / backend API spec / external research は PR 作成を阻害する不整合なし
 - 作業ログのみ、現在の実装・テスト状況を正確に表していないため修正が必要
 
@@ -300,39 +336,47 @@ pub struct GithubAppId(pub Option<u64>);
 ## レビュー結果（2026-05-04 review）
 
 ### 総評
+
 - 実装は GitHub App user access token を使った Installed Repositories API フォールバックの大枠を満たしており、`app_id` フィルタ、`suspended_at` 除外、best-effort エラーハンドリング、10分 TTL のスロットルという設計意図には沿っている。
 - ただし、`accessible_repo_ids` の有効キャッシュがある場合にフォールバック判定へ到達しないため、「インストール直後」や「直前に一覧を開いていたユーザー」のケースでは、Webhook 不着時に新規 repo が最大 10 分表示されない。Issue の主目的に対して未充足の経路が残っている。
 - あわせて、計画で明示したフォールバック固有テストとドキュメント更新が未完了で、worklog 上の計画・実装結果との整合も崩れている。
 
 ### 指摘事項
+
 1. 重大: `CachedGithubAccessChecker::list_accessible_repo_ids` は valid cache hit 時に即 return しており、その後段の `maybe_sync_installation_repos` に到達しない。このため、`/user/repos` キャッシュが warm な 10 分間は DB 未登録 repo の検出自体が行われず、Webhook 不着時の repo 一覧復旧が遅延する。Issue 本文の「GitHub Appインストール直後やWebhook不着時にもリポジトリ一覧を表示したい」に対して不十分。該当箇所: `crates/api/src/github_access.rs` の cache early return と fallback 呼び出し位置。
 2. 中: 計画ではフォールバック発火、スロットル、`app_id` フィルタ、`suspended_at` 除外、`github_app_id=None` をカバーするテスト追加を約束しているが、実際の `crates/api/tests/github_cache_test.rs` は既存キャッシュ挙動の確認が中心で、追加されたのはコンストラクタ引数変更の追従のみ。フォールバック固有ロジックの回帰を検知できない。
 3. 中: 計画では `docs/backend/api.md` への動作仕様追記と `README.md` への API サーバーでも `GITHUB_APP_ID` を使う旨の追記を宣言しているが未反映。README は依然として Worker 環境変数の文脈でのみ `GITHUB_APP_ID` を説明しており、運用者が API 側設定漏れを起こしやすい。
 
 ### 必須修正
+
 - cache hit 時でも DB 未登録 repo の検出とフォールバック同期判定ができるようにする。少なくとも `accessible_repo_ids` のキャッシュ値を使って `find_existing_github_ids` とスロットル判定を実行できる構造に改めること。
 - フォールバック固有のテストを追加する。最低限、warm cache 時の欠損 repo 検出、スロットル有効時の非同期スキップ、`app_id` 不一致除外、`suspended_at` 除外、`github_app_id=None` をカバーすること。
 - `README.md` と `docs/backend/api.md` を更新し、API サーバーでも `GITHUB_APP_ID` が必要であることと、一覧 API における best-effort fallback sync の動作を明記すること。
 
 ### 任意改善
+
 - `missing` 判定で `existing.contains(id)` を繰り返しており、大規模 org では O(n^2) になる。`HashSet` 化して判定コストを落とすとよい。
 - `reqwest::Client::new()` を毎回生成せず、checker がクライアントを保持する形に寄せると接続再利用とテスト差し替えがしやすい。
 - フォールバック実行ログに `app_id` や relevant installation 件数も出すと運用時に原因追跡しやすい。
 
 ### テスト結果
+
 - `mise exec -- cargo test -p boardflow-api --test github_cache_test`: 17 passed
 - 近傍テストは成功したが、フォールバック固有ケースの検証は含まれていない。
 
 ### ドキュメント確認
+
 - `README.md`: `GITHUB_APP_ID` は Worker 環境変数としてのみ記載されている。
 - `docs/backend/api.md`: fallback sync の仕様記載なし。
 - `docs/external/github-user-installations-api.md`: 調査内容は今回の実装方針と整合している。
 
 ### PR/完了結果
+
 - `pr_ready: false`
 - 理由: Issue #77 の主目的に対する warm cache 経路の機能欠落、フォールバック固有テスト不足、計画済み docs 更新未完了があるため。
 
 ### 残リスク
+
 - warm cache 問題を修正しても、ホットパス同期のため大規模 org ではレイテンシ増加余地が残る。
 - webhook と fallback sync の最終整合性は eventual consistency であり、完全即時反映は保証できない。
 
@@ -341,40 +385,49 @@ pub struct GithubAppId(pub Option<u64>);
 ## レビュー結果（2026-05-04 review 2）
 
 ### 総評
+
 - 前回の重大指摘だった warm cache 経路は修正され、`CachedGithubAccessChecker::list_accessible_repo_ids` の valid cache hit でも `maybe_sync_installation_repos` を通るようになったため、Issue #77 の主目的に対する制御フロー上の欠落は解消されている。
 - その一方で、今回の追加テストはフォールバックのスキップ条件に偏っており、GitHub API 取得 → app_id / suspended フィルタ → `repository::upsert` までの成功系が未検証のまま残っている。
 - あわせて、恒久ドキュメントと認証前提の表現にズレが残っており、運用者が必要な GitHub App 前提を誤解する余地がある。
 
 ### 指摘事項
+
 1. 中: フォールバック成功系の中核ロジックが依然として自動テストで担保されていない。今回追加されたテストは `github_app_id=None`、全 repo 既存、スロットル有効の skip ケースに集中しており、`fetch_user_installations` / `fetch_installation_repos` / `repository::upsert` を通る成功パス、および計画で明示した `app_id` 不一致除外・`suspended_at` 除外を検証していない。この状態だと、レスポンス shape 変更、ページング、`full_name` パース、upsert 経路の退行を検知できない。
 2. 中: 実装・research・恒久 docs の認証前提がまだ揃っていない。Issue #77 の調査成果物は `GET /user/installations*` を GitHub App user access token 前提で整理している一方、現行の公開 docs と login 実装は GitHub OAuth / OAuth App の表現を維持している。`GITHUB_APP_ID` を API でも使う旨の注記は追加されたが、どの GitHub App 設定と権限が必要なのか、既存の login token がこの API 群を叩ける前提を README / backend docs から読み取れない。
 
 ### 必須修正
+
 - 成功系フォールバックを検証する focused test を追加する。少なくとも 1 件は HTTP 層を差し替えられる形にして、`/user/installations` と `/user/installations/{id}/repositories` の応答から repository upsert まで確認したい。
 - `app_id` 不一致除外と `suspended_at` 除外を plan 通りにテストへ落とし込む。
 - README / `docs/backend/api.md` / research の記述を揃え、Issue #77 のフォールバックが依存する GitHub App 側の前提条件を明記する。
 
 ### 任意改善
+
 - `reqwest::Client` を checker に保持して差し替え可能にすると、成功系テストが容易になる。
 - フォールバック実行ログに relevant installation 件数や skip 理由を出すと運用観測性が上がる。
 
 ### テスト結果
+
 - `mise exec -- cargo test -p boardflow-api --test github_cache_test`: 22 passed
 - `git diff --check main..HEAD`: 問題なし
 
 ### ドキュメント確認
+
 - `README.md` は `GITHUB_APP_ID` の API 側利用を追記しており、前回指摘の docs 更新漏れ自体は解消した。
 - ただし、`GET /user/installations*` を成立させる認証モデルの説明はなお曖昧で、Issue #77 の research と恒久 docs の橋渡しが不足している。
 
 ### plan / research / docs との不整合
+
 - plan では `app_id` フィルタ、`suspended_at` 除外、エラー耐性をテスト観点に含めていたが、現状の追加テストは skip 系 3 件と DB existence query に留まる。
 - research は GitHub App user access token 前提を明記しているが、README / backend docs / login 実装の表現は OAuth App 寄りで、前提の読み取りが一貫していない。
 
 ### PR/完了結果
+
 - `pr_ready: false`
 - 理由: 前回の blocking bug は解消済みだが、Issue #77 の価値そのものである成功系フォールバックが未実証であり、認証前提の docs 整合も不足しているため。
 
 ### 残リスク
+
 - GitHub API の成功系をモックしていないため、実環境でのみ顕在化する integration mismatch が残る。
 - 認証前提を誤って運用すると、コードが正しくても fallback sync が恒常的に発火失敗する可能性がある。
 
@@ -383,41 +436,52 @@ pub struct GithubAppId(pub Option<u64>);
 ## レビュー結果（2026-05-04 review 3）
 
 ### 総評
+
 - Issue #77 の受け入れ条件、research、実装、テスト、ドキュメントを再照合した結果、前回までの指摘だった warm cache 経路、成功系テスト不足、README / backend docs の更新漏れは解消済み。
 - `CachedGithubAccessChecker::list_accessible_repo_ids` は cache hit / miss の両経路で `maybe_sync_installation_repos` に到達し、`app_id` フィルタ、`suspended_at` 除外、best-effort エラーハンドリング、10 分スロットルの要件とも整合している。
 - worklog、README、`docs/backend/api.md`、`docs/external/github-user-installations-api.md` の記述も今回の実装状態と矛盾していない。
 
 ### 指摘事項
+
 - 重大な残指摘なし。
 
 ### 必須修正
+
 - なし。
 
 ### 任意改善
+
 - フォールバック同期の observability を上げるなら、skip 理由と relevant installation 件数を structured log に出すと運用時に追跡しやすい。
 
 ### テスト不足
+
 - blocking ではないが、`GET /api/v1/repositories` エンドポイントを実際に叩き、fallback sync 後の一覧反映まで含めた HTTP レベルの統合確認があると回帰耐性はさらに上がる。
 
 ### ドキュメント更新漏れ
+
 - なし。
 
 ### plan / research / docs との不整合
+
 - なし。
 
 ### テスト結果
+
 - `mise exec -- cargo test -p boardflow-api --test github_cache_test`: 26 passed
 - `mise exec -- cargo check --workspace`: 成功
 - 参考: 素の `cargo` では edition2024 非対応のため失敗し、リポジトリ前提どおり `mise exec -- cargo ...` が必要
 
 ### PR/完了結果
+
 - `pr_ready: true`
 
 ### 残リスク
+
 - 大規模 org では fallback sync がリクエスト内で動くため、ページ数に応じて一覧 API のレイテンシが伸びる余地は残る。
 - `GITHUB_APP_ID` や GitHub App user access token 前提が本番で満たされない場合、機能は degraded で動作するが fallback 自体は有効化されない。
 
 ### 更新した作業ログパス
+
 - `docs/logs/77/worklog.md`
 
 ---
@@ -425,21 +489,34 @@ pub struct GithubAppId(pub Option<u64>);
 ## PR/完了結果（2026-05-04 pr）
 
 ### PR作成
-- **PR URL**: https://github.com/f0reachARR/boardflow/pull/82
+
+- **PR URL**: <https://github.com/f0reachARR/boardflow/pull/82>
 - **タイトル**: feat(#77): Webhook不着時のリポジトリ一覧取得: Installation Repos APIフォールバック
 - **ベース**: main
 - **ラベル**: bug, backend, api
 - **Closes**: #77
 
 ### 最終確認
+
 - review: `pr_ready: true`（review 3）
 - docs: `docs_ready: true`
 - 未コミット変更: なし（worklog review 3 追記をコミット後プッシュ）
 - テスト: `cargo test -p boardflow-api --test github_cache_test` 26件全パス
 
 ### 残リスク
+
 - 大規模 org では fallback sync がホットパスで動くため、ページ数に応じて一覧 API のレイテンシが伸びる余地あり（将来的にバックグラウンドジョブ化で対応可能）
 - `GITHUB_APP_ID` 未設定または GitHub App user access token 前提が本番で満たされない場合、fallback sync は有効化されないが既存動作への影響はない
 
 ### 更新した作業ログパス
+
 - `docs/logs/77/worklog.md`
+
+---
+
+## PR作成完了（2026-05-04）
+
+- **PR**: <https://github.com/f0reachARR/boardflow/pull/82>
+- **ブランチ**: `feature/77-installation-repos-fallback`
+- **ステータス**: PR作成完了
+- **Closes**: #77


### PR DESCRIPTION
## 要件

- GitHub App の Webhook (`installation`/`installation_repositories`) が不着の場合でも、ユーザーのリポジトリ一覧 API (`GET /api/v1/repositories`) にアクセスした時点で Installation Repositories API を使ってリポジトリをDBに同期する
- 10分間のスロットル制御で過剰な API 呼び出しを防止
- \`GITHUB_APP_ID\` 未設定時はフォールバック無効（degraded動作）
- エラー時は best-effort（ログ出力して通常のレスポンスを返す）

Closes #77

## 調査結果

- \`GET /user/installations\` で全インストールを取得し、\`app_id\` フィルタ + \`suspended_at\` 除外でBoardFlow対象を絞り込む
- \`GET /user/installations/{id}/repositories\` でリポジトリ一覧を取得し、既存の \`repository::upsert\` で同期
- \`github_api_cache\` テーブルに \`cache_type = "installation_repos_sync"\` で TTL 10分のスロットルを実装
- 詳細: \`docs/external/github-user-installations-api.md\`

## 実装概要

### 主要変更ファイル

| ファイル | 変更内容 |
|---|---|
| \`crates/config/src/app.rs\` | \`github_app_id: Option<u64>\` フィールド追加（\`GITHUB_APP_ID\` 環境変数） |
| \`crates/api/src/lib.rs\` | \`GithubAppId\` newtype + Extension layer注入 |
| \`crates/api/src/github_access.rs\` | \`CachedGithubAccessChecker\` にフォールバック同期ロジック追加（\`maybe_sync_installation_repos\`、\`fetch_user_installations\`、\`fetch_installation_repos\`） |
| \`crates/api/src/main.rs\` | \`config.github_app_id\` を \`create_app_with_config\` に渡す |
| \`crates/db/src/queries/repository.rs\` | \`find_existing_github_ids\` クエリ追加 |
| \`crates/api/Cargo.toml\` | \`wiremock\` dev-dependency追加 |
| \`crates/api/tests/github_cache_test.rs\` | フォールバック同期テスト10件追加 |
| テスト5ファイル | コンストラクタ変更に伴う \`None\` 引数追加 |
| \`README.md\` | \`GITHUB_APP_ID\` の API 側使用 Note 追加 |
| \`docs/backend/api.md\` | Section 1.2.1 fallback sync 仕様追加 |
| \`docs/external/github-user-installations-api.md\` | 新規作成（API調査メモ） |

### フォールバック発火フロー

1. \`list_accessible_repo_ids\` が cache hit / miss にかかわらず \`maybe_sync_installation_repos\` を呼び出す
2. \`find_existing_github_ids\` で DB 未登録 repo ID が存在するか確認
3. \`github_api_cache\` でスロットルチェック（TTL 10分）
4. \`GET /user/installations\` → \`app_id\` フィルタ + \`suspended_at\` 除外 → \`GET /user/installations/{id}/repositories\` → \`repository::upsert\`

## テスト結果

- \`cargo test -p boardflow-api --test github_cache_test\`: **26テスト全パス**
- \`cargo test -p boardflow-api -- --skip test_app_config_from_env\`: **全テストパス**

### 追加テスト内訳

| テスト名 | 種別 |
|---|---|
| \`test_fallback_sync_success_upserts_repos\` | wiremock 成功系 |
| \`test_fallback_sync_filters_wrong_app_id\` | wiremock app_idフィルタ |
| \`test_fallback_sync_filters_suspended_installations\` | wiremock suspended除外 |
| \`test_fallback_sync_github_api_error_graceful\` | wiremock エラー耐性 |
| \`test_fallback_sync_skipped_when_app_id_none\` | スキップ系 |
| \`test_fallback_sync_skipped_when_all_repos_exist\` | スキップ系 |
| \`test_fallback_sync_skipped_when_throttled\` | スキップ系 |
| \`test_find_existing_github_ids\` | DBクエリ |
| \`test_find_existing_github_ids_empty_input\` | DBクエリ |

## 更新ドキュメント

- \`README.md\`: \`GITHUB_APP_ID\` がAPIサーバーでも必要な旨を追記
- \`docs/backend/api.md\`: Section 1.2.1 に fallback sync 仕様追記
- \`docs/external/github-user-installations-api.md\`: GitHub Installations API 調査メモ（新規）
- \`docs/logs/77/worklog.md\`: 作業ログ（全フェーズ）

## 外部調査メモ

- \`GET /user/installations\` は GitHub App user access token で認証し、全インストールが返るため \`app_id\` フィルタ必須
- \`GET /user/installations/{id}/repositories\` は \`metadata\` パーミッション（read）が必要
- 詳細: \`docs/external/github-user-installations-api.md\`

## 残リスク

- 大規模 org では fallback sync がホットパスで動くため、ページ数に応じて一覧 API のレイテンシが伸びる余地あり（将来的にバックグラウンドジョブ化で対応可能）
- \`GITHUB_APP_ID\` 未設定または GitHub App user access token 前提が本番で満たされない場合、fallback sync は有効化されないが既存動作への影響はない

## review / docs OK判定

- review: \`pr_ready: true\`（review 3、2026-05-04）
- docs: \`docs_ready: true\`（2026-05-04）
