### PR TITLE
feat(kicad): add boardflow-kicad crate (Issue #73 Phase 1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,6 +808,23 @@ name = "boardflow-jobs"
 version = "0.0.1"
 
 [[package]]
+name = "boardflow-kicad"
+version = "0.0.1"
+dependencies = [
+ "globset",
+ "hex",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "sha2 0.10.9",
+ "tempfile",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "walkdir",
+]
+
+[[package]]
 name = "boardflow-worker"
 version = "0.0.1"
 dependencies = [
@@ -830,6 +847,16 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -1679,6 +1706,19 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -3176,6 +3216,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3349,6 +3398,19 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -4180,6 +4242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4282,6 +4350,16 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -4458,6 +4536,15 @@ checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
  "libredox",
  "wasite",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/github",
     "crates/artifact",
     "crates/config",
+    "crates/kicad",
 ]
 
 [workspace.dependencies]
@@ -53,6 +54,10 @@ jsonwebtoken = { version = "10", default-features = false, features = [
     "use_pem",
 ] }
 dotenvy = "0.15"
+serde_yaml = "0.9"
+globset = "0.4"
+walkdir = "2"
+tempfile = "3"
 
 [workspace.lints.clippy]
 collapsible_if = "allow"

--- a/crates/kicad/Cargo.toml
+++ b/crates/kicad/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "boardflow-kicad"
+version = "0.0.1"
+edition = "2024"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+sha2 = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+globset = { workspace = true }
+walkdir = { workspace = true }
+hex = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/kicad/Cargo.toml
+++ b/crates/kicad/Cargo.toml
@@ -2,6 +2,7 @@
 name = "boardflow-kicad"
 version = "0.0.1"
 edition = "2024"
+description = "KiCad CLI wrapper — command execution, output parsing, and project detection"
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/kicad/src/cli.rs
+++ b/crates/kicad/src/cli.rs
@@ -4,6 +4,29 @@ use tokio::process::Command;
 
 use crate::{KicadError, Result};
 
+/// PCB side for SVG export and 3D render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PcbSide {
+    Top,
+    Bottom,
+}
+
+impl PcbSide {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            PcbSide::Top => "top",
+            PcbSide::Bottom => "bottom",
+        }
+    }
+
+    fn svg_layers(&self) -> &'static str {
+        match self {
+            PcbSide::Top => "F.Cu,F.Silkscreen,F.Mask,Edge.Cuts",
+            PcbSide::Bottom => "B.Cu,B.Silkscreen,B.Mask,Edge.Cuts",
+        }
+    }
+}
+
 pub struct CommandOutput {
     pub exit_code: i32,
     pub stdout: String,
@@ -58,7 +81,7 @@ impl KicadCli {
         &self,
         pcb_file: &Path,
         output_svg: &Path,
-        side: &str,
+        side: PcbSide,
     ) -> Result<CommandOutput> {
         let args = Self::build_pcb_svg_args(pcb_file, output_svg, side);
         let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -105,7 +128,7 @@ impl KicadCli {
         &self,
         pcb_file: &Path,
         output_png: &Path,
-        side: &str,
+        side: PcbSide,
     ) -> Result<CommandOutput> {
         let args = Self::build_render_3d_args(pcb_file, output_png, side);
         let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
@@ -166,18 +189,14 @@ impl KicadCli {
         ]
     }
 
-    pub fn build_pcb_svg_args(pcb_file: &Path, output_svg: &Path, side: &str) -> Vec<String> {
-        let layers = match side {
-            "bottom" => "B.Cu,B.Silkscreen,B.Mask,Edge.Cuts",
-            _ => "F.Cu,F.Silkscreen,F.Mask,Edge.Cuts", // top (default)
-        };
+    pub fn build_pcb_svg_args(pcb_file: &Path, output_svg: &Path, side: PcbSide) -> Vec<String> {
         vec![
             "pcb".into(),
             "export".into(),
             "svg".into(),
             "--mode-multi".into(),
             "--layers".into(),
-            layers.into(),
+            side.svg_layers().into(),
             "--output".into(),
             output_svg.to_str().unwrap_or_default().into(),
             pcb_file.to_str().unwrap_or_default().into(),
@@ -241,12 +260,12 @@ impl KicadCli {
         ]
     }
 
-    pub fn build_render_3d_args(pcb_file: &Path, output_png: &Path, side: &str) -> Vec<String> {
+    pub fn build_render_3d_args(pcb_file: &Path, output_png: &Path, side: PcbSide) -> Vec<String> {
         vec![
             "pcb".into(),
             "render".into(),
             "--side".into(),
-            side.into(),
+            side.as_str().into(),
             "--quality".into(),
             "basic".into(),
             "--output".into(),

--- a/crates/kicad/src/cli.rs
+++ b/crates/kicad/src/cli.rs
@@ -31,43 +31,38 @@ impl KicadCli {
     }
 
     pub async fn run_erc(&self, sch_file: &Path, output_json: &Path) -> Result<CommandOutput> {
-        let sch = sch_file.to_str().unwrap_or_default();
-        let out = output_json.to_str().unwrap_or_default();
-        self.exec_erc_drc(&["sch", "erc", "--format", "json", "--output", out, sch])
-            .await
+        let args = Self::build_erc_args(sch_file, output_json);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec_erc_drc(&args_ref).await
     }
 
     pub async fn run_drc(&self, pcb_file: &Path, output_json: &Path) -> Result<CommandOutput> {
-        let pcb = pcb_file.to_str().unwrap_or_default();
-        let out = output_json.to_str().unwrap_or_default();
-        self.exec_erc_drc(&["pcb", "drc", "--format", "json", "--output", out, pcb])
-            .await
+        let args = Self::build_drc_args(pcb_file, output_json);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec_erc_drc(&args_ref).await
     }
 
     pub async fn export_pcb_pdf(&self, pcb_file: &Path, output_pdf: &Path) -> Result<CommandOutput> {
-        let pcb = pcb_file.to_str().unwrap_or_default();
-        let out = output_pdf.to_str().unwrap_or_default();
-        self.exec(&["pcb", "export", "pdf", "--output", out, pcb])
-            .await
+        let args = Self::build_pcb_pdf_args(pcb_file, output_pdf);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec(&args_ref).await
     }
 
     pub async fn export_sch_pdf(&self, sch_file: &Path, output_pdf: &Path) -> Result<CommandOutput> {
-        let sch = sch_file.to_str().unwrap_or_default();
-        let out = output_pdf.to_str().unwrap_or_default();
-        self.exec(&["sch", "export", "pdf", "--output", out, sch])
-            .await
+        let args = Self::build_sch_pdf_args(sch_file, output_pdf);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec(&args_ref).await
     }
 
     pub async fn export_pcb_svg(
         &self,
         pcb_file: &Path,
         output_svg: &Path,
-        layers: &str,
+        side: &str,
     ) -> Result<CommandOutput> {
-        let pcb = pcb_file.to_str().unwrap_or_default();
-        let out = output_svg.to_str().unwrap_or_default();
-        self.exec(&["pcb", "export", "svg", "--layers", layers, "--output", out, pcb])
-            .await
+        let args = Self::build_pcb_svg_args(pcb_file, output_svg, side);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec(&args_ref).await
     }
 
     pub async fn export_gerbers(
@@ -75,10 +70,9 @@ impl KicadCli {
         pcb_file: &Path,
         output_dir: &Path,
     ) -> Result<CommandOutput> {
-        let pcb = pcb_file.to_str().unwrap_or_default();
-        let out = output_dir.to_str().unwrap_or_default();
-        self.exec(&["pcb", "export", "gerbers", "--output", out, pcb])
-            .await
+        let args = Self::build_gerbers_args(pcb_file, output_dir);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec(&args_ref).await
     }
 
     pub async fn export_drill(
@@ -86,17 +80,15 @@ impl KicadCli {
         pcb_file: &Path,
         output_dir: &Path,
     ) -> Result<CommandOutput> {
-        let pcb = pcb_file.to_str().unwrap_or_default();
-        let out = output_dir.to_str().unwrap_or_default();
-        self.exec(&["pcb", "export", "drill", "--output", out, pcb])
-            .await
+        let args = Self::build_drill_args(pcb_file, output_dir);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec(&args_ref).await
     }
 
     pub async fn export_bom(&self, sch_file: &Path, output_csv: &Path) -> Result<CommandOutput> {
-        let sch = sch_file.to_str().unwrap_or_default();
-        let out = output_csv.to_str().unwrap_or_default();
-        self.exec(&["sch", "export", "bom", "--output", out, sch])
-            .await
+        let args = Self::build_bom_args(sch_file, output_csv);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec(&args_ref).await
     }
 
     pub async fn export_position(
@@ -104,10 +96,9 @@ impl KicadCli {
         pcb_file: &Path,
         output_csv: &Path,
     ) -> Result<CommandOutput> {
-        let pcb = pcb_file.to_str().unwrap_or_default();
-        let out = output_csv.to_str().unwrap_or_default();
-        self.exec(&["pcb", "export", "pos", "--output", out, pcb])
-            .await
+        let args = Self::build_position_args(pcb_file, output_csv);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec(&args_ref).await
     }
 
     pub async fn render_3d(
@@ -116,15 +107,158 @@ impl KicadCli {
         output_png: &Path,
         side: &str,
     ) -> Result<CommandOutput> {
-        let pcb = pcb_file.to_str().unwrap_or_default();
-        let out = output_png.to_str().unwrap_or_default();
-        self.exec(&["pcb", "render", "--side", side, "--output", out, pcb])
-            .await
+        let args = Self::build_render_3d_args(pcb_file, output_png, side);
+        let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        self.exec(&args_ref).await
+    }
+
+    // --- Argument builders (pub for testing) ---
+
+    pub fn build_erc_args(sch_file: &Path, output_json: &Path) -> Vec<String> {
+        vec![
+            "sch".into(),
+            "erc".into(),
+            "--format".into(),
+            "json".into(),
+            "--severity-all".into(),
+            "--exit-code-violations".into(),
+            "--output".into(),
+            output_json.to_str().unwrap_or_default().into(),
+            sch_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_drc_args(pcb_file: &Path, output_json: &Path) -> Vec<String> {
+        vec![
+            "pcb".into(),
+            "drc".into(),
+            "--format".into(),
+            "json".into(),
+            "--severity-all".into(),
+            "--exit-code-violations".into(),
+            "--output".into(),
+            output_json.to_str().unwrap_or_default().into(),
+            pcb_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_pcb_pdf_args(pcb_file: &Path, output_pdf: &Path) -> Vec<String> {
+        vec![
+            "pcb".into(),
+            "export".into(),
+            "pdf".into(),
+            "--layers".into(),
+            "F.Cu,B.Cu,F.Silkscreen,B.Silkscreen,Edge.Cuts".into(),
+            "--output".into(),
+            output_pdf.to_str().unwrap_or_default().into(),
+            pcb_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_sch_pdf_args(sch_file: &Path, output_pdf: &Path) -> Vec<String> {
+        vec![
+            "sch".into(),
+            "export".into(),
+            "pdf".into(),
+            "--output".into(),
+            output_pdf.to_str().unwrap_or_default().into(),
+            sch_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_pcb_svg_args(pcb_file: &Path, output_svg: &Path, side: &str) -> Vec<String> {
+        let layers = match side {
+            "bottom" => "B.Cu,B.Silkscreen,B.Mask,Edge.Cuts",
+            _ => "F.Cu,F.Silkscreen,F.Mask,Edge.Cuts", // top (default)
+        };
+        vec![
+            "pcb".into(),
+            "export".into(),
+            "svg".into(),
+            "--mode-multi".into(),
+            "--layers".into(),
+            layers.into(),
+            "--output".into(),
+            output_svg.to_str().unwrap_or_default().into(),
+            pcb_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_gerbers_args(pcb_file: &Path, output_dir: &Path) -> Vec<String> {
+        let mut out = output_dir.to_str().unwrap_or_default().to_string();
+        if !out.ends_with('/') {
+            out.push('/');
+        }
+        vec![
+            "pcb".into(),
+            "export".into(),
+            "gerbers".into(),
+            "--output".into(),
+            out,
+            pcb_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_drill_args(pcb_file: &Path, output_dir: &Path) -> Vec<String> {
+        let mut out = output_dir.to_str().unwrap_or_default().to_string();
+        if !out.ends_with('/') {
+            out.push('/');
+        }
+        vec![
+            "pcb".into(),
+            "export".into(),
+            "drill".into(),
+            "--format".into(),
+            "excellon".into(),
+            "--excellon-separate-th".into(),
+            "--output".into(),
+            out,
+            pcb_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_bom_args(sch_file: &Path, output_csv: &Path) -> Vec<String> {
+        vec![
+            "sch".into(),
+            "export".into(),
+            "bom".into(),
+            "--output".into(),
+            output_csv.to_str().unwrap_or_default().into(),
+            sch_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_position_args(pcb_file: &Path, output_csv: &Path) -> Vec<String> {
+        vec![
+            "pcb".into(),
+            "export".into(),
+            "pos".into(),
+            "--format".into(),
+            "csv".into(),
+            "--output".into(),
+            output_csv.to_str().unwrap_or_default().into(),
+            pcb_file.to_str().unwrap_or_default().into(),
+        ]
+    }
+
+    pub fn build_render_3d_args(pcb_file: &Path, output_png: &Path, side: &str) -> Vec<String> {
+        vec![
+            "pcb".into(),
+            "render".into(),
+            "--side".into(),
+            side.into(),
+            "--quality".into(),
+            "basic".into(),
+            "--output".into(),
+            output_png.to_str().unwrap_or_default().into(),
+            pcb_file.to_str().unwrap_or_default().into(),
+        ]
     }
 
     async fn exec(&self, args: &[&str]) -> Result<CommandOutput> {
         let child = Command::new(&self.bin_path)
             .args(args)
+            .kill_on_drop(true)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()?;
@@ -148,19 +282,17 @@ impl KicadCli {
                 })
             }
             Ok(Err(e)) => Err(KicadError::Io(e)),
-            Err(_) => {
-                // On timeout, the child future is dropped which kills the process
-                Err(KicadError::Timeout {
-                    command: command_str,
-                    timeout_secs: self.timeout.as_secs(),
-                })
-            }
+            Err(_) => Err(KicadError::Timeout {
+                command: command_str,
+                timeout_secs: self.timeout.as_secs(),
+            }),
         }
     }
 
     async fn exec_erc_drc(&self, args: &[&str]) -> Result<CommandOutput> {
         let child = Command::new(&self.bin_path)
             .args(args)
+            .kill_on_drop(true)
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .spawn()?;
@@ -185,13 +317,10 @@ impl KicadCli {
                 })
             }
             Ok(Err(e)) => Err(KicadError::Io(e)),
-            Err(_) => {
-                // On timeout, the child future is dropped which kills the process
-                Err(KicadError::Timeout {
-                    command: command_str,
-                    timeout_secs: self.timeout.as_secs(),
-                })
-            }
+            Err(_) => Err(KicadError::Timeout {
+                command: command_str,
+                timeout_secs: self.timeout.as_secs(),
+            }),
         }
     }
 }

--- a/crates/kicad/src/cli.rs
+++ b/crates/kicad/src/cli.rs
@@ -1,0 +1,203 @@
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::process::Command;
+
+use crate::{KicadError, Result};
+
+pub struct CommandOutput {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+pub struct KicadCli {
+    pub bin_path: PathBuf,
+    pub timeout: Duration,
+}
+
+impl KicadCli {
+    pub fn new() -> Self {
+        Self {
+            bin_path: PathBuf::from("kicad-cli"),
+            timeout: Duration::from_secs(300),
+        }
+    }
+
+    pub fn with_bin_path(bin_path: impl Into<PathBuf>) -> Self {
+        Self {
+            bin_path: bin_path.into(),
+            timeout: Duration::from_secs(300),
+        }
+    }
+
+    pub async fn run_erc(&self, sch_file: &Path, output_json: &Path) -> Result<CommandOutput> {
+        let sch = sch_file.to_str().unwrap_or_default();
+        let out = output_json.to_str().unwrap_or_default();
+        self.exec_erc_drc(&["sch", "erc", "--format", "json", "--output", out, sch])
+            .await
+    }
+
+    pub async fn run_drc(&self, pcb_file: &Path, output_json: &Path) -> Result<CommandOutput> {
+        let pcb = pcb_file.to_str().unwrap_or_default();
+        let out = output_json.to_str().unwrap_or_default();
+        self.exec_erc_drc(&["pcb", "drc", "--format", "json", "--output", out, pcb])
+            .await
+    }
+
+    pub async fn export_pcb_pdf(&self, pcb_file: &Path, output_pdf: &Path) -> Result<CommandOutput> {
+        let pcb = pcb_file.to_str().unwrap_or_default();
+        let out = output_pdf.to_str().unwrap_or_default();
+        self.exec(&["pcb", "export", "pdf", "--output", out, pcb])
+            .await
+    }
+
+    pub async fn export_sch_pdf(&self, sch_file: &Path, output_pdf: &Path) -> Result<CommandOutput> {
+        let sch = sch_file.to_str().unwrap_or_default();
+        let out = output_pdf.to_str().unwrap_or_default();
+        self.exec(&["sch", "export", "pdf", "--output", out, sch])
+            .await
+    }
+
+    pub async fn export_pcb_svg(
+        &self,
+        pcb_file: &Path,
+        output_svg: &Path,
+        layers: &str,
+    ) -> Result<CommandOutput> {
+        let pcb = pcb_file.to_str().unwrap_or_default();
+        let out = output_svg.to_str().unwrap_or_default();
+        self.exec(&["pcb", "export", "svg", "--layers", layers, "--output", out, pcb])
+            .await
+    }
+
+    pub async fn export_gerbers(
+        &self,
+        pcb_file: &Path,
+        output_dir: &Path,
+    ) -> Result<CommandOutput> {
+        let pcb = pcb_file.to_str().unwrap_or_default();
+        let out = output_dir.to_str().unwrap_or_default();
+        self.exec(&["pcb", "export", "gerbers", "--output", out, pcb])
+            .await
+    }
+
+    pub async fn export_drill(
+        &self,
+        pcb_file: &Path,
+        output_dir: &Path,
+    ) -> Result<CommandOutput> {
+        let pcb = pcb_file.to_str().unwrap_or_default();
+        let out = output_dir.to_str().unwrap_or_default();
+        self.exec(&["pcb", "export", "drill", "--output", out, pcb])
+            .await
+    }
+
+    pub async fn export_bom(&self, sch_file: &Path, output_csv: &Path) -> Result<CommandOutput> {
+        let sch = sch_file.to_str().unwrap_or_default();
+        let out = output_csv.to_str().unwrap_or_default();
+        self.exec(&["sch", "export", "bom", "--output", out, sch])
+            .await
+    }
+
+    pub async fn export_position(
+        &self,
+        pcb_file: &Path,
+        output_csv: &Path,
+    ) -> Result<CommandOutput> {
+        let pcb = pcb_file.to_str().unwrap_or_default();
+        let out = output_csv.to_str().unwrap_or_default();
+        self.exec(&["pcb", "export", "pos", "--output", out, pcb])
+            .await
+    }
+
+    pub async fn render_3d(
+        &self,
+        pcb_file: &Path,
+        output_png: &Path,
+        side: &str,
+    ) -> Result<CommandOutput> {
+        let pcb = pcb_file.to_str().unwrap_or_default();
+        let out = output_png.to_str().unwrap_or_default();
+        self.exec(&["pcb", "render", "--side", side, "--output", out, pcb])
+            .await
+    }
+
+    async fn exec(&self, args: &[&str]) -> Result<CommandOutput> {
+        let child = Command::new(&self.bin_path)
+            .args(args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+
+        let command_str = format!("{} {}", self.bin_path.display(), args.join(" "));
+
+        match tokio::time::timeout(self.timeout, child.wait_with_output()).await {
+            Ok(Ok(output)) => {
+                let exit_code = output.status.code().unwrap_or(-1);
+                if exit_code != 0 {
+                    return Err(KicadError::CommandFailed {
+                        command: command_str,
+                        exit_code,
+                        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                    });
+                }
+                Ok(CommandOutput {
+                    exit_code,
+                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                })
+            }
+            Ok(Err(e)) => Err(KicadError::Io(e)),
+            Err(_) => {
+                // On timeout, the child future is dropped which kills the process
+                Err(KicadError::Timeout {
+                    command: command_str,
+                    timeout_secs: self.timeout.as_secs(),
+                })
+            }
+        }
+    }
+
+    async fn exec_erc_drc(&self, args: &[&str]) -> Result<CommandOutput> {
+        let child = Command::new(&self.bin_path)
+            .args(args)
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .spawn()?;
+
+        let command_str = format!("{} {}", self.bin_path.display(), args.join(" "));
+
+        match tokio::time::timeout(self.timeout, child.wait_with_output()).await {
+            Ok(Ok(output)) => {
+                let exit_code = output.status.code().unwrap_or(-1);
+                // ERC/DRC: exit code 5 means violations found, still success
+                if exit_code != 0 && exit_code != 5 {
+                    return Err(KicadError::CommandFailed {
+                        command: command_str,
+                        exit_code,
+                        stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                    });
+                }
+                Ok(CommandOutput {
+                    exit_code,
+                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                })
+            }
+            Ok(Err(e)) => Err(KicadError::Io(e)),
+            Err(_) => {
+                // On timeout, the child future is dropped which kills the process
+                Err(KicadError::Timeout {
+                    command: command_str,
+                    timeout_secs: self.timeout.as_secs(),
+                })
+            }
+        }
+    }
+}
+
+impl Default for KicadCli {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/kicad/src/cli.rs
+++ b/crates/kicad/src/cli.rs
@@ -65,13 +65,21 @@ impl KicadCli {
         self.exec_erc_drc(&args_ref).await
     }
 
-    pub async fn export_pcb_pdf(&self, pcb_file: &Path, output_pdf: &Path) -> Result<CommandOutput> {
+    pub async fn export_pcb_pdf(
+        &self,
+        pcb_file: &Path,
+        output_pdf: &Path,
+    ) -> Result<CommandOutput> {
         let args = Self::build_pcb_pdf_args(pcb_file, output_pdf);
         let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
         self.exec(&args_ref).await
     }
 
-    pub async fn export_sch_pdf(&self, sch_file: &Path, output_pdf: &Path) -> Result<CommandOutput> {
+    pub async fn export_sch_pdf(
+        &self,
+        sch_file: &Path,
+        output_pdf: &Path,
+    ) -> Result<CommandOutput> {
         let args = Self::build_sch_pdf_args(sch_file, output_pdf);
         let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
         self.exec(&args_ref).await
@@ -98,11 +106,7 @@ impl KicadCli {
         self.exec(&args_ref).await
     }
 
-    pub async fn export_drill(
-        &self,
-        pcb_file: &Path,
-        output_dir: &Path,
-    ) -> Result<CommandOutput> {
+    pub async fn export_drill(&self, pcb_file: &Path, output_dir: &Path) -> Result<CommandOutput> {
         let args = Self::build_drill_args(pcb_file, output_dir);
         let args_ref: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
         self.exec(&args_ref).await

--- a/crates/kicad/src/config.rs
+++ b/crates/kicad/src/config.rs
@@ -16,7 +16,7 @@ pub struct BoardflowConfig {
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct OutputsConfig {
-    pub preset: Option<String>,
+    pub preset: String,
 }
 
 /// Parse a `.boardflow.yml` file into a `BoardflowConfig`.
@@ -35,12 +35,11 @@ pub fn validate_schema_v1(config: &BoardflowConfig) -> Result<()> {
         )));
     }
     if let Some(ref outputs) = config.outputs {
-        if let Some(ref preset) = outputs.preset {
-            if preset != "default" {
-                return Err(KicadError::ConfigValidation(format!(
-                    "unsupported outputs.preset: \"{preset}\", only \"default\" is allowed"
-                )));
-            }
+        if outputs.preset != "default" {
+            return Err(KicadError::ConfigValidation(format!(
+                "unsupported outputs.preset: \"{}\", only \"default\" is allowed",
+                outputs.preset
+            )));
         }
     }
     Ok(())

--- a/crates/kicad/src/config.rs
+++ b/crates/kicad/src/config.rs
@@ -1,0 +1,48 @@
+use serde::Deserialize;
+use std::path::Path;
+
+use crate::{KicadError, Result};
+
+#[derive(Debug, Deserialize)]
+pub struct BoardflowConfig {
+    pub version: u32,
+    #[serde(default)]
+    pub outputs: Option<OutputsConfig>,
+    #[serde(default)]
+    pub exclude_paths: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OutputsConfig {
+    pub preset: Option<String>,
+}
+
+/// Parse a `.boardflow.yml` file into a `BoardflowConfig`.
+pub fn parse_boardflow_yml(path: &Path) -> Result<BoardflowConfig> {
+    let content = std::fs::read_to_string(path)?;
+    let config: BoardflowConfig = serde_yaml::from_str(&content)?;
+    Ok(config)
+}
+
+/// Validate the config follows schema v1 rules.
+pub fn validate_schema_v1(config: &BoardflowConfig) -> Result<()> {
+    if config.version != 1 {
+        return Err(KicadError::ConfigValidation(format!(
+            "unsupported version: {}, expected 1",
+            config.version
+        )));
+    }
+    Ok(())
+}
+
+/// Merge exclude patterns from builtin defaults, user input, and yml config.
+/// Returns a deduplicated union of all patterns.
+pub fn merge_excludes(builtin: &[&str], input: &[String], yml: &[String]) -> Vec<String> {
+    let mut result: Vec<String> = builtin.iter().map(|s| s.to_string()).collect();
+    for pattern in input.iter().chain(yml.iter()) {
+        if !result.contains(pattern) {
+            result.push(pattern.clone());
+        }
+    }
+    result
+}

--- a/crates/kicad/src/config.rs
+++ b/crates/kicad/src/config.rs
@@ -4,6 +4,7 @@ use std::path::Path;
 use crate::{KicadError, Result};
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BoardflowConfig {
     pub version: u32,
     #[serde(default)]
@@ -13,6 +14,7 @@ pub struct BoardflowConfig {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct OutputsConfig {
     pub preset: Option<String>,
 }
@@ -31,6 +33,15 @@ pub fn validate_schema_v1(config: &BoardflowConfig) -> Result<()> {
             "unsupported version: {}, expected 1",
             config.version
         )));
+    }
+    if let Some(ref outputs) = config.outputs {
+        if let Some(ref preset) = outputs.preset {
+            if preset != "default" {
+                return Err(KicadError::ConfigValidation(format!(
+                    "unsupported outputs.preset: \"{preset}\", only \"default\" is allowed"
+                )));
+            }
+        }
     }
     Ok(())
 }

--- a/crates/kicad/src/detect.rs
+++ b/crates/kicad/src/detect.rs
@@ -1,0 +1,129 @@
+use std::path::{Path, PathBuf};
+
+use crate::{KicadError, Result};
+
+pub struct ProjectFiles {
+    pub project_dir: PathBuf,
+    pub pro_file: PathBuf,
+    pub pcb_file: PathBuf,
+    pub sch_file: PathBuf,
+}
+
+/// Recursively find all `.boardflow.yml` files under `workspace`.
+pub fn find_boardflow_ymls(workspace: &Path) -> Result<Vec<PathBuf>> {
+    let mut results = Vec::new();
+    for entry in walkdir::WalkDir::new(workspace)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if entry.file_type().is_file() && entry.file_name() == ".boardflow.yml" {
+            results.push(entry.into_path());
+        }
+    }
+    if results.is_empty() {
+        return Err(KicadError::NoBoardflowYml);
+    }
+    Ok(results)
+}
+
+/// Detect project directories by finding `.boardflow.yml` files and returning their parent dirs.
+pub fn detect_projects(workspace: &Path) -> Result<Vec<PathBuf>> {
+    let ymls = find_boardflow_ymls(workspace)?;
+    let dirs: Vec<PathBuf> = ymls
+        .into_iter()
+        .filter_map(|p| p.parent().map(|d| d.to_path_buf()))
+        .collect();
+    Ok(dirs)
+}
+
+/// Find a unique `.kicad_pro` file in the given directory (non-recursive).
+pub fn resolve_kicad_pro(dir: &Path) -> Result<PathBuf> {
+    let mut found = Vec::new();
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == "kicad_pro" {
+                    found.push(path);
+                }
+            }
+        }
+    }
+    match found.len() {
+        0 => Err(KicadError::NoKicadPro(dir.to_path_buf())),
+        1 => Ok(found.into_iter().next().unwrap()),
+        _ => Err(KicadError::MultipleKicadPro(dir.to_path_buf())),
+    }
+}
+
+/// Resolve the `.kicad_pcb` file with the given stem in `dir`.
+pub fn resolve_pcb_file(dir: &Path, stem: &str) -> Result<PathBuf> {
+    let expected = dir.join(format!("{stem}.kicad_pcb"));
+    if expected.is_file() {
+        return Ok(expected);
+    }
+    // Fallback: look for any .kicad_pcb in the directory
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == "kicad_pcb" {
+                    return Ok(path);
+                }
+            }
+        }
+    }
+    Err(KicadError::NoKicadPcb {
+        dir: dir.to_path_buf(),
+        stem: stem.to_string(),
+    })
+}
+
+/// Resolve the root `.kicad_sch` file with the given stem in `dir`.
+pub fn resolve_root_schematic(dir: &Path, stem: &str) -> Result<PathBuf> {
+    let expected = dir.join(format!("{stem}.kicad_sch"));
+    if expected.is_file() {
+        return Ok(expected);
+    }
+    // Fallback: look for any .kicad_sch in the directory
+    let entries = std::fs::read_dir(dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == "kicad_sch" {
+                    return Ok(path);
+                }
+            }
+        }
+    }
+    Err(KicadError::NoKicadSch {
+        dir: dir.to_path_buf(),
+        stem: stem.to_string(),
+    })
+}
+
+/// Resolve all project files (.kicad_pro, .kicad_pcb, .kicad_sch) from a directory.
+pub fn resolve_project_files(dir: &Path) -> Result<ProjectFiles> {
+    let pro_file = resolve_kicad_pro(dir)?;
+    let stem = pro_file
+        .file_stem()
+        .unwrap_or_default()
+        .to_str()
+        .unwrap_or_default()
+        .to_string();
+    let pcb_file = resolve_pcb_file(dir, &stem)?;
+    let sch_file = resolve_root_schematic(dir, &stem)?;
+    Ok(ProjectFiles {
+        project_dir: dir.to_path_buf(),
+        pro_file,
+        pcb_file,
+        sch_file,
+    })
+}

--- a/crates/kicad/src/detect.rs
+++ b/crates/kicad/src/detect.rs
@@ -65,7 +65,8 @@ pub fn resolve_pcb_file(dir: &Path, stem: &str) -> Result<PathBuf> {
     if expected.is_file() {
         return Ok(expected);
     }
-    // Fallback: look for any .kicad_pcb in the directory
+    // Fallback: only allow if exactly one .kicad_pcb exists in the directory
+    let mut found = Vec::new();
     let entries = std::fs::read_dir(dir)?;
     for entry in entries {
         let entry = entry?;
@@ -73,15 +74,22 @@ pub fn resolve_pcb_file(dir: &Path, stem: &str) -> Result<PathBuf> {
         if path.is_file() {
             if let Some(ext) = path.extension() {
                 if ext == "kicad_pcb" {
-                    return Ok(path);
+                    found.push(path);
                 }
             }
         }
     }
-    Err(KicadError::NoKicadPcb {
-        dir: dir.to_path_buf(),
-        stem: stem.to_string(),
-    })
+    match found.len() {
+        0 => Err(KicadError::NoKicadPcb {
+            dir: dir.to_path_buf(),
+            stem: stem.to_string(),
+        }),
+        1 => Ok(found.into_iter().next().unwrap()),
+        _ => Err(KicadError::MultipleKicadPcb {
+            dir: dir.to_path_buf(),
+            stem: stem.to_string(),
+        }),
+    }
 }
 
 /// Resolve the root `.kicad_sch` file with the given stem in `dir`.
@@ -90,7 +98,8 @@ pub fn resolve_root_schematic(dir: &Path, stem: &str) -> Result<PathBuf> {
     if expected.is_file() {
         return Ok(expected);
     }
-    // Fallback: look for any .kicad_sch in the directory
+    // Fallback: only allow if exactly one .kicad_sch exists in the directory
+    let mut found = Vec::new();
     let entries = std::fs::read_dir(dir)?;
     for entry in entries {
         let entry = entry?;
@@ -98,15 +107,22 @@ pub fn resolve_root_schematic(dir: &Path, stem: &str) -> Result<PathBuf> {
         if path.is_file() {
             if let Some(ext) = path.extension() {
                 if ext == "kicad_sch" {
-                    return Ok(path);
+                    found.push(path);
                 }
             }
         }
     }
-    Err(KicadError::NoKicadSch {
-        dir: dir.to_path_buf(),
-        stem: stem.to_string(),
-    })
+    match found.len() {
+        0 => Err(KicadError::NoKicadSch {
+            dir: dir.to_path_buf(),
+            stem: stem.to_string(),
+        }),
+        1 => Ok(found.into_iter().next().unwrap()),
+        _ => Err(KicadError::MultipleKicadSch {
+            dir: dir.to_path_buf(),
+            stem: stem.to_string(),
+        }),
+    }
 }
 
 /// Resolve all project files (.kicad_pro, .kicad_pcb, .kicad_sch) from a directory.

--- a/crates/kicad/src/error.rs
+++ b/crates/kicad/src/error.rs
@@ -1,0 +1,44 @@
+use std::path::PathBuf;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum KicadError {
+    #[error("KiCad CLI command failed: {command} (exit code: {exit_code})")]
+    CommandFailed {
+        command: String,
+        exit_code: i32,
+        stderr: String,
+    },
+
+    #[error("KiCad CLI command timed out after {timeout_secs}s: {command}")]
+    Timeout { command: String, timeout_secs: u64 },
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("JSON parse error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("YAML parse error: {0}")]
+    Yaml(#[from] serde_yaml::Error),
+
+    #[error("No .kicad_pro found in {0}")]
+    NoKicadPro(PathBuf),
+
+    #[error("Multiple .kicad_pro found in {0}")]
+    MultipleKicadPro(PathBuf),
+
+    #[error("No .kicad_pcb found for {stem} in {dir}")]
+    NoKicadPcb { dir: PathBuf, stem: String },
+
+    #[error("No .kicad_sch found for {stem} in {dir}")]
+    NoKicadSch { dir: PathBuf, stem: String },
+
+    #[error("Config validation error: {0}")]
+    ConfigValidation(String),
+
+    #[error("No .boardflow.yml found")]
+    NoBoardflowYml,
+}
+
+pub type Result<T> = std::result::Result<T, KicadError>;

--- a/crates/kicad/src/error.rs
+++ b/crates/kicad/src/error.rs
@@ -31,8 +31,14 @@ pub enum KicadError {
     #[error("No .kicad_pcb found for {stem} in {dir}")]
     NoKicadPcb { dir: PathBuf, stem: String },
 
+    #[error("Multiple .kicad_pcb found in {dir} (no unique match for stem {stem})")]
+    MultipleKicadPcb { dir: PathBuf, stem: String },
+
     #[error("No .kicad_sch found for {stem} in {dir}")]
     NoKicadSch { dir: PathBuf, stem: String },
+
+    #[error("Multiple .kicad_sch found in {dir} (no unique match for stem {stem})")]
+    MultipleKicadSch { dir: PathBuf, stem: String },
 
     #[error("Config validation error: {0}")]
     ConfigValidation(String),

--- a/crates/kicad/src/hash.rs
+++ b/crates/kicad/src/hash.rs
@@ -38,10 +38,7 @@ pub fn list_project_files(dir: &Path, excludes: &[String]) -> Result<Vec<PathBuf
         if !entry.file_type().is_file() {
             continue;
         }
-        let rel_path = entry
-            .path()
-            .strip_prefix(dir)
-            .unwrap_or(entry.path());
+        let rel_path = entry.path().strip_prefix(dir).unwrap_or(entry.path());
         let rel_str = rel_path.to_str().unwrap_or_default();
         if !globset.is_match(rel_str) {
             files.push(entry.into_path());
@@ -106,5 +103,7 @@ fn build_globset(patterns: &[String]) -> GlobSet {
             builder.add(glob);
         }
     }
-    builder.build().unwrap_or_else(|_| GlobSetBuilder::new().build().unwrap())
+    builder
+        .build()
+        .unwrap_or_else(|_| GlobSetBuilder::new().build().unwrap())
 }

--- a/crates/kicad/src/hash.rs
+++ b/crates/kicad/src/hash.rs
@@ -1,0 +1,110 @@
+use std::path::{Path, PathBuf};
+
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use sha2::{Digest, Sha256};
+
+use crate::Result;
+
+pub const BUILTIN_EXCLUDES: &[&str] = &[
+    "**/*.lck",
+    "**/*.bak",
+    "**/*-backups/**",
+    "**/fp-info-cache",
+    "**/.DS_Store",
+    "**/output/**",
+    "**/outputs/**",
+    "**/fabrication/**",
+    "**/gerber/**",
+    "**/gerbers/**",
+];
+
+/// Check if a relative path matches any of the given glob patterns.
+pub fn is_excluded(path: &str, patterns: &[String]) -> bool {
+    let globset = build_globset(patterns);
+    globset.is_match(path)
+}
+
+/// List all files in `dir` recursively, excluding those matching `excludes` patterns.
+pub fn list_project_files(dir: &Path, excludes: &[String]) -> Result<Vec<PathBuf>> {
+    let globset = build_globset(excludes);
+    let mut files = Vec::new();
+
+    for entry in walkdir::WalkDir::new(dir)
+        .follow_links(false)
+        .sort_by_file_name()
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let rel_path = entry
+            .path()
+            .strip_prefix(dir)
+            .unwrap_or(entry.path());
+        let rel_str = rel_path.to_str().unwrap_or_default();
+        if !globset.is_match(rel_str) {
+            files.push(entry.into_path());
+        }
+    }
+
+    Ok(files)
+}
+
+/// Compute the SHA256 hash of a single file, returning the hex string.
+pub fn compute_file_sha256(path: &Path) -> Result<String> {
+    let data = std::fs::read(path)?;
+    let mut hasher = Sha256::new();
+    hasher.update(&data);
+    let hash = hasher.finalize();
+    Ok(hex::encode(hash))
+}
+
+/// Compute a tree hash over all non-excluded files in a directory.
+///
+/// Algorithm:
+/// 1. List all files (excluding patterns)
+/// 2. Sort by relative path (UTF-8 byte order)
+/// 3. For each file: `"{rel_path}\0{sha256_hex}\n"`
+/// 4. SHA256 the concatenation
+pub fn compute_tree_hash(dir: &Path, excludes: &[String]) -> Result<String> {
+    let files = list_project_files(dir, excludes)?;
+
+    // Build sorted (relative_path, absolute_path) pairs
+    let mut entries: Vec<(String, PathBuf)> = files
+        .into_iter()
+        .filter_map(|abs_path| {
+            let rel = abs_path.strip_prefix(dir).ok()?;
+            Some((rel.to_str()?.to_string(), abs_path))
+        })
+        .collect();
+
+    // Sort by relative path (byte order)
+    entries.sort_by(|a, b| a.0.as_bytes().cmp(b.0.as_bytes()));
+
+    // Build the content to hash
+    let mut content = String::new();
+    for (rel_path, abs_path) in &entries {
+        let file_hash = compute_file_sha256(abs_path)?;
+        content.push_str(rel_path);
+        content.push('\0');
+        content.push_str(&file_hash);
+        content.push('\n');
+    }
+
+    // Hash the entire content
+    let mut hasher = Sha256::new();
+    hasher.update(content.as_bytes());
+    let hash = hasher.finalize();
+    Ok(hex::encode(hash))
+}
+
+fn build_globset(patterns: &[String]) -> GlobSet {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        if let Ok(glob) = Glob::new(pattern) {
+            builder.add(glob);
+        }
+    }
+    builder.build().unwrap_or_else(|_| GlobSetBuilder::new().build().unwrap())
+}

--- a/crates/kicad/src/ibom.rs
+++ b/crates/kicad/src/ibom.rs
@@ -1,0 +1,53 @@
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+use crate::{KicadError, Result};
+
+/// Run InteractiveHtmlBom generation via xvfb-run.
+///
+/// Returns the path to the generated HTML file on success.
+pub async fn run_ibom(pcb_path: &Path, output_dir: &Path) -> Result<PathBuf> {
+    let pcb = pcb_path.to_str().unwrap_or_default();
+    let out = output_dir.to_str().unwrap_or_default();
+
+    let output = Command::new("xvfb-run")
+        .args([
+            "generate_interactive_bom",
+            "--no-browser",
+            "--dest-dir",
+            out,
+            pcb,
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .output()
+        .await?;
+
+    if !output.status.success() {
+        let exit_code = output.status.code().unwrap_or(-1);
+        return Err(KicadError::CommandFailed {
+            command: format!("xvfb-run generate_interactive_bom --no-browser --dest-dir {out} {pcb}"),
+            exit_code,
+            stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+        });
+    }
+
+    // Find the generated .html file in output_dir
+    let entries = std::fs::read_dir(output_dir)?;
+    for entry in entries {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_file() {
+            if let Some(ext) = path.extension() {
+                if ext == "html" {
+                    return Ok(path);
+                }
+            }
+        }
+    }
+
+    Err(KicadError::Io(std::io::Error::new(
+        std::io::ErrorKind::NotFound,
+        "iBOM HTML file not found in output directory",
+    )))
+}

--- a/crates/kicad/src/ibom.rs
+++ b/crates/kicad/src/ibom.rs
@@ -26,7 +26,9 @@ pub async fn run_ibom(pcb_path: &Path, output_dir: &Path) -> Result<PathBuf> {
     if !output.status.success() {
         let exit_code = output.status.code().unwrap_or(-1);
         return Err(KicadError::CommandFailed {
-            command: format!("xvfb-run generate_interactive_bom --no-browser --dest-dir {out} {pcb}"),
+            command: format!(
+                "xvfb-run generate_interactive_bom --no-browser --dest-dir {out} {pcb}"
+            ),
             exit_code,
             stderr: String::from_utf8_lossy(&output.stderr).to_string(),
         });

--- a/crates/kicad/src/lib.rs
+++ b/crates/kicad/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod cli;
+pub mod config;
+pub mod detect;
+pub mod error;
+pub mod hash;
+pub mod ibom;
+pub mod report;
+
+pub use error::{KicadError, Result};

--- a/crates/kicad/src/lib.rs
+++ b/crates/kicad/src/lib.rs
@@ -6,4 +6,5 @@ pub mod hash;
 pub mod ibom;
 pub mod report;
 
+pub use cli::PcbSide;
 pub use error::{KicadError, Result};

--- a/crates/kicad/src/report.rs
+++ b/crates/kicad/src/report.rs
@@ -1,0 +1,106 @@
+use serde::Deserialize;
+
+use crate::Result;
+
+#[derive(Debug, Deserialize)]
+pub struct ErcReport {
+    pub sheets: Vec<ErcSheet>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ErcSheet {
+    pub path: String,
+    pub violations: Vec<Violation>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct DrcReport {
+    pub violations: Vec<Violation>,
+    #[serde(default)]
+    pub unconnected_items: Vec<Violation>,
+    #[serde(default)]
+    pub schematic_parity: Vec<Violation>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Violation {
+    #[serde(rename = "type")]
+    pub violation_type: String,
+    pub description: String,
+    pub severity: String,
+    #[serde(default)]
+    pub items: Vec<ViolationItem>,
+    #[serde(default)]
+    pub excluded: bool,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ViolationItem {
+    pub description: String,
+    #[serde(default)]
+    pub pos: Option<Position>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct Position {
+    pub x: f64,
+    pub y: f64,
+}
+
+impl ErcReport {
+    pub fn parse(json: &str) -> Result<Self> {
+        let report: Self = serde_json::from_str(json)?;
+        Ok(report)
+    }
+
+    pub fn all_violations(&self) -> Vec<&Violation> {
+        self.sheets.iter().flat_map(|s| &s.violations).collect()
+    }
+
+    pub fn actionable_violations(&self) -> Vec<&Violation> {
+        self.all_violations()
+            .into_iter()
+            .filter(|v| v.is_actionable())
+            .collect()
+    }
+
+    pub fn has_errors(&self) -> bool {
+        self.actionable_violations()
+            .iter()
+            .any(|v| v.severity == "error")
+    }
+}
+
+impl DrcReport {
+    pub fn parse(json: &str) -> Result<Self> {
+        let report: Self = serde_json::from_str(json)?;
+        Ok(report)
+    }
+
+    pub fn all_violations(&self) -> Vec<&Violation> {
+        self.violations
+            .iter()
+            .chain(&self.unconnected_items)
+            .chain(&self.schematic_parity)
+            .collect()
+    }
+
+    pub fn actionable_violations(&self) -> Vec<&Violation> {
+        self.all_violations()
+            .into_iter()
+            .filter(|v| v.is_actionable())
+            .collect()
+    }
+
+    pub fn has_errors(&self) -> bool {
+        self.actionable_violations()
+            .iter()
+            .any(|v| v.severity == "error")
+    }
+}
+
+impl Violation {
+    pub fn is_actionable(&self) -> bool {
+        !self.excluded && self.severity != "exclusion"
+    }
+}

--- a/crates/kicad/tests/cli_test.rs
+++ b/crates/kicad/tests/cli_test.rs
@@ -1,0 +1,239 @@
+use std::path::Path;
+
+use boardflow_kicad::cli::KicadCli;
+
+#[test]
+fn build_erc_args_matches_bash() {
+    let args = KicadCli::build_erc_args(Path::new("/proj/board.kicad_sch"), Path::new("/out/erc.json"));
+    assert_eq!(
+        args,
+        vec![
+            "sch",
+            "erc",
+            "--format",
+            "json",
+            "--severity-all",
+            "--exit-code-violations",
+            "--output",
+            "/out/erc.json",
+            "/proj/board.kicad_sch",
+        ]
+    );
+}
+
+#[test]
+fn build_drc_args_matches_bash() {
+    let args = KicadCli::build_drc_args(Path::new("/proj/board.kicad_pcb"), Path::new("/out/drc.json"));
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "drc",
+            "--format",
+            "json",
+            "--severity-all",
+            "--exit-code-violations",
+            "--output",
+            "/out/drc.json",
+            "/proj/board.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_pcb_pdf_args_matches_bash() {
+    let args = KicadCli::build_pcb_pdf_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/b.pdf"));
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "export",
+            "pdf",
+            "--layers",
+            "F.Cu,B.Cu,F.Silkscreen,B.Silkscreen,Edge.Cuts",
+            "--output",
+            "/out/b.pdf",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_sch_pdf_args_matches_bash() {
+    let args = KicadCli::build_sch_pdf_args(Path::new("/proj/b.kicad_sch"), Path::new("/out/b.pdf"));
+    assert_eq!(
+        args,
+        vec!["sch", "export", "pdf", "--output", "/out/b.pdf", "/proj/b.kicad_sch"]
+    );
+}
+
+#[test]
+fn build_pcb_svg_top_args_matches_bash() {
+    let args = KicadCli::build_pcb_svg_args(
+        Path::new("/proj/b.kicad_pcb"),
+        Path::new("/out/top.svg"),
+        "top",
+    );
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "export",
+            "svg",
+            "--mode-multi",
+            "--layers",
+            "F.Cu,F.Silkscreen,F.Mask,Edge.Cuts",
+            "--output",
+            "/out/top.svg",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_pcb_svg_bottom_args_matches_bash() {
+    let args = KicadCli::build_pcb_svg_args(
+        Path::new("/proj/b.kicad_pcb"),
+        Path::new("/out/bottom.svg"),
+        "bottom",
+    );
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "export",
+            "svg",
+            "--mode-multi",
+            "--layers",
+            "B.Cu,B.Silkscreen,B.Mask,Edge.Cuts",
+            "--output",
+            "/out/bottom.svg",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_gerbers_args_matches_bash() {
+    let args = KicadCli::build_gerbers_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/gerbers"));
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "export",
+            "gerbers",
+            "--output",
+            "/out/gerbers/",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_gerbers_args_trailing_slash() {
+    // If output_dir already ends with /, no double slash
+    let args = KicadCli::build_gerbers_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/gerbers/"));
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "export",
+            "gerbers",
+            "--output",
+            "/out/gerbers/",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_drill_args_matches_bash() {
+    let args = KicadCli::build_drill_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/drill"));
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "export",
+            "drill",
+            "--format",
+            "excellon",
+            "--excellon-separate-th",
+            "--output",
+            "/out/drill/",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_bom_args_matches_bash() {
+    let args = KicadCli::build_bom_args(Path::new("/proj/b.kicad_sch"), Path::new("/out/bom.csv"));
+    assert_eq!(
+        args,
+        vec!["sch", "export", "bom", "--output", "/out/bom.csv", "/proj/b.kicad_sch"]
+    );
+}
+
+#[test]
+fn build_position_args_matches_bash() {
+    let args = KicadCli::build_position_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/pos.csv"));
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "export",
+            "pos",
+            "--format",
+            "csv",
+            "--output",
+            "/out/pos.csv",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_render_3d_top_args_matches_bash() {
+    let args = KicadCli::build_render_3d_args(
+        Path::new("/proj/b.kicad_pcb"),
+        Path::new("/out/3d_top.png"),
+        "top",
+    );
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "render",
+            "--side",
+            "top",
+            "--quality",
+            "basic",
+            "--output",
+            "/out/3d_top.png",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}
+
+#[test]
+fn build_render_3d_bottom_args_matches_bash() {
+    let args = KicadCli::build_render_3d_args(
+        Path::new("/proj/b.kicad_pcb"),
+        Path::new("/out/3d_bottom.png"),
+        "bottom",
+    );
+    assert_eq!(
+        args,
+        vec![
+            "pcb",
+            "render",
+            "--side",
+            "bottom",
+            "--quality",
+            "basic",
+            "--output",
+            "/out/3d_bottom.png",
+            "/proj/b.kicad_pcb",
+        ]
+    );
+}

--- a/crates/kicad/tests/cli_test.rs
+++ b/crates/kicad/tests/cli_test.rs
@@ -1,6 +1,6 @@
 use std::path::Path;
 
-use boardflow_kicad::cli::KicadCli;
+use boardflow_kicad::cli::{KicadCli, PcbSide};
 
 #[test]
 fn build_erc_args_matches_bash() {
@@ -72,7 +72,7 @@ fn build_pcb_svg_top_args_matches_bash() {
     let args = KicadCli::build_pcb_svg_args(
         Path::new("/proj/b.kicad_pcb"),
         Path::new("/out/top.svg"),
-        "top",
+        PcbSide::Top,
     );
     assert_eq!(
         args,
@@ -95,7 +95,7 @@ fn build_pcb_svg_bottom_args_matches_bash() {
     let args = KicadCli::build_pcb_svg_args(
         Path::new("/proj/b.kicad_pcb"),
         Path::new("/out/bottom.svg"),
-        "bottom",
+        PcbSide::Bottom,
     );
     assert_eq!(
         args,
@@ -197,7 +197,7 @@ fn build_render_3d_top_args_matches_bash() {
     let args = KicadCli::build_render_3d_args(
         Path::new("/proj/b.kicad_pcb"),
         Path::new("/out/3d_top.png"),
-        "top",
+        PcbSide::Top,
     );
     assert_eq!(
         args,
@@ -220,7 +220,7 @@ fn build_render_3d_bottom_args_matches_bash() {
     let args = KicadCli::build_render_3d_args(
         Path::new("/proj/b.kicad_pcb"),
         Path::new("/out/3d_bottom.png"),
-        "bottom",
+        PcbSide::Bottom,
     );
     assert_eq!(
         args,

--- a/crates/kicad/tests/cli_test.rs
+++ b/crates/kicad/tests/cli_test.rs
@@ -4,7 +4,10 @@ use boardflow_kicad::cli::{KicadCli, PcbSide};
 
 #[test]
 fn build_erc_args_matches_bash() {
-    let args = KicadCli::build_erc_args(Path::new("/proj/board.kicad_sch"), Path::new("/out/erc.json"));
+    let args = KicadCli::build_erc_args(
+        Path::new("/proj/board.kicad_sch"),
+        Path::new("/out/erc.json"),
+    );
     assert_eq!(
         args,
         vec![
@@ -23,7 +26,10 @@ fn build_erc_args_matches_bash() {
 
 #[test]
 fn build_drc_args_matches_bash() {
-    let args = KicadCli::build_drc_args(Path::new("/proj/board.kicad_pcb"), Path::new("/out/drc.json"));
+    let args = KicadCli::build_drc_args(
+        Path::new("/proj/board.kicad_pcb"),
+        Path::new("/out/drc.json"),
+    );
     assert_eq!(
         args,
         vec![
@@ -42,7 +48,8 @@ fn build_drc_args_matches_bash() {
 
 #[test]
 fn build_pcb_pdf_args_matches_bash() {
-    let args = KicadCli::build_pcb_pdf_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/b.pdf"));
+    let args =
+        KicadCli::build_pcb_pdf_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/b.pdf"));
     assert_eq!(
         args,
         vec![
@@ -60,10 +67,18 @@ fn build_pcb_pdf_args_matches_bash() {
 
 #[test]
 fn build_sch_pdf_args_matches_bash() {
-    let args = KicadCli::build_sch_pdf_args(Path::new("/proj/b.kicad_sch"), Path::new("/out/b.pdf"));
+    let args =
+        KicadCli::build_sch_pdf_args(Path::new("/proj/b.kicad_sch"), Path::new("/out/b.pdf"));
     assert_eq!(
         args,
-        vec!["sch", "export", "pdf", "--output", "/out/b.pdf", "/proj/b.kicad_sch"]
+        vec![
+            "sch",
+            "export",
+            "pdf",
+            "--output",
+            "/out/b.pdf",
+            "/proj/b.kicad_sch"
+        ]
     );
 }
 
@@ -115,7 +130,8 @@ fn build_pcb_svg_bottom_args_matches_bash() {
 
 #[test]
 fn build_gerbers_args_matches_bash() {
-    let args = KicadCli::build_gerbers_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/gerbers"));
+    let args =
+        KicadCli::build_gerbers_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/gerbers"));
     assert_eq!(
         args,
         vec![
@@ -132,7 +148,8 @@ fn build_gerbers_args_matches_bash() {
 #[test]
 fn build_gerbers_args_trailing_slash() {
     // If output_dir already ends with /, no double slash
-    let args = KicadCli::build_gerbers_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/gerbers/"));
+    let args =
+        KicadCli::build_gerbers_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/gerbers/"));
     assert_eq!(
         args,
         vec![
@@ -170,13 +187,21 @@ fn build_bom_args_matches_bash() {
     let args = KicadCli::build_bom_args(Path::new("/proj/b.kicad_sch"), Path::new("/out/bom.csv"));
     assert_eq!(
         args,
-        vec!["sch", "export", "bom", "--output", "/out/bom.csv", "/proj/b.kicad_sch"]
+        vec![
+            "sch",
+            "export",
+            "bom",
+            "--output",
+            "/out/bom.csv",
+            "/proj/b.kicad_sch"
+        ]
     );
 }
 
 #[test]
 fn build_position_args_matches_bash() {
-    let args = KicadCli::build_position_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/pos.csv"));
+    let args =
+        KicadCli::build_position_args(Path::new("/proj/b.kicad_pcb"), Path::new("/out/pos.csv"));
     assert_eq!(
         args,
         vec![

--- a/crates/kicad/tests/config_test.rs
+++ b/crates/kicad/tests/config_test.rs
@@ -23,8 +23,8 @@ exclude_paths:
     let config = parse_boardflow_yml(&yml_path).unwrap();
     assert_eq!(config.version, 1);
     assert_eq!(
-        config.outputs.as_ref().unwrap().preset.as_deref(),
-        Some("default")
+        config.outputs.as_ref().unwrap().preset.as_str(),
+        "default"
     );
     assert_eq!(config.exclude_paths.len(), 2);
     assert_eq!(config.exclude_paths[0], "docs/**");
@@ -131,13 +131,14 @@ fn validate_schema_v1_accepts_preset_default() {
 }
 
 #[test]
-fn validate_schema_v1_accepts_no_preset() {
+fn validate_schema_v1_rejects_null_preset() {
     let tmp = TempDir::new().unwrap();
     let yml_path = tmp.path().join(".boardflow.yml");
     fs::write(&yml_path, "version: 1\noutputs:\n  preset:\n").unwrap();
 
     let config = parse_boardflow_yml(&yml_path).unwrap();
-    assert!(validate_schema_v1(&config).is_ok());
+    let result = validate_schema_v1(&config);
+    assert!(result.is_err(), "null/empty preset should be rejected by validation");
 }
 
 #[test]

--- a/crates/kicad/tests/config_test.rs
+++ b/crates/kicad/tests/config_test.rs
@@ -22,10 +22,7 @@ exclude_paths:
 
     let config = parse_boardflow_yml(&yml_path).unwrap();
     assert_eq!(config.version, 1);
-    assert_eq!(
-        config.outputs.as_ref().unwrap().preset.as_str(),
-        "default"
-    );
+    assert_eq!(config.outputs.as_ref().unwrap().preset.as_str(), "default");
     assert_eq!(config.exclude_paths.len(), 2);
     assert_eq!(config.exclude_paths[0], "docs/**");
     assert_eq!(config.exclude_paths[1], "test/**");
@@ -120,11 +117,7 @@ fn validate_schema_v1_rejects_version_2() {
 fn validate_schema_v1_accepts_preset_default() {
     let tmp = TempDir::new().unwrap();
     let yml_path = tmp.path().join(".boardflow.yml");
-    fs::write(
-        &yml_path,
-        "version: 1\noutputs:\n  preset: default\n",
-    )
-    .unwrap();
+    fs::write(&yml_path, "version: 1\noutputs:\n  preset: default\n").unwrap();
 
     let config = parse_boardflow_yml(&yml_path).unwrap();
     assert!(validate_schema_v1(&config).is_ok());
@@ -138,18 +131,17 @@ fn validate_schema_v1_rejects_null_preset() {
 
     let config = parse_boardflow_yml(&yml_path).unwrap();
     let result = validate_schema_v1(&config);
-    assert!(result.is_err(), "null/empty preset should be rejected by validation");
+    assert!(
+        result.is_err(),
+        "null/empty preset should be rejected by validation"
+    );
 }
 
 #[test]
 fn validate_schema_v1_rejects_preset_custom() {
     let tmp = TempDir::new().unwrap();
     let yml_path = tmp.path().join(".boardflow.yml");
-    fs::write(
-        &yml_path,
-        "version: 1\noutputs:\n  preset: custom\n",
-    )
-    .unwrap();
+    fs::write(&yml_path, "version: 1\noutputs:\n  preset: custom\n").unwrap();
 
     let config = parse_boardflow_yml(&yml_path).unwrap();
     let result = validate_schema_v1(&config);
@@ -160,11 +152,7 @@ fn validate_schema_v1_rejects_preset_custom() {
 fn validate_schema_v1_rejects_preset_full() {
     let tmp = TempDir::new().unwrap();
     let yml_path = tmp.path().join(".boardflow.yml");
-    fs::write(
-        &yml_path,
-        "version: 1\noutputs:\n  preset: full\n",
-    )
-    .unwrap();
+    fs::write(&yml_path, "version: 1\noutputs:\n  preset: full\n").unwrap();
 
     let config = parse_boardflow_yml(&yml_path).unwrap();
     let result = validate_schema_v1(&config);

--- a/crates/kicad/tests/config_test.rs
+++ b/crates/kicad/tests/config_test.rs
@@ -1,0 +1,136 @@
+use std::fs;
+
+use boardflow_kicad::config::{merge_excludes, parse_boardflow_yml, validate_schema_v1};
+use tempfile::TempDir;
+
+#[test]
+fn parse_valid_boardflow_yml() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(
+        &yml_path,
+        r#"
+version: 1
+outputs:
+  preset: full
+exclude_paths:
+  - "docs/**"
+  - "test/**"
+"#,
+    )
+    .unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    assert_eq!(config.version, 1);
+    assert_eq!(config.outputs.as_ref().unwrap().preset.as_deref(), Some("full"));
+    assert_eq!(config.exclude_paths.len(), 2);
+    assert_eq!(config.exclude_paths[0], "docs/**");
+    assert_eq!(config.exclude_paths[1], "test/**");
+}
+
+#[test]
+fn parse_minimal_boardflow_yml() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(&yml_path, "version: 1\n").unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    assert_eq!(config.version, 1);
+    assert!(config.outputs.is_none());
+    assert!(config.exclude_paths.is_empty());
+}
+
+#[test]
+fn parse_boardflow_yml_with_unknown_fields() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(
+        &yml_path,
+        r#"
+version: 1
+unknown_field: hello
+outputs:
+  preset: basic
+"#,
+    )
+    .unwrap();
+
+    // serde_yaml by default ignores unknown fields with #[serde(deny_unknown_fields)]
+    // absent, so this should succeed
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    assert_eq!(config.version, 1);
+}
+
+#[test]
+fn validate_schema_v1_accepts_version_1() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(&yml_path, "version: 1\n").unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    assert!(validate_schema_v1(&config).is_ok());
+}
+
+#[test]
+fn validate_schema_v1_rejects_version_2() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(&yml_path, "version: 2\n").unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    let result = validate_schema_v1(&config);
+    assert!(result.is_err());
+}
+
+#[test]
+fn parse_invalid_yaml_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(&yml_path, "not: [valid: yaml: content").unwrap();
+
+    let result = parse_boardflow_yml(&yml_path);
+    assert!(result.is_err());
+}
+
+#[test]
+fn parse_nonexistent_file_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join("nonexistent.yml");
+
+    let result = parse_boardflow_yml(&yml_path);
+    assert!(result.is_err());
+}
+
+#[test]
+fn merge_excludes_combines_all_sources() {
+    let builtin = &["**/*.lck", "**/*.bak"];
+    let input = vec!["custom/**".to_string()];
+    let yml = vec!["docs/**".to_string()];
+
+    let merged = merge_excludes(builtin, &input, &yml);
+    assert_eq!(merged.len(), 4);
+    assert!(merged.contains(&"**/*.lck".to_string()));
+    assert!(merged.contains(&"**/*.bak".to_string()));
+    assert!(merged.contains(&"custom/**".to_string()));
+    assert!(merged.contains(&"docs/**".to_string()));
+}
+
+#[test]
+fn merge_excludes_deduplicates() {
+    let builtin = &["**/*.lck"];
+    let input = vec!["**/*.lck".to_string()]; // duplicate
+    let yml = vec!["**/*.lck".to_string()]; // duplicate
+
+    let merged = merge_excludes(builtin, &input, &yml);
+    assert_eq!(merged.len(), 1);
+}
+
+#[test]
+fn merge_excludes_empty_inputs() {
+    let builtin: &[&str] = &[];
+    let input: Vec<String> = vec![];
+    let yml: Vec<String> = vec![];
+
+    let merged = merge_excludes(builtin, &input, &yml);
+    assert!(merged.is_empty());
+}

--- a/crates/kicad/tests/config_test.rs
+++ b/crates/kicad/tests/config_test.rs
@@ -12,7 +12,7 @@ fn parse_valid_boardflow_yml() {
         r#"
 version: 1
 outputs:
-  preset: full
+  preset: default
 exclude_paths:
   - "docs/**"
   - "test/**"
@@ -22,7 +22,10 @@ exclude_paths:
 
     let config = parse_boardflow_yml(&yml_path).unwrap();
     assert_eq!(config.version, 1);
-    assert_eq!(config.outputs.as_ref().unwrap().preset.as_deref(), Some("full"));
+    assert_eq!(
+        config.outputs.as_ref().unwrap().preset.as_deref(),
+        Some("default")
+    );
     assert_eq!(config.exclude_paths.len(), 2);
     assert_eq!(config.exclude_paths[0], "docs/**");
     assert_eq!(config.exclude_paths[1], "test/**");
@@ -41,7 +44,7 @@ fn parse_minimal_boardflow_yml() {
 }
 
 #[test]
-fn parse_boardflow_yml_with_unknown_fields() {
+fn parse_boardflow_yml_rejects_unknown_fields() {
     let tmp = TempDir::new().unwrap();
     let yml_path = tmp.path().join(".boardflow.yml");
     fs::write(
@@ -50,15 +53,35 @@ fn parse_boardflow_yml_with_unknown_fields() {
 version: 1
 unknown_field: hello
 outputs:
-  preset: basic
+  preset: default
 "#,
     )
     .unwrap();
 
-    // serde_yaml by default ignores unknown fields with #[serde(deny_unknown_fields)]
-    // absent, so this should succeed
-    let config = parse_boardflow_yml(&yml_path).unwrap();
-    assert_eq!(config.version, 1);
+    let result = parse_boardflow_yml(&yml_path);
+    assert!(result.is_err(), "unknown fields should be rejected");
+}
+
+#[test]
+fn parse_boardflow_yml_rejects_unknown_outputs_field() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(
+        &yml_path,
+        r#"
+version: 1
+outputs:
+  preset: default
+  extra: true
+"#,
+    )
+    .unwrap();
+
+    let result = parse_boardflow_yml(&yml_path);
+    assert!(
+        result.is_err(),
+        "unknown fields in outputs should be rejected"
+    );
 }
 
 #[test]
@@ -72,6 +95,17 @@ fn validate_schema_v1_accepts_version_1() {
 }
 
 #[test]
+fn validate_schema_v1_rejects_version_0() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(&yml_path, "version: 0\n").unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    let result = validate_schema_v1(&config);
+    assert!(result.is_err());
+}
+
+#[test]
 fn validate_schema_v1_rejects_version_2() {
     let tmp = TempDir::new().unwrap();
     let yml_path = tmp.path().join(".boardflow.yml");
@@ -80,6 +114,60 @@ fn validate_schema_v1_rejects_version_2() {
     let config = parse_boardflow_yml(&yml_path).unwrap();
     let result = validate_schema_v1(&config);
     assert!(result.is_err());
+}
+
+#[test]
+fn validate_schema_v1_accepts_preset_default() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(
+        &yml_path,
+        "version: 1\noutputs:\n  preset: default\n",
+    )
+    .unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    assert!(validate_schema_v1(&config).is_ok());
+}
+
+#[test]
+fn validate_schema_v1_accepts_no_preset() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(&yml_path, "version: 1\noutputs:\n  preset:\n").unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    assert!(validate_schema_v1(&config).is_ok());
+}
+
+#[test]
+fn validate_schema_v1_rejects_preset_custom() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(
+        &yml_path,
+        "version: 1\noutputs:\n  preset: custom\n",
+    )
+    .unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    let result = validate_schema_v1(&config);
+    assert!(result.is_err(), "preset 'custom' should be rejected");
+}
+
+#[test]
+fn validate_schema_v1_rejects_preset_full() {
+    let tmp = TempDir::new().unwrap();
+    let yml_path = tmp.path().join(".boardflow.yml");
+    fs::write(
+        &yml_path,
+        "version: 1\noutputs:\n  preset: full\n",
+    )
+    .unwrap();
+
+    let config = parse_boardflow_yml(&yml_path).unwrap();
+    let result = validate_schema_v1(&config);
+    assert!(result.is_err(), "preset 'full' should be rejected");
 }
 
 #[test]

--- a/crates/kicad/tests/detect_test.rs
+++ b/crates/kicad/tests/detect_test.rs
@@ -1,0 +1,160 @@
+use std::fs;
+
+use boardflow_kicad::detect::{
+    detect_projects, find_boardflow_ymls, resolve_kicad_pro, resolve_pcb_file,
+    resolve_project_files, resolve_root_schematic,
+};
+use tempfile::TempDir;
+
+fn create_project_dir(dir: &std::path::Path, name: &str) {
+    fs::write(dir.join(".boardflow.yml"), "version: 1\n").unwrap();
+    fs::write(dir.join(format!("{name}.kicad_pro")), "{}").unwrap();
+    fs::write(dir.join(format!("{name}.kicad_pcb")), "").unwrap();
+    fs::write(dir.join(format!("{name}.kicad_sch")), "").unwrap();
+}
+
+#[test]
+fn find_boardflow_ymls_in_nested_dirs() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Create two project directories
+    let proj1 = root.join("proj1");
+    fs::create_dir_all(&proj1).unwrap();
+    fs::write(proj1.join(".boardflow.yml"), "version: 1\n").unwrap();
+
+    let proj2 = root.join("sub/proj2");
+    fs::create_dir_all(&proj2).unwrap();
+    fs::write(proj2.join(".boardflow.yml"), "version: 1\n").unwrap();
+
+    let ymls = find_boardflow_ymls(root).unwrap();
+    assert_eq!(ymls.len(), 2);
+}
+
+#[test]
+fn find_boardflow_ymls_returns_error_when_none() {
+    let tmp = TempDir::new().unwrap();
+    let result = find_boardflow_ymls(tmp.path());
+    assert!(result.is_err());
+}
+
+#[test]
+fn detect_projects_returns_parent_dirs() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    let proj = root.join("myproject");
+    fs::create_dir_all(&proj).unwrap();
+    fs::write(proj.join(".boardflow.yml"), "version: 1\n").unwrap();
+
+    let dirs = detect_projects(root).unwrap();
+    assert_eq!(dirs.len(), 1);
+    assert_eq!(dirs[0], proj);
+}
+
+#[test]
+fn resolve_kicad_pro_single_file() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    fs::write(dir.join("Board.kicad_pro"), "{}").unwrap();
+
+    let pro = resolve_kicad_pro(dir).unwrap();
+    assert_eq!(pro.file_name().unwrap(), "Board.kicad_pro");
+}
+
+#[test]
+fn resolve_kicad_pro_no_file_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let result = resolve_kicad_pro(tmp.path());
+    assert!(result.is_err());
+}
+
+#[test]
+fn resolve_kicad_pro_multiple_files_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    fs::write(dir.join("A.kicad_pro"), "{}").unwrap();
+    fs::write(dir.join("B.kicad_pro"), "{}").unwrap();
+
+    let result = resolve_kicad_pro(dir);
+    assert!(result.is_err());
+}
+
+#[test]
+fn resolve_pcb_file_exact_stem() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    fs::write(dir.join("Board.kicad_pcb"), "").unwrap();
+
+    let pcb = resolve_pcb_file(dir, "Board").unwrap();
+    assert_eq!(pcb.file_name().unwrap(), "Board.kicad_pcb");
+}
+
+#[test]
+fn resolve_pcb_file_fallback_different_name() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    fs::write(dir.join("Other.kicad_pcb"), "").unwrap();
+
+    let pcb = resolve_pcb_file(dir, "Board").unwrap();
+    assert_eq!(pcb.file_name().unwrap(), "Other.kicad_pcb");
+}
+
+#[test]
+fn resolve_pcb_file_not_found() {
+    let tmp = TempDir::new().unwrap();
+    let result = resolve_pcb_file(tmp.path(), "Board");
+    assert!(result.is_err());
+}
+
+#[test]
+fn resolve_root_schematic_exact_stem() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    fs::write(dir.join("Board.kicad_sch"), "").unwrap();
+
+    let sch = resolve_root_schematic(dir, "Board").unwrap();
+    assert_eq!(sch.file_name().unwrap(), "Board.kicad_sch");
+}
+
+#[test]
+fn resolve_root_schematic_fallback() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    fs::write(dir.join("Other.kicad_sch"), "").unwrap();
+
+    let sch = resolve_root_schematic(dir, "Board").unwrap();
+    assert_eq!(sch.file_name().unwrap(), "Other.kicad_sch");
+}
+
+#[test]
+fn resolve_root_schematic_not_found() {
+    let tmp = TempDir::new().unwrap();
+    let result = resolve_root_schematic(tmp.path(), "Board");
+    assert!(result.is_err());
+}
+
+#[test]
+fn resolve_project_files_full_project() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    create_project_dir(dir, "MyBoard");
+
+    let pf = resolve_project_files(dir).unwrap();
+    assert_eq!(pf.project_dir, dir);
+    assert_eq!(pf.pro_file.file_name().unwrap(), "MyBoard.kicad_pro");
+    assert_eq!(pf.pcb_file.file_name().unwrap(), "MyBoard.kicad_pcb");
+    assert_eq!(pf.sch_file.file_name().unwrap(), "MyBoard.kicad_sch");
+}
+
+#[test]
+fn resolve_project_files_missing_pcb() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    fs::write(dir.join("Board.kicad_pro"), "{}").unwrap();
+    fs::write(dir.join("Board.kicad_sch"), "").unwrap();
+    // No .kicad_pcb
+
+    let result = resolve_project_files(dir);
+    assert!(result.is_err());
+}

--- a/crates/kicad/tests/detect_test.rs
+++ b/crates/kicad/tests/detect_test.rs
@@ -94,10 +94,26 @@ fn resolve_pcb_file_exact_stem() {
 fn resolve_pcb_file_fallback_different_name() {
     let tmp = TempDir::new().unwrap();
     let dir = tmp.path();
+    // Only one .kicad_pcb with different name → fallback succeeds
     fs::write(dir.join("Other.kicad_pcb"), "").unwrap();
 
     let pcb = resolve_pcb_file(dir, "Board").unwrap();
     assert_eq!(pcb.file_name().unwrap(), "Other.kicad_pcb");
+}
+
+#[test]
+fn resolve_pcb_file_multiple_candidates_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    // Two .kicad_pcb files, stem matches neither → error
+    fs::write(dir.join("A.kicad_pcb"), "").unwrap();
+    fs::write(dir.join("B.kicad_pcb"), "").unwrap();
+
+    let result = resolve_pcb_file(dir, "Board");
+    assert!(
+        result.is_err(),
+        "multiple .kicad_pcb without stem match should error"
+    );
 }
 
 #[test]
@@ -121,10 +137,26 @@ fn resolve_root_schematic_exact_stem() {
 fn resolve_root_schematic_fallback() {
     let tmp = TempDir::new().unwrap();
     let dir = tmp.path();
+    // Only one .kicad_sch with different name → fallback succeeds
     fs::write(dir.join("Other.kicad_sch"), "").unwrap();
 
     let sch = resolve_root_schematic(dir, "Board").unwrap();
     assert_eq!(sch.file_name().unwrap(), "Other.kicad_sch");
+}
+
+#[test]
+fn resolve_root_schematic_multiple_candidates_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+    // Two .kicad_sch files, stem matches neither → error
+    fs::write(dir.join("A.kicad_sch"), "").unwrap();
+    fs::write(dir.join("B.kicad_sch"), "").unwrap();
+
+    let result = resolve_root_schematic(dir, "Board");
+    assert!(
+        result.is_err(),
+        "multiple .kicad_sch without stem match should error"
+    );
 }
 
 #[test]

--- a/crates/kicad/tests/hash_test.rs
+++ b/crates/kicad/tests/hash_test.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use boardflow_kicad::hash::{
-    compute_file_sha256, compute_tree_hash, is_excluded, list_project_files, BUILTIN_EXCLUDES,
+    BUILTIN_EXCLUDES, compute_file_sha256, compute_tree_hash, is_excluded, list_project_files,
 };
 use tempfile::TempDir;
 

--- a/crates/kicad/tests/hash_test.rs
+++ b/crates/kicad/tests/hash_test.rs
@@ -1,0 +1,215 @@
+use std::fs;
+
+use boardflow_kicad::hash::{
+    compute_file_sha256, compute_tree_hash, is_excluded, list_project_files, BUILTIN_EXCLUDES,
+};
+use tempfile::TempDir;
+
+#[test]
+fn is_excluded_matches_lck_pattern() {
+    let patterns: Vec<String> = BUILTIN_EXCLUDES.iter().map(|s| s.to_string()).collect();
+    assert!(is_excluded("project.kicad_pro.lck", &patterns));
+    assert!(is_excluded("sub/dir/file.lck", &patterns));
+}
+
+#[test]
+fn is_excluded_matches_bak_pattern() {
+    let patterns: Vec<String> = BUILTIN_EXCLUDES.iter().map(|s| s.to_string()).collect();
+    assert!(is_excluded("file.bak", &patterns));
+    assert!(is_excluded("deep/nested/file.bak", &patterns));
+}
+
+#[test]
+fn is_excluded_matches_backups_dir() {
+    let patterns: Vec<String> = BUILTIN_EXCLUDES.iter().map(|s| s.to_string()).collect();
+    assert!(is_excluded("proj-backups/file.kicad_sch", &patterns));
+    assert!(is_excluded("sub/proj-backups/file.txt", &patterns));
+}
+
+#[test]
+fn is_excluded_matches_fp_info_cache() {
+    let patterns: Vec<String> = BUILTIN_EXCLUDES.iter().map(|s| s.to_string()).collect();
+    assert!(is_excluded("fp-info-cache", &patterns));
+    assert!(is_excluded("sub/fp-info-cache", &patterns));
+}
+
+#[test]
+fn is_excluded_matches_ds_store() {
+    let patterns: Vec<String> = BUILTIN_EXCLUDES.iter().map(|s| s.to_string()).collect();
+    assert!(is_excluded(".DS_Store", &patterns));
+    assert!(is_excluded("sub/.DS_Store", &patterns));
+}
+
+#[test]
+fn is_excluded_matches_output_dirs() {
+    let patterns: Vec<String> = BUILTIN_EXCLUDES.iter().map(|s| s.to_string()).collect();
+    assert!(is_excluded("output/gerber.gbr", &patterns));
+    assert!(is_excluded("outputs/bom.csv", &patterns));
+    assert!(is_excluded("fabrication/drill.drl", &patterns));
+    assert!(is_excluded("gerber/file.gbr", &patterns));
+    assert!(is_excluded("gerbers/file.gbr", &patterns));
+}
+
+#[test]
+fn is_excluded_does_not_match_normal_files() {
+    let patterns: Vec<String> = BUILTIN_EXCLUDES.iter().map(|s| s.to_string()).collect();
+    assert!(!is_excluded("Board.kicad_pro", &patterns));
+    assert!(!is_excluded("Board.kicad_pcb", &patterns));
+    assert!(!is_excluded("Board.kicad_sch", &patterns));
+    assert!(!is_excluded("sub/component.kicad_sym", &patterns));
+}
+
+#[test]
+fn is_excluded_custom_pattern() {
+    let patterns = vec!["docs/**".to_string()];
+    assert!(is_excluded("docs/readme.md", &patterns));
+    assert!(!is_excluded("src/main.rs", &patterns));
+}
+
+#[test]
+fn list_project_files_excludes_patterns() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    fs::write(dir.join("Board.kicad_pro"), "{}").unwrap();
+    fs::write(dir.join("Board.kicad_pcb"), "").unwrap();
+    fs::write(dir.join("Board.kicad_pro.lck"), "").unwrap();
+    fs::write(dir.join("file.bak"), "").unwrap();
+    fs::write(dir.join("fp-info-cache"), "").unwrap();
+
+    let excludes: Vec<String> = BUILTIN_EXCLUDES.iter().map(|s| s.to_string()).collect();
+    let files = list_project_files(dir, &excludes).unwrap();
+
+    let names: Vec<&str> = files
+        .iter()
+        .map(|p| p.file_name().unwrap().to_str().unwrap())
+        .collect();
+    assert!(names.contains(&"Board.kicad_pro"));
+    assert!(names.contains(&"Board.kicad_pcb"));
+    assert!(!names.contains(&"Board.kicad_pro.lck"));
+    assert!(!names.contains(&"file.bak"));
+    assert!(!names.contains(&"fp-info-cache"));
+}
+
+#[test]
+fn list_project_files_recurses_directories() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    fs::write(dir.join("top.txt"), "top").unwrap();
+    let sub = dir.join("sub");
+    fs::create_dir_all(&sub).unwrap();
+    fs::write(sub.join("nested.txt"), "nested").unwrap();
+
+    let files = list_project_files(dir, &[]).unwrap();
+    assert_eq!(files.len(), 2);
+}
+
+#[test]
+fn compute_file_sha256_known_value() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("test.txt");
+    fs::write(&file_path, "hello\n").unwrap();
+
+    let hash = compute_file_sha256(&file_path).unwrap();
+    // SHA256 of "hello\n"
+    assert_eq!(
+        hash,
+        "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03"
+    );
+}
+
+#[test]
+fn compute_file_sha256_empty_file() {
+    let tmp = TempDir::new().unwrap();
+    let file_path = tmp.path().join("empty.txt");
+    fs::write(&file_path, "").unwrap();
+
+    let hash = compute_file_sha256(&file_path).unwrap();
+    // SHA256 of empty string
+    assert_eq!(
+        hash,
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    );
+}
+
+#[test]
+fn compute_tree_hash_deterministic() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    fs::write(dir.join("a.txt"), "aaa").unwrap();
+    fs::write(dir.join("b.txt"), "bbb").unwrap();
+
+    let hash1 = compute_tree_hash(dir, &[]).unwrap();
+    let hash2 = compute_tree_hash(dir, &[]).unwrap();
+    assert_eq!(hash1, hash2);
+}
+
+#[test]
+fn compute_tree_hash_changes_with_content() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    fs::write(dir.join("a.txt"), "aaa").unwrap();
+    let hash1 = compute_tree_hash(dir, &[]).unwrap();
+
+    fs::write(dir.join("a.txt"), "bbb").unwrap();
+    let hash2 = compute_tree_hash(dir, &[]).unwrap();
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn compute_tree_hash_changes_with_filename() {
+    let tmp1 = TempDir::new().unwrap();
+    let dir1 = tmp1.path();
+    fs::write(dir1.join("a.txt"), "content").unwrap();
+
+    let tmp2 = TempDir::new().unwrap();
+    let dir2 = tmp2.path();
+    fs::write(dir2.join("b.txt"), "content").unwrap();
+
+    let hash1 = compute_tree_hash(dir1, &[]).unwrap();
+    let hash2 = compute_tree_hash(dir2, &[]).unwrap();
+
+    assert_ne!(hash1, hash2);
+}
+
+#[test]
+fn compute_tree_hash_excludes_files() {
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    fs::write(dir.join("a.txt"), "aaa").unwrap();
+    fs::write(dir.join("b.bak"), "bak").unwrap();
+
+    let excludes = vec!["**/*.bak".to_string()];
+    let hash_with_exclude = compute_tree_hash(dir, &excludes).unwrap();
+
+    // Compare with a dir that only has a.txt
+    let tmp2 = TempDir::new().unwrap();
+    let dir2 = tmp2.path();
+    fs::write(dir2.join("a.txt"), "aaa").unwrap();
+
+    let hash_without_bak = compute_tree_hash(dir2, &[]).unwrap();
+    assert_eq!(hash_with_exclude, hash_without_bak);
+}
+
+#[test]
+fn compute_tree_hash_sorted_order() {
+    // Create files in reverse order, tree_hash should be the same regardless of creation order
+    let tmp1 = TempDir::new().unwrap();
+    let dir1 = tmp1.path();
+    fs::write(dir1.join("z.txt"), "z").unwrap();
+    fs::write(dir1.join("a.txt"), "a").unwrap();
+
+    let tmp2 = TempDir::new().unwrap();
+    let dir2 = tmp2.path();
+    fs::write(dir2.join("a.txt"), "a").unwrap();
+    fs::write(dir2.join("z.txt"), "z").unwrap();
+
+    let hash1 = compute_tree_hash(dir1, &[]).unwrap();
+    let hash2 = compute_tree_hash(dir2, &[]).unwrap();
+    assert_eq!(hash1, hash2);
+}

--- a/crates/kicad/tests/report_test.rs
+++ b/crates/kicad/tests/report_test.rs
@@ -1,0 +1,279 @@
+use boardflow_kicad::report::{DrcReport, ErcReport};
+
+#[test]
+fn parse_erc_report_with_violations() {
+    let json = r#"{
+        "meta": {"version": 0},
+        "sheets": [
+            {
+                "path": "/",
+                "violations": [
+                    {
+                        "type": "pin_not_connected",
+                        "description": "Pin not connected",
+                        "severity": "error",
+                        "items": [
+                            {
+                                "description": "Pin U1 pad 1",
+                                "pos": {"x": 100.0, "y": 50.0}
+                            }
+                        ],
+                        "excluded": false
+                    },
+                    {
+                        "type": "power_pin_not_driven",
+                        "description": "Power pin not driven",
+                        "severity": "warning",
+                        "items": [],
+                        "excluded": false
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let report = ErcReport::parse(json).unwrap();
+    assert_eq!(report.sheets.len(), 1);
+    assert_eq!(report.sheets[0].violations.len(), 2);
+    assert_eq!(report.all_violations().len(), 2);
+    assert_eq!(report.actionable_violations().len(), 2);
+    assert!(report.has_errors());
+}
+
+#[test]
+fn parse_erc_report_no_errors() {
+    let json = r#"{
+        "meta": {"version": 0},
+        "sheets": [
+            {
+                "path": "/",
+                "violations": [
+                    {
+                        "type": "pin_not_connected",
+                        "description": "Pin not connected",
+                        "severity": "warning",
+                        "items": [],
+                        "excluded": false
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let report = ErcReport::parse(json).unwrap();
+    assert!(!report.has_errors());
+}
+
+#[test]
+fn parse_erc_report_excluded_violations_filtered() {
+    let json = r#"{
+        "meta": {"version": 0},
+        "sheets": [
+            {
+                "path": "/",
+                "violations": [
+                    {
+                        "type": "pin_not_connected",
+                        "description": "Pin not connected",
+                        "severity": "error",
+                        "items": [],
+                        "excluded": true
+                    },
+                    {
+                        "type": "missing_power_flag",
+                        "description": "Missing power flag",
+                        "severity": "exclusion",
+                        "items": [],
+                        "excluded": false
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let report = ErcReport::parse(json).unwrap();
+    assert_eq!(report.all_violations().len(), 2);
+    assert_eq!(report.actionable_violations().len(), 0);
+    assert!(!report.has_errors());
+}
+
+#[test]
+fn parse_erc_report_multiple_sheets() {
+    let json = r#"{
+        "meta": {"version": 0},
+        "sheets": [
+            {
+                "path": "/",
+                "violations": [
+                    {
+                        "type": "err1",
+                        "description": "Error 1",
+                        "severity": "error",
+                        "items": [],
+                        "excluded": false
+                    }
+                ]
+            },
+            {
+                "path": "/sub",
+                "violations": [
+                    {
+                        "type": "err2",
+                        "description": "Error 2",
+                        "severity": "error",
+                        "items": [],
+                        "excluded": false
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let report = ErcReport::parse(json).unwrap();
+    assert_eq!(report.all_violations().len(), 2);
+}
+
+#[test]
+fn parse_erc_empty_sheets() {
+    let json = r#"{"meta": {"version": 0}, "sheets": []}"#;
+    let report = ErcReport::parse(json).unwrap();
+    assert_eq!(report.all_violations().len(), 0);
+    assert!(!report.has_errors());
+}
+
+#[test]
+fn parse_drc_report_with_all_sections() {
+    let json = r#"{
+        "meta": {"version": 0},
+        "violations": [
+            {
+                "type": "clearance",
+                "description": "Clearance violation",
+                "severity": "error",
+                "items": [
+                    {"description": "Pad to pad", "pos": {"x": 10.0, "y": 20.0}}
+                ],
+                "excluded": false
+            }
+        ],
+        "unconnected_items": [
+            {
+                "type": "unconnected",
+                "description": "Unconnected pad",
+                "severity": "error",
+                "items": [],
+                "excluded": false
+            }
+        ],
+        "schematic_parity": [
+            {
+                "type": "missing_footprint",
+                "description": "Missing footprint",
+                "severity": "warning",
+                "items": [],
+                "excluded": false
+            }
+        ]
+    }"#;
+
+    let report = DrcReport::parse(json).unwrap();
+    assert_eq!(report.violations.len(), 1);
+    assert_eq!(report.unconnected_items.len(), 1);
+    assert_eq!(report.schematic_parity.len(), 1);
+    assert_eq!(report.all_violations().len(), 3);
+    assert!(report.has_errors());
+}
+
+#[test]
+fn parse_drc_report_empty_optional_sections() {
+    let json = r#"{
+        "meta": {"version": 0},
+        "violations": [
+            {
+                "type": "clearance",
+                "description": "Clearance violation",
+                "severity": "warning",
+                "items": [],
+                "excluded": false
+            }
+        ]
+    }"#;
+
+    let report = DrcReport::parse(json).unwrap();
+    assert_eq!(report.unconnected_items.len(), 0);
+    assert_eq!(report.schematic_parity.len(), 0);
+    assert_eq!(report.all_violations().len(), 1);
+    assert!(!report.has_errors());
+}
+
+#[test]
+fn parse_drc_actionable_excludes_excluded() {
+    let json = r#"{
+        "meta": {"version": 0},
+        "violations": [
+            {
+                "type": "clearance",
+                "description": "Clearance violation",
+                "severity": "error",
+                "items": [],
+                "excluded": true
+            },
+            {
+                "type": "track_width",
+                "description": "Track width violation",
+                "severity": "error",
+                "items": [],
+                "excluded": false
+            }
+        ]
+    }"#;
+
+    let report = DrcReport::parse(json).unwrap();
+    assert_eq!(report.all_violations().len(), 2);
+    assert_eq!(report.actionable_violations().len(), 1);
+    assert_eq!(
+        report.actionable_violations()[0].violation_type,
+        "track_width"
+    );
+}
+
+#[test]
+fn violation_item_position_parsing() {
+    let json = r#"{
+        "meta": {"version": 0},
+        "sheets": [
+            {
+                "path": "/",
+                "violations": [
+                    {
+                        "type": "test",
+                        "description": "Test",
+                        "severity": "error",
+                        "items": [
+                            {"description": "Item with pos", "pos": {"x": 1.5, "y": 2.5}},
+                            {"description": "Item without pos"}
+                        ],
+                        "excluded": false
+                    }
+                ]
+            }
+        ]
+    }"#;
+
+    let report = ErcReport::parse(json).unwrap();
+    let violation = &report.sheets[0].violations[0];
+    assert_eq!(violation.items.len(), 2);
+    let pos = violation.items[0].pos.as_ref().unwrap();
+    assert_eq!(pos.x, 1.5);
+    assert_eq!(pos.y, 2.5);
+    assert!(violation.items[1].pos.is_none());
+}
+
+#[test]
+fn parse_invalid_json_returns_error() {
+    let result = ErcReport::parse("not json");
+    assert!(result.is_err());
+
+    let result = DrcReport::parse("{invalid}");
+    assert!(result.is_err());
+}

--- a/docs/logs/73/worklog.md
+++ b/docs/logs/73/worklog.md
@@ -405,3 +405,30 @@ cargo test -p boardflow-kicad
 ### 残リスク
 
 - 実行系は単体テスト中心のため、KiCad 実環境での end-to-end 検証は Phase 2 で別途必要。
+
+---
+
+## PR作成結果 (2026-05-04)
+
+### PR情報
+
+- **PR番号**: #83
+- **URL**: https://github.com/f0reachARR/boardflow/pull/83
+- **タイトル**: `feat(kicad): add boardflow-kicad crate (Issue #73 Phase 1)`
+- **base**: `main` ← `feature/73-kicad-crate`
+- **Refs**: #73
+
+### 最終確認
+
+- 未コミット変更: なし
+- push 済み: origin/feature/73-kicad-crate に最新コミットあり
+- code review: `pr_ready: true`（5回目レビュー）
+- docs review: ドキュメント不整合なしを確認（5回目レビュー）
+- `cargo test -p boardflow-kicad`: 72 tests passed
+- `cargo check --workspace`: passed
+
+### 残リスク
+
+- KiCad / xvfb 実環境を伴う統合テストは未実施（Phase 2 接続時に確認予定）
+- `ibom.rs` の timeout/kill_on_drop は Phase 2 以降で対応
+- `hash.rs` の GlobSet 毎回再構築はパフォーマンス改善余地あり（Phase 2 以降）

--- a/docs/logs/73/worklog.md
+++ b/docs/logs/73/worklog.md
@@ -59,3 +59,97 @@ cargo test -p boardflow-kicad
 - `ibom.rs` も同様にxvfb環境が必要なためinteg testはPhase 2以降
 - `tokio::process::Child` の `wait_with_output` が ownership を取るため、timeout時の明示的kill は省略（tokio側でdrop時にkillされる仕様）
 - `serde_yaml` は deprecated 表示があるが 0.9 系で機能的に問題なし
+
+---
+
+## Review結果 (2026-05-04)
+
+### 総評
+
+- Phase 1 の crate 追加、workspace 組み込み、hash/report の基礎実装までは進んでいるが、bash 実装との忠実性と spec 準拠に未解決の差分が残る。
+- とくに config validation、project file fallback 解決、CLI オプション再現、timeout 挙動に受け入れ条件との不一致があるため、このままの PR 化は不可。
+
+### 再確認テスト結果
+
+- `mise exec -- cargo test -p boardflow-kicad`: 51 tests passed
+- `mise exec -- cargo check --workspace`: passed
+
+### レビュー結果
+
+- `pr_ready: false`
+
+### 必須修正
+
+1. `config.rs` が spec の schema v1 を満たしていない。未知フィールド拒否、`outputs.preset` の許可値制約、型検証が未実装で、現状は version しか見ていない。`config_test.rs` でも未知フィールド許容を成功ケースとして固定しており、spec と逆転している。
+2. `detect.rs` の `.kicad_pcb` / `.kicad_sch` fallback が「最初に見つかった1件」を返しており、bash 実装の「fallback 時は一意な1件のみ許可」と一致していない。複数候補時に誤った project 解決を引き起こす。
+3. `cli.rs` の KiCad 呼び出しが bash 実装を再現していない。ERC/DRC の `--severity-all` と `--exit-code-violations` が欠落し、PDF/SVG/drill/pos/render でも既存オプションが抜けているため、生成物や exit code の意味が変わる。
+4. `cli.rs` の timeout 実装は、コメントに反して timeout 時に子プロセス kill を保証していない。`tokio::process::Child` は既定では drop で継続実行されるため、300 秒 timeout の受け入れ条件を満たしたとは言えない。
+
+### 任意改善
+
+1. `detect.rs` に required file exclusion validation 相当の API がなく、`action/lib/detect.sh` の `validate_required_files` 相当ロジックが欠けている。Phase 2 以降で再実装を避けるなら crate に寄せた方がよい。
+2. `hash.rs` は `is_excluded` ごとに `GlobSet` を再構築している。ホットパス化するなら compile 済み matcher を保持する API の方が扱いやすい。
+3. `ibom.rs` も `KicadCli` と同様の timeout/kill 方針を明示しておくと運用時の一貫性が出る。
+
+### テスト不足
+
+- `cli.rs` のコマンド組み立てテストがなく、既存 bash オプションとの差分を検知できない。
+- `detect.rs` の複数 fallback 候補ケース（`.kicad_pcb` 複数、`.kicad_sch` 複数）の失敗テストがない。
+- `config.rs` の未知フィールド拒否、`outputs.preset != default` 拒否、型不正拒否のテストがない。
+- bash 実装との `tree_hash` 同値性を直接比較する回帰テストがない。
+- timeout 時にプロセスが終了することを確認するテストがない。
+
+---
+
+## Phase 1 レビュー指摘修正 (2026-05-04)
+
+### 修正内容
+
+| 指摘 | 修正内容 |
+|---|---|
+| 1. config schema厳格化 | `BoardflowConfig`, `OutputsConfig` に `#[serde(deny_unknown_fields)]` 追加。`validate_schema_v1` で `outputs.preset` が指定時 `"default"` のみ許可に制限 |
+| 2. detect fallback修正 | `resolve_pcb_file`, `resolve_root_schematic` を「一意な1件のみ」に修正。2件以上→`MultipleKicadPcb`/`MultipleKicadSch` エラー追加 |
+| 3. CLI オプション修正 | bash実装と同一のオプションに修正（`--severity-all`, `--exit-code-violations`, `--layers`, `--mode-multi`, `--format excellon`, `--excellon-separate-th`, `--format csv`, `--quality basic`）。各コマンドの引数を `build_*_args` pub メソッドに分離 |
+| 4. timeout時の明示的kill | `exec()`, `exec_erc_drc()` の `Command::new()` に `.kill_on_drop(true)` を設定。誤解コメント「On timeout, the child future is dropped which kills the process」を削除 |
+
+### export_pcb_svg APIの変更
+
+`export_pcb_svg` の第3引数を `layers: &str` → `side: &str` に変更。`"top"` / `"bottom"` を渡すとbash実装と同じレイヤーセットが適用される。
+
+### 追加/更新テスト
+
+| テストファイル | 変更 |
+|---|---|
+| `tests/cli_test.rs` | **新規** 13テスト — 全コマンドの引数組み立てをbashと比較 |
+| `tests/config_test.rs` | 16テスト（10→16）: 未知フィールド拒否(2件)、preset "custom"/"full" 拒否、version 0 拒否、preset "default" 許可、preset null 許可 |
+| `tests/detect_test.rs` | 16テスト（14→16）: 複数 `.kicad_pcb` / `.kicad_sch` 候補時のエラーケース追加 |
+
+### テスト結果
+
+```
+cargo test -p boardflow-kicad
+72 tests passed (0 failed, 0 ignored)
+- cli_test: 13 tests
+- config_test: 16 tests
+- detect_test: 16 tests
+- hash_test: 17 tests
+- report_test: 10 tests
+```
+
+`cargo check --workspace` もパス。
+
+### 残リスク
+
+- `ibom.rs` は `kill_on_drop` 未適用（改善推奨事項の範囲、Phase 2以降で対応可）
+- `hash.rs` の `is_excluded` は毎回 GlobSet 再構築（改善推奨事項の範囲）
+
+### ドキュメント確認
+
+- `docs/spec.md` の `.boardflow.yml` v1 制約と current `config.rs` 実装が不一致。
+- `docs/external/kicad-erc-drc-findings.md` と `docs/external/kicad-docker-cli.md` で前提にしている KiCad CLI オプション群が `cli.rs` で再現されていない。
+- `worklog.md` 末尾の「drop時にkillされる仕様」という記述は Tokio の既定挙動と一致しないため修正が必要。
+
+### レビュー残リスク
+
+- KiCad 実行環境がなくても通る単体テストだけでは、Phase 2 で command-line 互換性の差分が顕在化する可能性が高い。
+- project 検出の誤解決は、誤った board project を build 対象にして Plan/Create payload を壊すリスクがある。

--- a/docs/logs/73/worklog.md
+++ b/docs/logs/73/worklog.md
@@ -17,3 +17,45 @@
 ## 残リスク
 - Dockerfile内でのRustビルド時間
 - Docker imageサイズへの影響
+
+---
+
+## Phase 1 実装 (2026-05-04)
+
+### 実装内容
+ブランチ: `feature/73-kicad-crate` (origin/mainから作成)
+
+`crates/kicad/` を新規作成。以下のモジュールを実装:
+
+| モジュール | 内容 |
+|---|---|
+| `error.rs` | `KicadError` enum (thiserror) — 全エラーを集約 |
+| `cli.rs` | `KicadCli` 構造体 — KiCad CLIコマンド10種をラップ（300秒timeout, ERC/DRC exit code 5対応） |
+| `report.rs` | `ErcReport` / `DrcReport` — KiCad ERC/DRC JSON出力のserdeパース |
+| `detect.rs` | `.boardflow.yml` 探索、`.kicad_pro`/`.kicad_pcb`/`.kicad_sch` 解決 |
+| `config.rs` | `.boardflow.yml` YAMLパース、v1バリデーション、excludeマージ |
+| `hash.rs` | glob exclude、SHA256計算、tree_hash（ソート済みファイル一覧のハッシュ） |
+| `ibom.rs` | `xvfb-run generate_interactive_bom` ラッパー |
+
+### ワークスペース変更
+- `Cargo.toml`: `members` に `"crates/kicad"` 追加
+- `[workspace.dependencies]` に `serde_yaml`, `globset`, `walkdir`, `tempfile` 追加
+
+### テスト結果
+```
+cargo test -p boardflow-kicad
+51 tests passed (0 failed, 0 ignored)
+- config_test: 10 tests (YAML parse/validate, merge_excludes)
+- detect_test: 14 tests (find ymls, resolve pro/pcb/sch, project files)
+- hash_test: 17 tests (is_excluded, file sha256, tree_hash determinism)
+- report_test: 10 tests (ERC/DRC parse, violations filter, has_errors)
+```
+
+### 更新ドキュメント
+- `docs/logs/73/worklog.md` (本ファイル)
+
+### 残リスク
+- CLIテスト（`cli.rs`）はKiCad未インストール環境のため `#[ignore]` 対象（今回テストファイルなし — Phase 2以降でinteg test追加予定）
+- `ibom.rs` も同様にxvfb環境が必要なためinteg testはPhase 2以降
+- `tokio::process::Child` の `wait_with_output` が ownership を取るため、timeout時の明示的kill は省略（tokio側でdrop時にkillされる仕様）
+- `serde_yaml` は deprecated 表示があるが 0.9 系で機能的に問題なし

--- a/docs/logs/73/worklog.md
+++ b/docs/logs/73/worklog.md
@@ -112,9 +112,9 @@ cargo test -p boardflow-kicad
 | 3. CLI オプション修正 | bash実装と同一のオプションに修正（`--severity-all`, `--exit-code-violations`, `--layers`, `--mode-multi`, `--format excellon`, `--excellon-separate-th`, `--format csv`, `--quality basic`）。各コマンドの引数を `build_*_args` pub メソッドに分離 |
 | 4. timeout時の明示的kill | `exec()`, `exec_erc_drc()` の `Command::new()` に `.kill_on_drop(true)` を設定。誤解コメント「On timeout, the child future is dropped which kills the process」を削除 |
 
-### export_pcb_svg APIの変更
+### export_pcb_svg / render_3d APIの変更
 
-`export_pcb_svg` の第3引数を `layers: &str` → `side: &str` に変更。`"top"` / `"bottom"` を渡すとbash実装と同じレイヤーセットが適用される。
+`export_pcb_svg` と `render_3d` の side パラメータを `&str` → `PcbSide` enum に変更。`PcbSide::Top` / `PcbSide::Bottom` のみ受け付け、不正な値はコンパイル時に排除される。
 
 ### 追加/更新テスト
 
@@ -153,3 +153,255 @@ cargo test -p boardflow-kicad
 
 - KiCad 実行環境がなくても通る単体テストだけでは、Phase 2 で command-line 互換性の差分が顕在化する可能性が高い。
 - project 検出の誤解決は、誤った board project を build 対象にして Plan/Create payload を壊すリスクがある。
+
+---
+
+## Review結果 (2026-05-04, 2回目)
+
+### 総評
+
+- 前回レビューで必須としていた4件は、実装・テスト・spec との対応の観点で解消を確認した。
+- ただし、修正後の `export_pcb_svg` API に、契約外の `side` 値を受けた際に黙って top 面レイヤーへフォールバックする新しい挙動が入っており、誤った成果物を静かに生成し得る。
+
+### 再確認項目
+
+1. config schema厳格化
+	- `BoardflowConfig` / `OutputsConfig` に `#[serde(deny_unknown_fields)]` 追加を確認。
+	- `validate_schema_v1` で `outputs.preset` が `default` のみ許可されることを確認。
+	- `tests/config_test.rs` に未知フィールド拒否・非対応 preset 拒否の回帰テストを確認。
+2. detect fallback
+	- `.kicad_pcb` / `.kicad_sch` fallback が「ちょうど1件のみ成功」に修正され、複数候補時に `MultipleKicadPcb` / `MultipleKicadSch` を返すことを確認。
+	- `tests/detect_test.rs` に複数候補エラーの回帰テストを確認。
+3. CLI オプション
+	- `action/lib/kicad.sh` と `crates/kicad/src/cli.rs` を照合し、ERC/DRC、PDF、SVG、Gerber、Drill、BOM、POS、3D render の各引数が一致することを確認。
+	- `tests/cli_test.rs` 13件で引数組み立ての回帰を確認。
+4. kill_on_drop
+	- `exec()` / `exec_erc_drc()` の `Command::new()` に `.kill_on_drop(true)` が追加されていることを確認。
+	- Tokio の `kill_on_drop` は strict な reap 保証ではないが、前回指摘していた「drop 既定で継続実行される」問題への修正としては妥当。
+
+### テスト結果
+
+- `mise exec -- cargo test -p boardflow-kicad`: 72 tests passed
+- `mise exec -- cargo check --workspace`: passed
+- `get_errors` on `crates/kicad`: no errors
+
+### レビュー結果
+
+- `pr_ready: false`
+
+### 必須修正
+
+1. `crates/kicad/src/cli.rs` の `build_pcb_svg_args` が、`side` に `bottom` 以外の任意値を受けると黙って top 面レイヤーへフォールバックする。Issue #73 の作業ログでは `"top" / "bottom" を渡す` 契約として整理されている一方、実装は契約違反入力をエラーにせず誤った成果物生成へ進む。Phase 2 以降で呼び出し側をつないだ際、typo や値変換ミスを検知できないため、`side` を enum 化するか、少なくとも `top|bottom` 以外を `Result` で拒否する必要がある。
+
+### 任意改善
+
+- なし
+
+### テスト不足
+
+- `export_pcb_svg` / `build_pcb_svg_args` に対する不正 `side` 値の失敗テストがない。
+
+### ドキュメント確認
+
+- `docs/spec.md` の Phase 1 対象範囲と、今回確認した4件の修正内容は整合している。
+- `docs/external/kicad-docker-cli.md` に記載の ERC/DRC オプションと current 実装は整合している。
+
+### PR/完了結果
+
+- 4件の前回指摘はクローズ可能。
+- ただし `export_pcb_svg` の入力検証を入れるまでは PR ready とは判定しない。
+
+### 残リスク
+
+- `kill_on_drop(true)` は timeout 後の継続実行を防ぐ意図には沿うが、Unix 上の zombie cleanup は Tokio の best-effort であり、厳密な後始末保証まではしない。
+- KiCad 実バイナリを伴う統合確認は未実施のため、Phase 2 統合時に CLI 実行時差分が出る可能性は残る。
+
+---
+
+## Review結果 (2026-05-04, 3回目)
+
+### 総評
+
+- 前回レビューで唯一の必須修正としていた SVG/3D render の `side` 入力検証は、`PcbSide` enum 導入により API 境界で解消された。
+- `crates/kicad/src/cli.rs` では `export_pcb_svg` / `render_3d` / 各 arg builder が `PcbSide` を受け取り、`Top` / `Bottom` 以外の値を型レベルで受け付けない。
+- `crates/kicad/tests/cli_test.rs` の top/bottom ケースも `PcbSide::Top` / `PcbSide::Bottom` に更新されており、前回懸念していた「任意文字列が静かに top へフォールバックする」問題は再発していない。
+
+### 再確認項目
+
+1. `PcbSide` enum (`Top`, `Bottom`) が `crates/kicad/src/cli.rs` に追加され、`as_str()` と SVG layer 解決が enum 起点になっていることを確認。
+2. `export_pcb_svg` / `render_3d` と `build_pcb_svg_args` / `build_render_3d_args` が `&str` ではなく `PcbSide` を受け取ることを確認。
+3. `crates/kicad/src/lib.rs` から `PcbSide` が re-export され、crate 外からも同じ型を利用できることを確認。
+4. `crates/kicad/tests/cli_test.rs` で top/bottom の回帰テストが enum ベースに更新されていることを確認。
+5. `get_errors` on `crates/kicad`: no errors。
+
+### テスト結果
+
+- ユーザー申告: `cargo test -p boardflow-kicad` 72 tests passed
+- ユーザー申告: `cargo check --workspace` passed
+- 追加確認: `get_errors` on `crates/kicad` returned no errors
+
+### レビュー結果
+
+- `pr_ready: false`
+
+### 必須修正
+
+1. `docs/logs/73/worklog.md` に旧 API 契約の記述が残っている。Phase 1 修正内容の節で、`export_pcb_svg` の第3引数が `side: &str` であり `"top" / "bottom"` を渡す契約だとまだ記載されているが、現実の実装は `PcbSide` enum へ更新済み。Issue 成果物としての worklog と実装が不一致のままなので、PR 前に記述を最新状態へ直す必要がある。
+
+### 任意改善
+
+- なし
+
+### テスト不足
+
+- 今回の修正観点に限れば追加の不足は見当たらない。enum 化により不正 `side` 値は型レベルで表現不能になっている。
+
+### ドキュメント確認
+
+- `docs/spec.md` の Phase 1 スコープと今回の型安全化は整合している。
+- `docs/external/kicad-docker-cli.md` の top/bottom 固定値前提とも矛盾しない。
+- ただし `docs/logs/73/worklog.md` の API 説明だけが旧状態のまま残っている。
+
+### PR/完了結果
+
+- 前回レビューの唯一のコード指摘はクローズ可能。
+- ただし Issue 作業ログの記述不整合が残るため、このレビューでは PR ready とは判定しない。
+
+### 残リスク
+
+- code と test は整合しているため、残るリスクは主に成果物ドキュメントの誤読による後続 Phase での認識ずれ。
+
+---
+
+## ドキュメント確認 (2026-05-04, Phase 1 docs review)
+
+### 確認対象
+
+- `docs/logs/73/worklog.md`
+- `README.md`
+- `docs/spec.md`
+- `docs/technology.md`
+- `crates/kicad/Cargo.toml`
+- `docs/external/kicad-docker-cli.md`
+- `docs/external/kicad-erc-drc-findings.md`
+
+### 確認結果
+
+- `docs/logs/73/worklog.md` は、Phase 1 実装スコープ（`crates/kicad/` 新規作成、7モジュール、72 tests pass、`PcbSide` enum 導入）と整合している。
+- 直前レビュー履歴では `worklog` 自体の不整合を指摘していたが、現時点のファイル本文には `PcbSide` 化後の記述が反映されており、その指摘はクローズ可能。
+- `README.md` は現時点では環境構築・実行方法の案内が中心であり、Phase 1 の内部 crate 追加だけを理由にした更新は不要。
+- `docs/spec.md` は `.boardflow.yml` schema、project 検出、KiCad CLI 実行方針を既に記述しており、Phase 1 実装内容と矛盾しない。
+- `docs/technology.md` は採用技術の上位方針を扱っており、内部用 `crates/kicad/` 追加に伴う更新は不要。
+- `docs/external/kicad-docker-cli.md` と `docs/external/kicad-erc-drc-findings.md` の前提は current `crates/kicad/src/cli.rs` / `report.rs` と整合している。
+
+### 必須修正
+
+1. `crates/kicad/Cargo.toml` に `description` がなく、新規 crate の目的が package metadata から判別できない。Issue #73 Phase 1 の成果物として crate 自体の説明を追加する必要がある。
+
+### 任意改善
+
+- なし
+
+### ドキュメント確認結果
+
+- `docs_ready: false`
+
+### PR/完了結果
+
+- 既存ドキュメント（`README.md`, `docs/spec.md`, `docs/technology.md`）に Phase 1 起因の追加更新は不要。
+- ただし crate metadata の説明不足が残るため、ドキュメント観点では PR 作成可とは判定しない。
+
+### 残リスク
+
+- `Cargo.toml` metadata が不足したままだと、workspace 外から crate の責務を追う際に意図が伝わりにくい。
+
+---
+
+## Review結果 (2026-05-04, 4回目・最終)
+
+### 総評
+
+- 前回指摘していた `PcbSide` 化の worklog 不整合は解消され、CLI 引数・detect fallback・`kill_on_drop(true)`・crate metadata 追加も実装内容と整合している。
+- ただし `.boardflow.yml` schema の厳格化について、spec が要求する「型不一致は検出エラー」と現行実装がまだ一致していない。
+
+### テスト結果
+
+- ユーザー申告: `cargo test -p boardflow-kicad` 72 tests passed
+- ユーザー申告: `cargo check --workspace` passed
+- 追加確認: `get_errors` on `crates/kicad` returned no errors
+
+### レビュー結果
+
+- `pr_ready: false`
+
+### 必須修正
+
+1. `outputs.preset: null` を現在の実装が許容しており、`docs/spec.md` の schema 要件と矛盾している。spec では「未知フィールド、型不一致、非対応versionは検出エラー」と明記されている一方、`crates/kicad/src/config.rs` の `OutputsConfig` は `preset: Option<String>` のため YAML null を `None` として受理し、`validate_schema_v1` もそれをエラーにしない。さらに `crates/kicad/tests/config_test.rs` には `validate_schema_v1_accepts_no_preset` として `outputs:\n  preset:` を成功ケースにしている。`outputs` 自体の省略は許容してもよいが、`preset` フィールドを明示した上で null を与えるケースは型不一致として reject しないと spec 準拠にならない。
+
+### 任意改善
+
+- なし
+
+### テスト不足
+
+- `outputs.preset: null` を reject する回帰テストがない。spec に合わせるなら、parse もしくは validation のどちらで落とすかを固定し、その失敗テストを追加する必要がある。
+
+### ドキュメント確認
+
+- `docs/logs/73/worklog.md` の `PcbSide` 記述は current 実装と整合している。
+- `docs/external/kicad-docker-cli.md` と `crates/kicad/src/cli.rs` の KiCad CLI オプションは整合している。
+- 未解消の不整合は `docs/spec.md` の schema 厳格性と `crates/kicad/src/config.rs` / `crates/kicad/tests/config_test.rs` の null 許容のみ。
+
+### PR/完了結果
+
+- 前回までの指摘はクローズできる。
+- ただし schema 厳格性の未解消が残るため、この時点では PR ready とは判定しない。
+
+### 残リスク
+
+- `outputs.preset: null` を含む設定を静かに受理すると、MVP の「厳格な schema 検証」を前提にした後続 Phase のエラー設計と齟齬が出る。
+
+---
+
+## Review結果 (2026-05-04, 5回目・Phase 1 最終判定)
+
+### 総評
+
+- 前回の最終ブロッカーだった `outputs.preset: null` 許容は、`OutputsConfig.preset` の `String` 化と `validate_schema_v1` の `"default"` 固定チェックで解消された。
+- `crates/kicad/src/config.rs` は `#[serde(deny_unknown_fields)]` を維持しつつ、`outputs` 省略は許容、`preset` の不正値・空値は reject する現在の Phase 1 要件に整合している。
+- `crates/kicad/src/cli.rs` の `kill_on_drop(true)`、`PcbSide` enum、bash 同等の引数組み立て、`crates/kicad/Cargo.toml` の metadata 追加も維持されており、既知の必須指摘はクローズ可能。
+
+### 確認結果
+
+- ユーザー申告: `cargo test -p boardflow-kicad` 72 tests passed
+- ユーザー申告: `cargo check --workspace` passed
+- 追加確認: `mise exec -- cargo test -p boardflow-kicad validate_schema_v1_rejects_null_preset -- --exact` passed
+- 追加確認: `get_errors` on `crates/kicad` returned no errors
+
+### レビュー結果
+
+- `pr_ready: true`
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- `crates/kicad/src/ibom.rs` は `cli.rs` と異なり timeout / process cleanup 方針をまだ持たないため、Phase 2 以降で実行管理をそろえる余地はある。
+
+### テスト不足
+
+- KiCad / xvfb 実バイナリを使う統合テストは未実施のため、Phase 2 接続時に実行環境差分の確認は引き続き必要。
+
+### ドキュメント確認
+
+- `docs/logs/73/worklog.md`、`docs/spec.md`、`docs/external/kicad-docker-cli.md`、`docs/external/kicad-erc-drc-findings.md` の current 実装との不整合は見当たらない。
+
+### PR/完了結果
+
+- Issue #73 Phase 1 は PR 作成可と判定する。
+
+### 残リスク
+
+- 実行系は単体テスト中心のため、KiCad 実環境での end-to-end 検証は Phase 2 で別途必要。


### PR DESCRIPTION
## 概要

Refs #73

Issue #73「boardflow-action entrypointをRustバイナリへ移行」の **Phase 1** 実装。  
`crates/kicad/` を新規作成し、KiCad CLI ラッパー・出力パース・プロジェクト検出・設定ファイルパース・ハッシュ計算・iBOM生成の7モジュールを実装した。

---

## 要件（Phase 1 スコープ）

- KiCad CLI コマンド10種のラッパー（ERC/DRC/PDF/SVG/Gerber/Drill/BOM/POS/3D render）
- ERC/DRC JSON レポートパース
- \`.boardflow.yml\` スキーマ v1 パース・厳格バリデーション
- プロジェクトファイル検出（\`.kicad_pro\` / \`.kicad_pcb\` / \`.kicad_sch\`）
- SHA256 ファイルハッシュ・tree_hash（glob exclude 対応）
- iBOM 生成ラッパー

---

## 調査結果

- \`action/lib/kicad.sh\` の KiCad CLI オプションを全量照合し、\`cli.rs\` に再現
- KiCad ERC/DRC は exit code 5 が violations あり（正常終了扱い）— \`exec_erc_drc()\` で分岐
- \`tokio::process::Child\` は既定では drop で kill されないため \`.kill_on_drop(true)\` を明示設定
- \`serde_yaml 0.9\` で \`#[serde(deny_unknown_fields)]\` を活用し、未知フィールドを reject

---

## 実装概要

### 新規ファイル

| ファイル | 内容 |
|---|---|
| \`crates/kicad/Cargo.toml\` | crate 設定（description 含む） |
| \`crates/kicad/src/lib.rs\` | モジュール宣言・\`PcbSide\` re-export |
| \`crates/kicad/src/error.rs\` | \`KicadError\` enum (thiserror) |
| \`crates/kicad/src/cli.rs\` | \`KicadCli\` 構造体・\`PcbSide\` enum・300秒timeout・kill_on_drop |
| \`crates/kicad/src/report.rs\` | \`ErcReport\` / \`DrcReport\` — serde パース |
| \`crates/kicad/src/detect.rs\` | プロジェクトファイル検出（fallback は一意な1件のみ許可） |
| \`crates/kicad/src/config.rs\` | \`.boardflow.yml\` v1 パース・\`deny_unknown_fields\`・preset 厳格検証 |
| \`crates/kicad/src/hash.rs\` | glob exclude・SHA256・tree_hash |
| \`crates/kicad/src/ibom.rs\` | \`xvfb-run generate_interactive_bom\` ラッパー |

### 変更ファイル

| ファイル | 内容 |
|---|---|
| \`Cargo.toml\` (ルート) | \`crates/kicad\` を workspace member に追加、\`serde_yaml\` / \`globset\` / \`walkdir\` 依存追加 |

### 型安全性の強化

\`export_pcb_svg\` / \`render_3d\` の \`side\` 引数を \`&str\` から \`PcbSide\` enum へ変更。  
\`Top\` / \`Bottom\` 以外の値はコンパイル時に排除される。

---

## テスト結果

\`\`\`
cargo test -p boardflow-kicad
72 tests passed (0 failed, 0 ignored)

- cli_test:    13 tests  — 全コマンドの引数組み立てを bash 実装と比較
- config_test: 16 tests  — YAML parse / validate / deny_unknown_fields / preset 制約
- detect_test: 16 tests  — プロジェクト検出・複数候補エラー
- hash_test:   17 tests  — is_excluded / SHA256 / tree_hash
- report_test: 10 tests  — ERC/DRC parse / violations filter / has_errors
\`\`\`

\`cargo check --workspace\` も pass。

---

## 今後の予定

- **Phase 2**: \`crates/action-runner/\` — \`entrypoint.sh\` 相当の処理を Rust で再実装（inputs 解析 → KiCad 実行 → API アップロード → Job Summary 出力）
- **Phase 3**: Dockerfile 更新 + 既存 bash 実装の廃止
- **Phase 4**: Worker 統合（SaaS 側 KiCad 実行）

---

## 更新ドキュメント

- \`docs/logs/73/worklog.md\` — Phase 1 実装・レビュー履歴・PR 作成結果

---

## 外部調査メモ

- \`docs/external/kicad-docker-cli.md\` — KiCad CLI オプション一覧
- \`docs/external/kicad-erc-drc-findings.md\` — ERC/DRC exit code 仕様

---

## 残リスク

- KiCad / xvfb 実環境を伴う統合テストは未実施（Phase 2 接続時に確認予定）
- \`ibom.rs\` は \`kill_on_drop\` 未適用（Phase 2 以降で \`cli.rs\` と方針統一予定）
- \`hash.rs\` の \`is_excluded\` は呼び出しごとに \`GlobSet\` を再構築（パフォーマンス改善は Phase 2 以降）

---

## レビュー判定

- **code review**: \`pr_ready: true\`（5回目レビュー、2026-05-04）
- **docs review**: \`docs_ready: true\`（5回目レビューにてドキュメント不整合なしを確認）