### PR TITLE
feat(frontend): migrate CreateTokenDialog to TanStack Form + zod

### DIFF
--- a/boardflow/package.json
+++ b/boardflow/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@chakra-ui/react": "^3.35.0",
     "@emotion/react": "^11",
+    "@tanstack/react-form": "^1.29.1",
     "@tanstack/react-query": "^5.100.9",
     "@tanstack/react-query-devtools": "^5.100.9",
     "lucide-react": "^1.14.0",
@@ -20,7 +21,8 @@
     "openapi-fetch": "^0.17.0",
     "openapi-react-query": "^0.5.4",
     "react": "^19",
-    "react-dom": "^19"
+    "react-dom": "^19",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.4.14",

--- a/boardflow/pnpm-lock.yaml
+++ b/boardflow/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@emotion/react':
         specifier: ^11
         version: 11.14.0(@types/react@19.2.14)(react@19.2.5)
+      '@tanstack/react-form':
+        specifier: ^1.29.1
+        version: 1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       '@tanstack/react-query':
         specifier: ^5.100.9
         version: 5.100.9(react@19.2.5)
@@ -38,6 +41,9 @@ importers:
       react-dom:
         specifier: ^19
         version: 19.2.5(react@19.2.5)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.4.14
@@ -477,11 +483,32 @@ packages:
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
 
+  '@tanstack/devtools-event-client@0.4.3':
+    resolution: {integrity: sha512-OZI6QyULw0FI0wjgmeYzCIfbgPsOEzwJtCpa69XrfLMtNXLGnz3d/dIabk7frg0TmHo+Ah49w5I4KC7Tufwsvw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@tanstack/form-core@1.29.1':
+    resolution: {integrity: sha512-NIYPO36eEu7nSWvMpbFDQaBWyVtnH/C8fsZ3/XpJUT4uOWgmxsiUvHGbTbDNIQTXAKIkhwEl0sUrqBNn2SfUnw==}
+
+  '@tanstack/pacer-lite@0.1.1':
+    resolution: {integrity: sha512-y/xtNPNt/YeyoVxE/JCx+T7yjEzpezmbb+toK8DDD1P4m7Kzs5YR956+7OKexG3f8aXgC3rLZl7b1V+yNUSy5w==}
+    engines: {node: '>=18'}
+
   '@tanstack/query-core@5.100.9':
     resolution: {integrity: sha512-SJSFw1S8+kQ0+knv/XGfrbocWoAlT7vDKsSImtLx3ZPQmEcR46hkDjLSvynSy25N8Ms4tIEini1FuBd5k7IscQ==}
 
   '@tanstack/query-devtools@5.100.9':
     resolution: {integrity: sha512-gqiptrTIhbK2PuCaPRHmWXfJG1NGYVFpAr0HqogEqiSBNB5xDz6fmesQt7w4WgMOqOQPnPHJ3ZDMuhDaXvNO8g==}
+
+  '@tanstack/react-form@1.29.1':
+    resolution: {integrity: sha512-hVHk4g0phd0HxRsv2ry6Xt8BqmalT55Q3cokhJBCC1St0hcGZhgwJJbohm9atao45BPG9e55DGvtbwExqZe35g==}
+    peerDependencies:
+      '@tanstack/react-start': '*'
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@tanstack/react-start':
+        optional: true
 
   '@tanstack/react-query-devtools@5.100.9':
     resolution: {integrity: sha512-mM3slaVGXJmz+pOLgXdANj75ikgQCyudyl3kmFvm6brI1JyVeY/+IeD17uDHIvZrD8hfoO2sdZ54RFsHdYAuhA==}
@@ -493,6 +520,15 @@ packages:
     resolution: {integrity: sha512-Oa44XkaI3kCNN6ME0KByU3xT3SEUNOMfZpHxL6+wFoTm+OeUFYHKdeYVe0aOXlRDm/f15sgLwEt2HDorIdW8+A==}
     peerDependencies:
       react: ^18 || ^19
+
+  '@tanstack/react-store@0.9.3':
+    resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/store@0.9.3':
+    resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
@@ -1063,6 +1099,11 @@ packages:
   uri-js-replace@1.0.1:
     resolution: {integrity: sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   yaml-ast-parser@0.0.43:
     resolution: {integrity: sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A==}
 
@@ -1073,6 +1114,9 @@ packages:
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
@@ -1514,9 +1558,27 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@tanstack/devtools-event-client@0.4.3': {}
+
+  '@tanstack/form-core@1.29.1':
+    dependencies:
+      '@tanstack/devtools-event-client': 0.4.3
+      '@tanstack/pacer-lite': 0.1.1
+      '@tanstack/store': 0.9.3
+
+  '@tanstack/pacer-lite@0.1.1': {}
+
   '@tanstack/query-core@5.100.9': {}
 
   '@tanstack/query-devtools@5.100.9': {}
+
+  '@tanstack/react-form@1.29.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/form-core': 1.29.1
+      '@tanstack/react-store': 0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react: 19.2.5
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/react-query-devtools@5.100.9(@tanstack/react-query@5.100.9(react@19.2.5))(react@19.2.5)':
     dependencies:
@@ -1528,6 +1590,15 @@ snapshots:
     dependencies:
       '@tanstack/query-core': 5.100.9
       react: 19.2.5
+
+  '@tanstack/react-store@0.9.3(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/store': 0.9.3
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      use-sync-external-store: 1.6.0(react@19.2.5)
+
+  '@tanstack/store@0.9.3': {}
 
   '@types/node@25.6.0':
     dependencies:
@@ -2400,8 +2471,14 @@ snapshots:
 
   uri-js-replace@1.0.1: {}
 
+  use-sync-external-store@1.6.0(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   yaml-ast-parser@0.0.43: {}
 
   yaml@1.10.3: {}
 
   yargs-parser@21.1.1: {}
+
+  zod@4.4.3: {}

--- a/boardflow/src/components/tokens/create-token-dialog.tsx
+++ b/boardflow/src/components/tokens/create-token-dialog.tsx
@@ -112,6 +112,7 @@ export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
                 </Box>
               ) : (
                 <form
+                  id='create-token-form'
                   onSubmit={(e) => {
                     e.preventDefault();
                     e.stopPropagation();
@@ -149,37 +150,39 @@ export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
                       </Field.Root>
                     )}
                   </form.Field>
-                  <Dialog.Footer>
-                    <form.Subscribe
-                      selector={(state) => [state.canSubmit, state.isSubmitting] as const}
-                    >
-                      {([canSubmit, isSubmitting]) => (
-                        <HStack>
-                          <Button
-                            variant='outline'
-                            onClick={() => handleClose(false)}
-                            disabled={isSubmitting}
-                          >
-                            キャンセル
-                          </Button>
-                          <Button
-                            type='submit'
-                            colorPalette='blue'
-                            loading={isSubmitting}
-                            disabled={!canSubmit}
-                          >
-                            作成
-                          </Button>
-                        </HStack>
-                      )}
-                    </form.Subscribe>
-                  </Dialog.Footer>
                 </form>
               )}
             </Dialog.Body>
-            {createdToken && (
+            {createdToken ? (
               <Dialog.Footer>
                 <Button onClick={() => handleClose(false)}>閉じる</Button>
+              </Dialog.Footer>
+            ) : (
+              <Dialog.Footer>
+                <form.Subscribe
+                  selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+                >
+                  {([canSubmit, isSubmitting]) => (
+                    <HStack>
+                      <Button
+                        variant='outline'
+                        onClick={() => handleClose(false)}
+                        disabled={isSubmitting}
+                      >
+                        キャンセル
+                      </Button>
+                      <Button
+                        type='submit'
+                        form='create-token-form'
+                        colorPalette='blue'
+                        loading={isSubmitting}
+                        disabled={!canSubmit}
+                      >
+                        作成
+                      </Button>
+                    </HStack>
+                  )}
+                </form.Subscribe>
               </Dialog.Footer>
             )}
             {!createdToken && !form.state.isSubmitting && <Dialog.CloseTrigger />}

--- a/boardflow/src/components/tokens/create-token-dialog.tsx
+++ b/boardflow/src/components/tokens/create-token-dialog.tsx
@@ -11,9 +11,18 @@ import {
   Portal,
   Text,
 } from '@chakra-ui/react';
+import { useForm } from '@tanstack/react-form';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
+import { z } from 'zod';
 import { $api } from '@/lib/api/react-query';
+
+const createTokenSchema = z.object({
+  name: z
+    .string()
+    .min(1, '名前は1文字以上で入力してください')
+    .max(100, '名前は100文字以内で入力してください'),
+});
 
 interface Props {
   repositoryId: string;
@@ -22,48 +31,46 @@ interface Props {
 }
 
 export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
-  const [name, setName] = useState('');
-  const [error, setError] = useState('');
+  const [serverError, setServerError] = useState('');
   const [createdToken, setCreatedToken] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
-  const { mutate, isPending } = $api.useMutation(
+  const { mutateAsync } = $api.useMutation(
     'post',
     '/api/v1/repositories/{github_repository_id}/api-tokens',
-    {
-      onSuccess: (data) => {
+  );
+
+  const form = useForm({
+    defaultValues: { name: '' },
+    validators: {
+      onChange: createTokenSchema,
+    },
+    onSubmit: async ({ value }) => {
+      setServerError('');
+      try {
+        const data = await mutateAsync({
+          params: { path: { github_repository_id: Number(repositoryId) } },
+          body: { name: value.name.trim() },
+        });
         if (!data?.token) {
-          setError('トークンの作成に失敗しました');
+          setServerError('トークンの作成に失敗しました');
           return;
         }
         setCreatedToken(data.token);
         queryClient.invalidateQueries({
           queryKey: ['get', '/api/v1/repositories/{github_repository_id}/api-tokens'],
         });
-      },
-      onError: (err) => {
-        setError(err.error?.message ?? 'トークンの作成に失敗しました');
-      },
+      } catch (err: unknown) {
+        const apiErr = err as { error?: { message?: string } };
+        setServerError(apiErr.error?.message ?? 'トークンの作成に失敗しました');
+      }
     },
-  );
-
-  const handleCreate = () => {
-    const trimmed = name.trim();
-    if (trimmed.length < 1 || trimmed.length > 100) {
-      setError('名前は1〜100文字で入力してください');
-      return;
-    }
-    setError('');
-    mutate({
-      params: { path: { github_repository_id: Number(repositoryId) } },
-      body: { name: trimmed },
-    });
-  };
+  });
 
   const handleClose = (open: boolean) => {
     if (!open) {
-      setName('');
-      setError('');
+      form.reset();
+      setServerError('');
       setCreatedToken(null);
     }
     onOpenChange(open);
@@ -73,8 +80,8 @@ export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
     <Dialog.Root
       open={open}
       onOpenChange={(e) => handleClose(e.open)}
-      closeOnInteractOutside={!createdToken && !isPending}
-      closeOnEscape={!createdToken && !isPending}
+      closeOnInteractOutside={!createdToken && !form.state.isSubmitting}
+      closeOnEscape={!createdToken && !form.state.isSubmitting}
     >
       <Portal>
         <Dialog.Backdrop />
@@ -104,38 +111,78 @@ export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
                   </Clipboard.Root>
                 </Box>
               ) : (
-                <Field.Root invalid={!!error}>
-                  <Field.Label>トークン名</Field.Label>
-                  <Input
-                    placeholder='例: CI用トークン'
-                    value={name}
-                    onChange={(e) => setName(e.target.value)}
-                    maxLength={100}
-                  />
-                  {error && <Field.ErrorText>{error}</Field.ErrorText>}
-                </Field.Root>
+                <form
+                  onSubmit={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    form.handleSubmit();
+                  }}
+                >
+                  <form.Field name='name'>
+                    {(field) => (
+                      <Field.Root
+                        invalid={
+                          (field.state.meta.isTouched && field.state.meta.errors.length > 0) ||
+                          !!serverError
+                        }
+                      >
+                        <Field.Label>トークン名</Field.Label>
+                        <Input
+                          placeholder='例: CI用トークン'
+                          value={field.state.value}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          onBlur={field.handleBlur}
+                          maxLength={100}
+                        />
+                        {field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
+                          <Field.ErrorText>
+                            {field.state.meta.errors
+                              .map((e) =>
+                                typeof e === 'string'
+                                  ? e
+                                  : ((e as { message?: string })?.message ?? String(e)),
+                              )
+                              .join(', ')}
+                          </Field.ErrorText>
+                        )}
+                        {serverError && <Field.ErrorText>{serverError}</Field.ErrorText>}
+                      </Field.Root>
+                    )}
+                  </form.Field>
+                  <Dialog.Footer>
+                    <form.Subscribe
+                      selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+                    >
+                      {([canSubmit, isSubmitting]) => (
+                        <HStack>
+                          <Button
+                            variant='outline'
+                            onClick={() => handleClose(false)}
+                            disabled={isSubmitting}
+                          >
+                            キャンセル
+                          </Button>
+                          <Button
+                            type='submit'
+                            colorPalette='blue'
+                            loading={isSubmitting}
+                            disabled={!canSubmit}
+                          >
+                            作成
+                          </Button>
+                        </HStack>
+                      )}
+                    </form.Subscribe>
+                  </Dialog.Footer>
+                </form>
               )}
             </Dialog.Body>
-            <Dialog.Footer>
-              {createdToken ? (
+            {createdToken && (
+              <Dialog.Footer>
                 <Button onClick={() => handleClose(false)}>閉じる</Button>
-              ) : (
-                <HStack>
-                  <Button variant='outline' onClick={() => handleClose(false)} disabled={isPending}>
-                    キャンセル
-                  </Button>
-                  <Button
-                    colorPalette='blue'
-                    onClick={handleCreate}
-                    loading={isPending}
-                    disabled={!name.trim()}
-                  >
-                    作成
-                  </Button>
-                </HStack>
-              )}
-            </Dialog.Footer>
-            {!createdToken && !isPending && <Dialog.CloseTrigger />}
+              </Dialog.Footer>
+            )}
+            {!createdToken && !form.state.isSubmitting && <Dialog.CloseTrigger />}
           </Dialog.Content>
         </Dialog.Positioner>
       </Portal>

--- a/docs/external/tanstack-form-chakra-integration.md
+++ b/docs/external/tanstack-form-chakra-integration.md
@@ -321,25 +321,26 @@ const form = useForm({
 - 手動バリデーション（trim + 長さチェック）
 - `mutate` を `handleCreate` 内で呼び出し
 
-**移行後（提案）:**
+**移行後（実装済み）:**
 ```tsx
 'use client';
 
 import { useForm } from '@tanstack/react-form';
 import { z } from 'zod';
-import { Field, Input, Button, Dialog, /* ... */ } from '@chakra-ui/react';
+import { Field, Input, Button, Dialog, HStack, /* ... */ } from '@chakra-ui/react';
 import { useQueryClient } from '@tanstack/react-query';
 import { useState } from 'react';
 import { $api } from '@/lib/api/react-query';
 
+// trim() は使わない — Standard Schema では transform 扱いのため onSubmit で明示的に trim する
 const createTokenSchema = z.object({
   name: z.string()
-    .trim()
     .min(1, '名前は1文字以上で入力してください')
     .max(100, '名前は100文字以内で入力してください'),
 });
 
 export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
+  const [serverError, setServerError] = useState('');
   const [createdToken, setCreatedToken] = useState<string | null>(null);
   const queryClient = useQueryClient();
 
@@ -354,23 +355,31 @@ export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
       onChange: createTokenSchema,
     },
     onSubmit: async ({ value }) => {
-      const data = await mutateAsync({
-        params: { path: { github_repository_id: Number(repositoryId) } },
-        body: { name: value.name },
-      });
-      if (!data?.token) {
-        throw new Error('トークンの作成に失敗しました');
+      setServerError('');
+      try {
+        const data = await mutateAsync({
+          params: { path: { github_repository_id: Number(repositoryId) } },
+          body: { name: value.name.trim() }, // 明示的に trim
+        });
+        if (!data?.token) {
+          setServerError('トークンの作成に失敗しました');
+          return;
+        }
+        setCreatedToken(data.token);
+        queryClient.invalidateQueries({
+          queryKey: ['get', '/api/v1/repositories/{github_repository_id}/api-tokens'],
+        });
+      } catch (err: unknown) {
+        const apiErr = err as { error?: { message?: string } };
+        setServerError(apiErr.error?.message ?? 'トークンの作成に失敗しました');
       }
-      setCreatedToken(data.token);
-      queryClient.invalidateQueries({
-        queryKey: ['get', '/api/v1/repositories/{github_repository_id}/api-tokens'],
-      });
     },
   });
 
   const handleClose = (open: boolean) => {
     if (!open) {
       form.reset();
+      setServerError('');
       setCreatedToken(null);
     }
     onOpenChange(open);
@@ -383,17 +392,21 @@ export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
         {createdToken ? (
           /* トークン表示部分 — 変更なし */
         ) : (
+          {/* form に id を付与し、Dialog.Footer の submit ボタンから form 属性で関連付ける */}
           <form
+            id="create-token-form"
             onSubmit={(e) => {
               e.preventDefault();
               e.stopPropagation();
               form.handleSubmit();
             }}
           >
-            <form.Field
-              name="name"
-              children={(field) => (
-                <Field.Root invalid={!field.state.meta.isValid && field.state.meta.isTouched}>
+            <form.Field name="name">
+              {(field) => (
+                <Field.Root invalid={
+                  (field.state.meta.isTouched && field.state.meta.errors.length > 0) ||
+                  !!serverError
+                }>
                   <Field.Label>トークン名</Field.Label>
                   <Input
                     placeholder="例: CI用トークン"
@@ -402,31 +415,42 @@ export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
                     onBlur={field.handleBlur}
                     maxLength={100}
                   />
-                  {field.state.meta.isTouched && !field.state.meta.isValid && (
+                  {field.state.meta.isTouched && field.state.meta.errors.length > 0 && (
                     <Field.ErrorText>
-                      {field.state.meta.errors.join(', ')}
+                      {field.state.meta.errors
+                        .map((e) => typeof e === 'string' ? e : (e?.message ?? String(e)))
+                        .join(', ')}
                     </Field.ErrorText>
                   )}
+                  {serverError && <Field.ErrorText>{serverError}</Field.ErrorText>}
                 </Field.Root>
               )}
-            />
+            </form.Field>
           </form>
         )}
       </Dialog.Body>
+      {/* Dialog.Footer は Dialog.Content 直下に配置。submit ボタンは form 属性で紐付け */}
       <Dialog.Footer>
         <form.Subscribe
-          selector={(state) => [state.canSubmit, state.isSubmitting]}
-          children={([canSubmit, isSubmitting]) => (
-            <Button
-              colorPalette="blue"
-              onClick={() => form.handleSubmit()}
-              loading={isSubmitting}
-              disabled={!canSubmit}
-            >
-              作成
-            </Button>
+          selector={(state) => [state.canSubmit, state.isSubmitting] as const}
+        >
+          {([canSubmit, isSubmitting]) => (
+            <HStack>
+              <Button variant="outline" onClick={() => handleClose(false)} disabled={isSubmitting}>
+                キャンセル
+              </Button>
+              <Button
+                type="submit"
+                form="create-token-form"
+                colorPalette="blue"
+                loading={isSubmitting}
+                disabled={!canSubmit}
+              >
+                作成
+              </Button>
+            </HStack>
           )}
-        />
+        </form.Subscribe>
       </Dialog.Footer>
     </Dialog.Root>
   );
@@ -435,8 +459,9 @@ export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
 
 **削減される useState:**
 - `name` → `form.Field` が管理
-- `error` → `field.state.meta.errors` + `form.Subscribe` で管理
+- `error` → `field.state.meta.errors` + `serverError` useState で管理
 - `createdToken` → そのまま `useState` で維持（フォームのフィールドではないため）
+- `serverError` → `useState` で管理（API エラー専用。TanStack Form にサーバーエラー反映の公式パターンがないため）
 
 ### 10. BoardFlow 固有: RevokeTokenDialog について
 
@@ -446,7 +471,7 @@ RevokeTokenDialog は確認ダイアログであり、ユーザー入力フィ�
 
 ## BoardFlow への示唆
 
-1. **CreateTokenDialog** は TanStack Form への移行対象。useState 3個 → 1個（createdToken のみ）に削減
+1. **CreateTokenDialog** は TanStack Form への移行対象。useState 3個 → 2個（createdToken + serverError）に削減
 2. **RevokeTokenDialog** はフォームフィールドがないため移行対象外
 3. zod スキーマを `src/lib/schemas/` などに切り出すと、バリデーションロジックの共有が容易
 4. `form.Field` と Chakra UI `Field` の名前衝突は `form.Field` を使えば問題なし

--- a/docs/external/tanstack-form-chakra-integration.md
+++ b/docs/external/tanstack-form-chakra-integration.md
@@ -1,0 +1,495 @@
+# TanStack Form v1 + Chakra UI v3 統合調査
+
+## 要約
+
+TanStack Form v1 はヘッドレスフォームライブラリであり、Chakra UI v3 との統合を公式にサポートしている。zod 3.24+ は Standard Schema を実装済みのため、`@tanstack/zod-form-adapter` は不要で zod スキーマを直接 validators に渡せる。TanStack Query の mutation との連携は `onSubmit` 内で `mutateAsync` を呼ぶ公式パターンが確立されている。React 19 互換。
+
+## 確認した情報
+
+### 1. パッケージインストール
+
+**必要なパッケージ:**
+```bash
+pnpm add @tanstack/react-form zod
+```
+
+**不要なパッケージ（廃止・不要）:**
+- `@tanstack/zod-form-adapter` — zod 3.24+ が Standard Schema を実装しているため不要（[GitHub Issue #1136](https://github.com/TanStack/form/issues/1136)）
+- `@tanstack/react-form-nextjs` — Server Actions / SSR 統合が必要な場合のみ。今回のフォーム（Client Component ダイアログ）には不要
+
+**バージョン情報（2026-05-05 時点）:**
+- `@tanstack/react-form`: v1.29.1（最新）
+- React 19 互換確認済み（公式 examples が React 19 を使用）
+
+### 2. TanStack Form v1 基本構造
+
+```tsx
+import { useForm } from '@tanstack/react-form';
+
+const form = useForm({
+  defaultValues: {
+    name: '',
+  },
+  onSubmit: async ({ value }) => {
+    // value は型安全（defaultValues から推論される）
+    console.log(value);
+  },
+});
+
+// JSX 内
+<form
+  onSubmit={(e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    form.handleSubmit();
+  }}
+>
+  <form.Field
+    name="name"
+    children={(field) => (
+      <>
+        <input
+          value={field.state.value}
+          onChange={(e) => field.handleChange(e.target.value)}
+          onBlur={field.handleBlur}
+        />
+        {!field.state.meta.isValid && (
+          <em>{field.state.meta.errors.join(', ')}</em>
+        )}
+      </>
+    )}
+  />
+</form>
+```
+
+**主要コンセプト:**
+- `useForm` でフォームインスタンスを作成
+- `form.Field` で各フィールドを宣言（render props パターン）
+- `field.state.value` / `field.handleChange` / `field.handleBlur` でバインド
+- `field.state.meta.errors` でエラー表示
+- `form.Subscribe` で canSubmit / isSubmitting を監視
+- `form.handleSubmit()` でサブミットをトリガー
+
+### 3. zod バリデーション統合（Standard Schema）
+
+zod 3.24+ は Standard Schema をネイティブサポートしているため、アダプター不要で直接渡せる。
+
+**フォームレベルバリデーション:**
+```tsx
+import { z } from 'zod';
+import { useForm } from '@tanstack/react-form';
+
+const createTokenSchema = z.object({
+  name: z.string().min(1, '名前は必須です').max(100, '名前は100文字以内で入力してください'),
+});
+
+const form = useForm({
+  defaultValues: { name: '' },
+  validators: {
+    onChange: createTokenSchema,
+  },
+  onSubmit: async ({ value }) => { /* ... */ },
+});
+```
+
+**フィールドレベルバリデーション:**
+```tsx
+<form.Field
+  name="name"
+  validators={{
+    onChange: z.string().min(1, '名前は必須です').max(100, '100文字以内'),
+  }}
+  children={(field) => (
+    // ...
+  )}
+/>
+```
+
+**注意点:**
+- バリデーション時にはスキーマの transform 結果は反映されない。`onSubmit` で変換が必要な場合は `schema.parse(value)` を明示的に呼ぶ
+- フォームレベルの validators でフィールドレベルのエラーを返すことも可能（`fields` キー）
+- フィールドレベルの validators はフォームレベルのものを上書きする
+
+### 4. TanStack Query mutation 連携パターン
+
+公式 Query Integration example の推奨パターン:
+
+```tsx
+import { useForm } from '@tanstack/react-form';
+import { useQueryClient } from '@tanstack/react-query';
+import { $api } from '@/lib/api/react-query';
+
+function CreateTokenForm({ repositoryId }: { repositoryId: string }) {
+  const queryClient = useQueryClient();
+
+  // openapi-react-query の mutation を使用
+  const { mutateAsync, isPending } = $api.useMutation(
+    'post',
+    '/api/v1/repositories/{github_repository_id}/api-tokens',
+  );
+
+  const form = useForm({
+    defaultValues: { name: '' },
+    validators: {
+      onChange: z.object({
+        name: z.string().min(1, '名前は必須です').max(100, '100文字以内'),
+      }),
+    },
+    onSubmit: async ({ value }) => {
+      // mutation を onSubmit 内で呼び出す
+      const data = await mutateAsync({
+        params: { path: { github_repository_id: Number(repositoryId) } },
+        body: { name: value.name.trim() },
+      });
+      // 成功後の処理
+      queryClient.invalidateQueries({
+        queryKey: ['get', '/api/v1/repositories/{github_repository_id}/api-tokens'],
+      });
+      return data;
+    },
+  });
+  // ...
+}
+```
+
+**ポイント:**
+- `mutateAsync` を使って `onSubmit` 内で await する
+- mutation の `onSuccess`/`onError` は mutation 側ではなく form の `onSubmit` 内で処理可能
+- `formApi.reset()` でフォームをリセット
+- mutation の `isPending` は `form.state.isSubmitting` で代替可能（ただし mutation 固有の isPending も利用可能）
+
+### 5. Chakra UI v3 + TanStack Form 統合パターン
+
+公式ドキュメント（UI Libraries ガイド）にChakra UI v3の統合例がある。
+
+**Input との統合:**
+```tsx
+<form.Field
+  name="name"
+  children={({ state, handleChange, handleBlur }) => (
+    <Input
+      value={state.value}
+      onChange={(e) => handleChange(e.target.value)}
+      onBlur={handleBlur}
+      placeholder="Enter your name"
+    />
+  )}
+/>
+```
+
+**Chakra UI v3 Field.Root + エラー表示の統合:**
+```tsx
+import { Field, Input } from '@chakra-ui/react';
+
+<form.Field
+  name="name"
+  validators={{
+    onChange: z.string().min(1, '名前は必須です').max(100, '100文字以内'),
+  }}
+  children={(field) => (
+    <Field.Root invalid={!field.state.meta.isValid && field.state.meta.isTouched}>
+      <Field.Label>トークン名</Field.Label>
+      <Input
+        placeholder="例: CI用トークン"
+        value={field.state.value}
+        onChange={(e) => field.handleChange(e.target.value)}
+        onBlur={field.handleBlur}
+        maxLength={100}
+      />
+      {field.state.meta.isTouched && !field.state.meta.isValid && (
+        <Field.ErrorText>
+          {field.state.meta.errors.join(', ')}
+        </Field.ErrorText>
+      )}
+    </Field.Root>
+  )}
+/>
+```
+
+**Checkbox との統合（Chakra UI v3）:**
+```tsx
+<form.Field
+  name="isChecked"
+  children={({ state, handleChange, handleBlur }) => (
+    <Checkbox.Root
+      checked={state.value}
+      onCheckedChange={(details) => handleChange(!!details.checked)}
+      onBlur={handleBlur}
+    >
+      <Checkbox.HiddenInput />
+      <Checkbox.Control />
+      <Checkbox.Label>同意する</Checkbox.Label>
+    </Checkbox.Root>
+  )}
+/>
+```
+
+**注意: `Field` 名前の衝突**
+
+TanStack Form の `form.Field` と Chakra UI の `Field` コンポーネントの名前が衝突する。対処法:
+1. TanStack Form は `form.Field`（useForm の返り値から取得）として使い、Chakra UI は `Field` として import する → **衝突しない**
+2. destructure する場合は rename が必要:
+   ```tsx
+   const { Field: FormField } = useForm({ ... });
+   ```
+3. 推奨: `form.Field` をそのまま使う（公式推奨パターン）
+
+### 6. サブミットボタンの状態管理
+
+```tsx
+<form.Subscribe
+  selector={(state) => [state.canSubmit, state.isSubmitting]}
+  children={([canSubmit, isSubmitting]) => (
+    <Button
+      type="submit"
+      colorPalette="blue"
+      disabled={!canSubmit}
+      loading={isSubmitting}
+    >
+      作成
+    </Button>
+  )}
+/>
+```
+
+### 7. フォームリセット
+
+```tsx
+// onSubmit 完了後にリセット
+onSubmit: async ({ value, formApi }) => {
+  await mutateAsync(/* ... */);
+  formApi.reset();
+}
+
+// 外部からリセット（ダイアログ close 時）
+const handleClose = () => {
+  form.reset();
+  onOpenChange(false);
+};
+```
+
+### 8. サーバーエラーのフォームへの反映
+
+mutation のエラー（APIエラー）をフォームに反映するパターン:
+
+```tsx
+onSubmit: async ({ value }) => {
+  try {
+    await mutateAsync({ /* ... */ });
+  } catch (err) {
+    // フォームレベルのエラーを設定
+    // form.state.errorMap には直接設定できないため、
+    // useState でサーバーエラーを別管理するか、
+    // form の onSubmitAsync validator を使う
+    throw err; // TanStack Form が自動でエラーを capture
+  }
+}
+```
+
+より洗練されたパターン（`onSubmitAsync` validator 使用）:
+```tsx
+const form = useForm({
+  defaultValues: { name: '' },
+  validators: {
+    onChange: createTokenSchema,
+    onSubmitAsync: async ({ value }) => {
+      try {
+        await mutateAsync({
+          params: { path: { github_repository_id: Number(repositoryId) } },
+          body: { name: value.name.trim() },
+        });
+        return null; // no errors
+      } catch (err) {
+        return err.error?.message ?? 'トークンの作成に失敗しました';
+      }
+    },
+  },
+  onSubmit: async ({ value }) => {
+    // validators.onSubmitAsync が通った後に呼ばれる
+    // ここでは成功後の処理のみ
+    queryClient.invalidateQueries({ /* ... */ });
+  },
+});
+```
+
+**ただし注意:** `onSubmit` と `onSubmitAsync` validator の使い分けが複雑になるため、BoardFlow のように単純なフォームでは `onSubmit` 内で try/catch し、エラーは `useState` で管理する方がシンプル。
+
+### 9. BoardFlow 固有: CreateTokenDialog の移行パターン
+
+**移行前（現状）:**
+- `useState` x 3: name, error, createdToken
+- 手動バリデーション（trim + 長さチェック）
+- `mutate` を `handleCreate` 内で呼び出し
+
+**移行後（提案）:**
+```tsx
+'use client';
+
+import { useForm } from '@tanstack/react-form';
+import { z } from 'zod';
+import { Field, Input, Button, Dialog, /* ... */ } from '@chakra-ui/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { $api } from '@/lib/api/react-query';
+
+const createTokenSchema = z.object({
+  name: z.string()
+    .trim()
+    .min(1, '名前は1文字以上で入力してください')
+    .max(100, '名前は100文字以内で入力してください'),
+});
+
+export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+
+  const { mutateAsync } = $api.useMutation(
+    'post',
+    '/api/v1/repositories/{github_repository_id}/api-tokens',
+  );
+
+  const form = useForm({
+    defaultValues: { name: '' },
+    validators: {
+      onChange: createTokenSchema,
+    },
+    onSubmit: async ({ value }) => {
+      const data = await mutateAsync({
+        params: { path: { github_repository_id: Number(repositoryId) } },
+        body: { name: value.name },
+      });
+      if (!data?.token) {
+        throw new Error('トークンの作成に失敗しました');
+      }
+      setCreatedToken(data.token);
+      queryClient.invalidateQueries({
+        queryKey: ['get', '/api/v1/repositories/{github_repository_id}/api-tokens'],
+      });
+    },
+  });
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      form.reset();
+      setCreatedToken(null);
+    }
+    onOpenChange(open);
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(e) => handleClose(e.open)} /* ... */>
+      {/* ... */}
+      <Dialog.Body>
+        {createdToken ? (
+          /* トークン表示部分 — 変更なし */
+        ) : (
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              form.handleSubmit();
+            }}
+          >
+            <form.Field
+              name="name"
+              children={(field) => (
+                <Field.Root invalid={!field.state.meta.isValid && field.state.meta.isTouched}>
+                  <Field.Label>トークン名</Field.Label>
+                  <Input
+                    placeholder="例: CI用トークン"
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    onBlur={field.handleBlur}
+                    maxLength={100}
+                  />
+                  {field.state.meta.isTouched && !field.state.meta.isValid && (
+                    <Field.ErrorText>
+                      {field.state.meta.errors.join(', ')}
+                    </Field.ErrorText>
+                  )}
+                </Field.Root>
+              )}
+            />
+          </form>
+        )}
+      </Dialog.Body>
+      <Dialog.Footer>
+        <form.Subscribe
+          selector={(state) => [state.canSubmit, state.isSubmitting]}
+          children={([canSubmit, isSubmitting]) => (
+            <Button
+              colorPalette="blue"
+              onClick={() => form.handleSubmit()}
+              loading={isSubmitting}
+              disabled={!canSubmit}
+            >
+              作成
+            </Button>
+          )}
+        />
+      </Dialog.Footer>
+    </Dialog.Root>
+  );
+}
+```
+
+**削減される useState:**
+- `name` → `form.Field` が管理
+- `error` → `field.state.meta.errors` + `form.Subscribe` で管理
+- `createdToken` → そのまま `useState` で維持（フォームのフィールドではないため）
+
+### 10. BoardFlow 固有: RevokeTokenDialog について
+
+RevokeTokenDialog は確認ダイアログであり、ユーザー入力フィールドがない。TanStack Form への移行はオーバーエンジニアリングになる可能性がある。
+
+**判断:** RevokeTokenDialog は TanStack Form に移行しない（フォームフィールドが0個の確認ダイアログには不適切）。現状の useState(error) + mutation パターンを維持。
+
+## BoardFlow への示唆
+
+1. **CreateTokenDialog** は TanStack Form への移行対象。useState 3個 → 1個（createdToken のみ）に削減
+2. **RevokeTokenDialog** はフォームフィールドがないため移行対象外
+3. zod スキーマを `src/lib/schemas/` などに切り出すと、バリデーションロジックの共有が容易
+4. `form.Field` と Chakra UI `Field` の名前衝突は `form.Field` を使えば問題なし
+5. `@tanstack/zod-form-adapter` は不要。zod 3.24+ を使えば Standard Schema で直接渡せる
+6. 将来フォームが増えた場合にも同じパターンを適用可能
+
+## 採用/不採用判断
+
+| 項目 | 判断 | 理由 |
+|---|---|---|
+| `@tanstack/react-form` | **採用** | 型安全なフォーム管理、useState削減、zod統合、公式Chakra UI統合サポート |
+| `zod` | **採用** | Standard Schema によるバリデーション統合、スキーマ共有 |
+| `@tanstack/zod-form-adapter` | **不採用** | zod 3.24+ で不要（Standard Schema 対応済み） |
+| `@tanstack/react-form-nextjs` | **不採用** | Server Actions 統合は現段階で不要（フォームは Client Component 内） |
+| CreateTokenDialog の移行 | **採用** | useState 削減、バリデーション宣言的管理 |
+| RevokeTokenDialog の移行 | **不採用** | フォームフィールドが0個、オーバーエンジニアリング |
+
+## 制約と pitfall
+
+1. **`form.Field` vs Chakra `Field` の名前衝突**: `form.Field` を使えば問題ないが、`useForm` を destructure する場合は rename 必要
+2. **バリデーションで transform された値は onSubmit に渡されない**: `onSubmit` で `schema.parse(value)` を明示的に呼ぶ必要がある。ただし BoardFlow では trim のみなので `z.string().trim()` が Standard Schema で機能するか要検証
+3. **isSubmitting vs isPending**: TanStack Form の `isSubmitting`（form.handleSubmit 中）と TanStack Query の `isPending`（mutation 中）は同期しているが、使い分けに注意
+4. **Server-side エラー表示**: API からのエラーレスポンスをフォームのエラーとして表示するには追加の state 管理が必要になる可能性あり
+5. **ダイアログ内フォーム**: `<form>` タグを Dialog.Body 内に配置する場合、Dialog のネイティブボタンとの干渉に注意
+6. **Standard Schema の trim()**: `z.string().trim()` は Standard Schema validation で transform として扱われるため、`field.state.value` は trim されない。`onSubmit` の `value` も transform 前の値。submit 時に明示的に trim するか、`onChange` の `handleChange` 内で trim する設計が必要
+
+## 未解決の疑問
+
+1. ~~`z.string().trim()` が Standard Schema validation で正しく動作するか~~
+   → 動作するが transform として扱われるため、`onSubmit` の `value` は trim 前の値。明示的に `value.name.trim()` とする必要がある。**解決済み**
+2. TanStack Form の `onSubmit` 内で throw された Error がどのように表示されるか（`form.Subscribe` の `errorMap.onSubmit` に反映されるか）— 要実装時検証
+3. 将来的に他のフォーム（設定画面等）が追加された場合の共通パターン（schema ファイル分割方針）
+
+## 参照URL
+
+- [TanStack Form v1 公式ドキュメント](https://tanstack.com/form/v1/docs/overview)
+- [TanStack Form インストールガイド](https://tanstack.com/form/v1/docs/installation)
+- [TanStack Form バリデーションガイド](https://tanstack.com/form/v1/docs/framework/react/guides/validation)
+- [TanStack Form UI Libraries ガイド](https://tanstack.com/form/v1/docs/framework/react/guides/ui-libraries)
+- [TanStack Form Submission Handling](https://tanstack.com/form/v1/docs/framework/react/guides/submission-handling)
+- [TanStack Form SSR/Next.js ガイド](https://tanstack.com/form/v1/docs/framework/react/guides/ssr)
+- [TanStack Form Query Integration Example](https://tanstack.com/form/v1/docs/framework/react/examples/query-integration)
+- [TanStack Form Standard Schema Example](https://tanstack.com/form/v1/docs/framework/react/examples/standard-schema)
+- [@tanstack/react-form npm](https://www.npmjs.com/package/@tanstack/react-form) — v1.29.1
+- [zod-form-adapter deprecated (GitHub Issue #1136)](https://github.com/TanStack/form/issues/1136)
+- [React 19 互換性確認 (Answer Overflow)](https://www.answeroverflow.com/m/1339176859002343425)

--- a/docs/frontend/summary.md
+++ b/docs/frontend/summary.md
@@ -23,6 +23,7 @@ KiCad 実行、成果物生成、GitHub Issue 更新などの副作用は backen
 | アイコン | lucide-react | 軽量で一覧画面や状態表示に合わせやすい |
 | API 型 | `openapi-typescript` などの生成型 | OpenAPI と UI の齟齬を減らせる |
 | データ取得 | TanStack Query v5 + openapi-react-query | Client Component のキャッシュ、再取得、prefetch + hydration を型安全に扱える |
+| フォーム / バリデーション | TanStack Form + zod | 宣言的バリデーション、型安全なフォーム状態管理、TanStack Query mutation との連携 |
 | E2E | Playwright | 主要導線の smoke test に向く |
 
 ## 3. 画面アーキテクチャ

--- a/docs/logs/79/worklog.md
+++ b/docs/logs/79/worklog.md
@@ -374,3 +374,63 @@ git push origin feature/79-tanstack-form
 ### 更新した作業ログパス
 
 `docs/logs/79/worklog.md`
+
+---
+
+## 実装結果（2026-05-05 impl agent）
+
+### 実装内容
+
+ブランチ `feature/79-tanstack-form` で CreateTokenDialog を TanStack Form + zod に移行した。
+
+**変更ファイル:**
+
+| ファイル | 変更内容 |
+|---|---|
+| `boardflow/package.json` | `@tanstack/react-form` v1.29.1, `zod` v4.4.3 追加 |
+| `boardflow/pnpm-lock.yaml` | ロックファイル更新 |
+| `boardflow/src/components/tokens/create-token-dialog.tsx` | TanStack Form + zod リファクタリング |
+
+**主な変更点:**
+
+1. `useState(name)`, `useState(error)` を削除 → `useForm` + `form.Field` に置き換え
+2. `useState(serverError)` を追加（APIエラー専用）
+3. `mutate` → `mutateAsync`、`onSuccess`/`onError` コールバック → `onSubmit` 内 try/catch
+4. zod スキーマ `createTokenSchema` でクライアントバリデーション（`validators.onChange`）
+5. `form.Field` render props → JSX children 構文（biome `noChildrenProp` 対応）
+6. `form.Subscribe` で `canSubmit`/`isSubmitting` を監視してボタン制御
+7. `form.reset()` でダイアログ close 時のリセット
+8. `form.state.isSubmitting` で `closeOnInteractOutside`/`closeOnEscape`/`CloseTrigger` 制御
+
+**実装時の発見・対処:**
+
+- **zod v4**: `pnpm add zod` で v4.4.3 がインストールされた（計画時は v3.24+ を想定）。Standard Schema サポートは互換で問題なし
+- **`field.state.meta.errors` の型**: 要素が `undefined` になりうる（`ValidationError[]` の要素型）。`typeof e === 'string' ? e : (e as { message?: string })?.message ?? String(e)` で安全に処理
+- **biome `noChildrenProp`**: `children` prop パターンは lint エラー。JSX children 構文 `{(field) => (...)}` に変換して解消
+- **Dialog.Footer の配置**: `<form>` タグ内にフッターを含める必要があるため、フォーム表示時は `form` 内に `Dialog.Footer` を配置し、トークン作成後のフッターは `Dialog.Body` の外に別途配置
+
+### テスト結果
+
+| チェック | 結果 |
+|---|---|
+| `pnpm typecheck` | パス |
+| `pnpm lint --write --unsafe` | パス（biome 0 errors） |
+| `pnpm build` | パス（Next.js 16.2.4 Turbopack） |
+
+**注**: 本プロジェクトにはフロントエンドのユニットテスト（Jest/Vitest 等）が未導入のため、TDD の red-green は typecheck + lint + build で代替。
+
+### ドキュメント確認
+
+- `docs/external/tanstack-form-chakra-integration.md` — research agent が作成済み、変更不要
+- `docs/technology.md` — TanStack Form / zod の追記は今回スコープ外（既存にフロントエンドライブラリの詳細列挙なし）
+- `RevokeTokenDialog` — 変更なし（確認済み）
+
+### 残リスク
+
+1. **フロントエンド E2E / ユニットテスト未整備**: CreateTokenDialog の動作は手動確認が必要。将来的に Vitest + Testing Library の導入を推奨
+2. **zod v4 と TanStack Form の長期互換性**: zod v4 は Standard Schema 対応だが、TanStack Form 側の公式テストが zod v3 ベースの可能性あり。問題があれば `pnpm add zod@3` でダウングレード可能
+3. **サーバーエラーの型安全性**: `catch (err: unknown)` → `as { error?: { message?: string } }` のキャストは型安全ではない。openapi-react-query のエラー型定義が改善されれば型ガードに置き換え可能
+
+### 更新した作業ログパス
+
+`docs/logs/79/worklog.md`

--- a/docs/logs/79/worklog.md
+++ b/docs/logs/79/worklog.md
@@ -377,6 +377,138 @@ git push origin feature/79-tanstack-form
 
 ---
 
+## ドキュメント確認結果（2026-05-05 docs agent）
+
+### 総評
+
+- Issue #79 の実装本体は [boardflow/src/components/tokens/create-token-dialog.tsx](boardflow/src/components/tokens/create-token-dialog.tsx#L34) と [boardflow/src/components/tokens/create-token-dialog.tsx](boardflow/src/components/tokens/create-token-dialog.tsx#L53) を見る限り、TanStack Form + zod への移行内容と整合している。
+- ただし、research 成果物の [docs/external/tanstack-form-chakra-integration.md](docs/external/tanstack-form-chakra-integration.md#L317) と作業ログの既存レビュー/実装記録には、現実装と食い違う記述が残っている。
+- [docs/technology.md](docs/technology.md#L52) は repo 全体の粗い技術方針の粒度で書かれており、今回の変更だけでは必須更新とは言い切れない。一方で frontend の採用スタック表である [docs/frontend/summary.md](docs/frontend/summary.md#L17) には、必要なら Form/Validation の行を追加する余地がある。
+
+### PR 判定
+
+- `docs_ready: false`
+
+### 必須修正
+
+1. [docs/external/tanstack-form-chakra-integration.md](docs/external/tanstack-form-chakra-integration.md#L317) の BoardFlow 固有サンプルを現実装に合わせる。
+  - [docs/external/tanstack-form-chakra-integration.md](docs/external/tanstack-form-chakra-integration.md#L359) では `z.string().trim()` を使ったスキーマに対して submit 側で `value.name` をそのまま送っており、同ファイル内の transform 注意書き [docs/external/tanstack-form-chakra-integration.md](docs/external/tanstack-form-chakra-integration.md#L470) と矛盾している。
+  - 実装は [boardflow/src/components/tokens/create-token-dialog.tsx](boardflow/src/components/tokens/create-token-dialog.tsx#L53) の通り `value.name.trim()` を送っているため、research メモ側のサンプルもそれに合わせる必要がある。
+  - 同サンプルの `Dialog.Footer` 構成も、実装の [boardflow/src/components/tokens/create-token-dialog.tsx](boardflow/src/components/tokens/create-token-dialog.tsx#L115) と [boardflow/src/components/tokens/create-token-dialog.tsx](boardflow/src/components/tokens/create-token-dialog.tsx#L176) のように `form` 属性で submit を関連付ける形へ揃えるべき。
+2. [docs/logs/79/worklog.md](docs/logs/79/worklog.md#L395) 以降の既存レビュー結果を、現実装に合わせて訂正する。
+  - [docs/logs/79/worklog.md](docs/logs/79/worklog.md#L395) は `Dialog.Footer` が `form` 配下にあると指摘しているが、現実装はそうなっていない。
+  - [docs/logs/79/worklog.md](docs/logs/79/worklog.md#L487) の実装記録も `Dialog.Footer` を `form` 内に置いたと書いており、コード実態と不一致。
+  - [docs/logs/79/worklog.md](docs/logs/79/worklog.md#L499) の「external ドキュメントは変更不要」という判断も、上記不整合があるため成立していない。
+
+### 任意改善
+
+1. [docs/frontend/summary.md](docs/frontend/summary.md#L17) の採用スタック表に、Form/Validation として TanStack Form + zod を追加すると、frontend 標準の見通しがよくなる。
+2. [docs/technology.md](docs/technology.md#L52) は現状の粒度でも問題ないが、repo 全体の技術スタック一覧をより網羅的にしたい場合だけ frontend 補助ライブラリの記載を検討する。
+
+### 不整合のあるドキュメント
+
+- [docs/external/tanstack-form-chakra-integration.md](docs/external/tanstack-form-chakra-integration.md#L317)
+- [docs/logs/79/worklog.md](docs/logs/79/worklog.md#L395)
+
+### 不足しているドキュメント
+
+- 必須の追記先はない。
+- 任意で [docs/frontend/summary.md](docs/frontend/summary.md#L17) に Form/Validation 行を追加するとよい。
+
+### 外部調査メモに関する指摘
+
+- [docs/external/tanstack-form-chakra-integration.md](docs/external/tanstack-form-chakra-integration.md#L470) と [docs/external/tanstack-form-chakra-integration.md](docs/external/tanstack-form-chakra-integration.md#L474) の注意書き自体は妥当だが、BoardFlow 固有サンプル側がその結論を反映できていない。
+- research メモは「trim は submit 時に明示処理が必要」という判断を出せているので、サンプルコードだけを現実装ベースに直せば整合する。
+
+### PR本文案に対する確認
+
+- 概要と変更内容の方向性は妥当。
+- ただし docs 修正を入れる前提なら、更新ドキュメントとして research メモと worklog を追記したことを本文に含めた方が整合する。
+- テスト欄は実際に確認したコマンドだけを書くべきで、`pnpm lint` ではなく `pnpm lint --write --unsafe` を実行事実として書く方が正確。
+
+### 更新した作業ログパス
+
+- `docs/logs/79/worklog.md`
+
+---
+
+## レビュー結果（2026-05-05 review agent）
+
+### 総評
+
+- CreateTokenDialog の TanStack Form + zod への移行は、コード・research・実装差分・検証結果の整合が取れている。
+- `pnpm typecheck`, `pnpm lint`, `pnpm build` は現ブランチで再確認できた。
+- RevokeTokenDialog は Issue 79 の対象外として未変更を確認した。
+- ブロッカーは見当たらないため、PR 作成は可能と判断する。
+
+### PR 判定
+
+- `pr_ready: true`
+
+### 指摘事項
+
+1. **warning**: `Dialog.Footer` が Chakra UI のドキュメント例と異なり、`Dialog.Content` の直下ではなく `form` 配下にネストされている。
+  - 対象: `boardflow/src/components/tokens/create-token-dialog.tsx` の `form` 配下にあるフッター
+  - 参照: Chakra UI の Dialog 例は `Dialog.Content > Dialog.Header / Dialog.Body / Dialog.Footer` 構造を前提にしている
+  - 影響: 現状でビルドや型は通るが、将来の Chakra UI 更新時にレイアウトや余白、アクセシビリティ上の前提が崩れる可能性がある
+  - 対応案: `form` を `Dialog.Body` と `Dialog.Footer` の両方を包む位置へ移す、または `form` に `id` を付与して `Button` 側の `form` 属性で submit を紐付ける
+
+2. **info**: 作業ログの受け入れ条件 3 が、実装内容と不一致になっている。
+  - 対象: `docs/logs/79/worklog.md` の受け入れ条件
+  - 現状: `createdToken` のみ残すと記載されているが、実装と Issue 要約では `createdToken` と `serverError` を残す構成
+  - 影響: 実装評価基準の読み手に誤解を与える
+  - 対応案: 受け入れ条件 3 を実装実態に合わせて修正する
+
+### 受け入れ条件評価
+
+1. `@tanstack/react-form` と `zod` の追加: 満たす
+2. CreateTokenDialog の `useForm` + zod 移行: 満たす
+3. `name`, `error` の `useState` 削減と `createdToken` / `serverError` 残置: 実装は満たす
+4. `field.state.meta.errors` によるフィールドエラー表示: 満たす
+5. サーバーエラー表示: 満たす
+6. close 時の `form.reset()`: 満たす
+7. `pnpm typecheck`, `pnpm lint`, `pnpm build`: 満たす
+8. RevokeTokenDialog 非変更: 満たす
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- `Dialog.Footer` を Chakra UI の推奨構造に寄せる
+- `catch (err: unknown)` の API エラー取り出しを型ガード化して再利用可能にする
+
+### テスト不足
+
+- フロントエンドの自動 UI テストがないため、以下はビルド成功だけでは担保できない
+- 空 submit 時にフィールドエラーが表示されること
+- API エラー後に再入力して再 submit できること
+- close 時に `form.reset()` と `createdToken` / `serverError` のリセットが効くこと
+
+### ドキュメント確認
+
+- `docs/external/tanstack-form-chakra-integration.md`: 実装方針と整合
+- `docs/spec.md`: 本 Issue は UI 実装詳細のため仕様変更不要
+- `README.md`: 更新不要
+- `docs/logs/79/worklog.md`: 受け入れ条件 3 の記述だけ実装実態と不一致
+
+### plan / research / docs との不整合
+
+- plan/worklog 上の受け入れ条件 3 が古い記述のまま残っている
+- research で触れていた Chakra UI の構造例と、実装上の `Dialog.Footer` 配置が一致していない
+
+### 残リスク
+
+- Dialog 構造の逸脱が Chakra UI 将来更新で問題化する可能性
+- UI 操作系の回帰が自動テストで捕捉されない
+
+### 更新した作業ログパス
+
+- `docs/logs/79/worklog.md`
+
+---
+
 ## 実装結果（2026-05-05 impl agent）
 
 ### 実装内容
@@ -434,3 +566,78 @@ git push origin feature/79-tanstack-form
 ### 更新した作業ログパス
 
 `docs/logs/79/worklog.md`
+
+---
+
+## レビュー指摘修正 + ドキュメント修正（2026-05-05 orchestrator）
+
+### 修正内容
+
+1. **Dialog.Footer 構造修正**（review warning 対応）:
+   - `Dialog.Footer` を `<form>` 内から `Dialog.Content` 直下に移動
+   - `<form>` に `id="create-token-form"` を付与
+   - submit ボタンに `form="create-token-form"` 属性を追加して関連付け
+   - Chakra UI の推奨構造（Dialog.Content > Header/Body/Footer）に準拠
+
+2. **docs/external/tanstack-form-chakra-integration.md 修正**:
+   - BoardFlow 固有サンプル（セクション9）を実装に合わせて更新
+   - `z.string().trim()` → `z.string()` + onSubmit 内 `value.name.trim()` に修正
+   - `serverError` useState の追加
+   - form id + form 属性パターンでの Dialog.Footer 分離を反映
+   - useState 削減の記述を「3個 → 2個（createdToken + serverError）」に修正
+
+3. **docs/frontend/summary.md 更新**:
+   - 採用スタック表に「フォーム / バリデーション | TanStack Form + zod」行を追加
+
+### 検証結果
+
+- `pnpm typecheck` — パス
+- `pnpm lint --write --unsafe` — パス
+- `pnpm build` — パス
+
+---
+
+## ドキュメント再確認結果（2026-05-05 docs agent, follow-up）
+
+### 対象 Issue
+
+- Issue #79: TanStack Formへのフォームリファクタリング
+
+### 総評
+
+- [docs/external/tanstack-form-chakra-integration.md](docs/external/tanstack-form-chakra-integration.md#L334) の BoardFlow 固有サンプルは、[boardflow/src/components/tokens/create-token-dialog.tsx](boardflow/src/components/tokens/create-token-dialog.tsx#L16) と [boardflow/src/components/tokens/create-token-dialog.tsx](boardflow/src/components/tokens/create-token-dialog.tsx#L36) 以降の実装に整合している。
+- `z.string().trim()` をサンプルから除外し、submit 時に `value.name.trim()` を使う点、`serverError` を別 state で管理する点、`form id` + `form` 属性で `Dialog.Footer` の submit を関連付ける点が実装どおりに反映されている。
+- [docs/frontend/summary.md](docs/frontend/summary.md#L18) の「フォーム / バリデーション | TanStack Form + zod」追加も、frontend 採用スタックの粒度として適切。
+- 前回の必須修正 2 件と任意改善 1 件は、現時点ではいずれも対応済みと判断する。
+
+### PR 判定
+
+- `docs_ready: true`
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- なし
+
+### 不整合のあるドキュメント
+
+- なし
+
+### 不足しているドキュメント
+
+- なし
+
+### 外部調査メモに関する指摘
+
+- 以前の指摘対象だった BoardFlow 固有サンプルは解消済み。本文中の trim に関する注意書きとサンプルコードの採用判断も一致している。
+
+### 残リスク
+
+- worklog には過去レビュー時点の `docs_ready: false` 判定が履歴として残っているが、後続の修正記録と今回の再確認結果が時系列で追記されているため、運用上の矛盾とはみなさない。
+
+### 更新した作業ログパス
+
+- `docs/logs/79/worklog.md`

--- a/docs/logs/79/worklog.md
+++ b/docs/logs/79/worklog.md
@@ -1,24 +1,376 @@
-# Issue #79: TanStack Formへのフォームリファクタリング
+# Issue #79: TanStack Formへのフォームリファクタリング — 作業ログ
 
-## 経緯
+## Issue までの経緯
+
 - ユーザー要望8: すべてのフォームをTanStack Formに移行
+- Issue #78（TanStack Query mutation 移行）はマージ済み
+- 対象フォーム: CreateTokenDialog（入力フィールドあり）、RevokeTokenDialog（確認ダイアログのみ）
 
 ## ユーザー要望
-- フォームの状態管理をTanStack Formに統一
 
-## 調査結果
+- フォームの状態管理をTanStack Formに統一
+- useState 手動管理からの脱却
+- zod バリデーション統合
+- TanStack Query mutation との連携
+
+## 初期調査（Issue作成時）
+
 - 現在のフォーム: Token作成ダイアログ (`create-token-dialog.tsx`) で `useState` による手動管理
 - バリデーションは手動（文字列長チェック等）
 - ローディング/エラー状態も `useState` で個別管理
 
-## Issue作成内容
-- タイトル: TanStack Formへのフォームリファクタリング
-- ラベル: enhancement, frontend
-- 新規作成
+## 外部調査結果（2026-05-05 research agent）
 
-## 後続処理タイプ
-`implementation_required`
+### 調査トピックと結果
+
+1. **TanStack Form v1 基本構造** — 公式ドキュメントから確認完了
+   - `useForm`, `form.Field`, `validators`, `onSubmit` の基本パターン把握
+   - render props パターンで UI ライブラリと統合
+
+2. **zod バリデーション統合** — Standard Schema（zod 3.24+）で直接統合可能
+   - `@tanstack/zod-form-adapter` は廃止済み（GitHub Issue #1136）
+   - zod スキーマを `validators.onChange` に直接渡せる
+   - **注意**: `z.string().trim()` は transform 扱い。`onSubmit` の value は trim 前
+
+3. **TanStack Query mutation 連携** — 公式パターン確認
+   - `onSubmit` 内で `mutateAsync` を呼ぶ
+   - `formApi.reset()` でリセット
+   - `form.state.isSubmitting` で loading 状態を管理
+
+4. **Chakra UI v3 統合** — 公式 UI Libraries ガイドに例あり
+   - Input: `value={field.state.value}`, `onChange={(e) => field.handleChange(e.target.value)}`
+   - Checkbox: `onCheckedChange={(details) => handleChange(!!details.checked)}`
+   - `form.Field`（TanStack）と `Field`（Chakra UI）の名前衝突なし（`form.Field` を使えば OK）
+
+5. **React 19 / Next.js 互換性** — 確認済み
+   - React 19 互換（公式 examples が React 19 使用）
+   - Server Actions は `@tanstack/react-form-nextjs` だが今回は Client Component のみのため不要
+
+6. **パッケージ情報**
+   - `@tanstack/react-form` v1.29.1（最新）
+   - `zod`（新規インストール必要、プロジェクト未導入）
+
+### 移行判断
+
+| フォーム | 判断 | 理由 |
+|---|---|---|
+| CreateTokenDialog | **移行する** | フォームフィールドあり、useState 3→1 に削減可能 |
+| RevokeTokenDialog | **移行しない** | フォームフィールドが0個、確認ダイアログにはオーバーエンジニアリング |
+
+### 成果物
+
+- `docs/external/tanstack-form-chakra-integration.md` — 調査メモ（コード例・移行パターン付き）
+
+### 参照URL
+
+- https://tanstack.com/form/v1/docs/overview
+- https://tanstack.com/form/v1/docs/installation
+- https://tanstack.com/form/v1/docs/framework/react/guides/validation
+- https://tanstack.com/form/v1/docs/framework/react/guides/ui-libraries
+- https://tanstack.com/form/v1/docs/framework/react/guides/submission-handling
+- https://tanstack.com/form/v1/docs/framework/react/examples/query-integration
+- https://www.npmjs.com/package/@tanstack/react-form
+- https://github.com/TanStack/form/issues/1136
+
+## 結論ステータス
+
+**`implementation_required`**
+
+## 後続エージェントへの注意点
+
+1. `pnpm add @tanstack/react-form zod` でインストール（`@tanstack/zod-form-adapter` は不要）
+2. CreateTokenDialog のみ移行対象。RevokeTokenDialog は現状維持
+3. `z.string().trim()` は transform — `onSubmit` の value.name に対して明示的に `.trim()` が必要
+4. `form.Field`（TanStack）と `Field`（Chakra UI）の名前衝突は `form.Field` を使えば解決
+5. `createdToken` は useState で維持（フォームフィールドではないため）
+6. サーバーエラー表示パターンは実装時に検証が必要
 
 ## 残リスク
-- TanStack Form + Chakra UI v3 の統合パターンの調査が必要
-- Issue #78 (TanStack Query mutation) との連携
+
+1. `z.string().trim()` の Standard Schema での挙動 — 実装時に動作検証が必要
+2. TanStack Form `onSubmit` 内で throw された Error の表示挙動 — 実装時に検証が必要
+3. 将来のフォーム追加時の schema 分割方針は未確定（現時点ではフォームが1つのみのため先送り可）
+
+---
+
+## 実装計画（2026-05-05 plan agent）
+
+### 目的
+
+CreateTokenDialog の useState 手動フォーム管理を TanStack Form + zod に移行し、宣言的バリデーション・型安全なフォーム状態管理を実現する。
+
+### 非目的
+
+- RevokeTokenDialog の変更（フォームフィールド0個のため対象外）
+- 新しい UI コンポーネントの追加やデザイン変更
+- スキーマ定義の別ファイル切り出し（フォーム1つのみのため現時点では不要）
+- Server Actions / SSR フォーム統合
+
+### 受け入れ条件
+
+1. `@tanstack/react-form` と `zod` が `package.json` に追加されている
+2. CreateTokenDialog が `useForm` + zod バリデーションで動作する
+3. `useState` が `name`, `error` の2つ削減され、`createdToken` のみ残っている
+4. バリデーションエラーがフィールドレベルで表示される（`field.state.meta.errors`）
+5. サーバーエラー（API エラー）が適切に表示される
+6. ダイアログ close 時に `form.reset()` でフォームがリセットされる
+7. `pnpm typecheck`, `pnpm lint`, `pnpm build` がすべてパスする
+8. RevokeTokenDialog は変更されていない
+
+### 詳細要件
+
+#### フォーム状態管理
+- `useState('name')` → `form.Field` name フィールドに移行
+- `useState('error')` → `field.state.meta.errors` + サーバーエラー用 `useState` に統合
+  - クライアントバリデーションエラー: `field.state.meta.errors` で表示
+  - サーバーエラー（API失敗時）: `onSubmit` 内 try/catch → useState で管理（TanStack Form にはサーバーエラー反映の公式パターンがないため）
+- `useState('createdToken')` → 変更なし（フォームフィールドではない）
+
+#### バリデーション
+- zod スキーマ: `z.object({ name: z.string().min(1, '名前は1文字以上で入力してください').max(100, '名前は100文字以内で入力してください') })`
+- `validators.onChange` にスキーマを渡す
+- **trim は `z.string().trim()` を使わない**。Standard Schema では transform の結果が `onSubmit` の value に反映されない可能性がある。代わりに `onSubmit` 内で `value.name.trim()` を行う（現行コードと同じパターン）
+
+#### Mutation 連携
+- `mutate` → `mutateAsync` に変更
+- mutation の `onSuccess`/`onError` コールバックを削除し、`onSubmit` 内の try/catch に統合
+- `form.state.isSubmitting` でローディング状態を管理
+
+#### Chakra UI 統合
+- `form.Field`（TanStack）と `Field`（Chakra UI）は衝突しない（`form.Field` はインスタンスメソッド）
+- `Field.Root` の `invalid` prop: `field.state.meta.isTouched && field.state.meta.errors.length > 0`
+- エラーテキスト: `field.state.meta.isTouched` の場合のみ表示
+
+#### ダイアログ制御
+- `closeOnInteractOutside` / `closeOnEscape`: `form.state.isSubmitting` を参照
+- 作成ボタン: `form.Subscribe` で `canSubmit`/`isSubmitting` を監視
+- close 時: `form.reset()` + `setCreatedToken(null)`
+
+### 影響範囲
+
+| ファイル | 変更内容 |
+|---|---|
+| `boardflow/package.json` | `@tanstack/react-form`, `zod` 追加 |
+| `boardflow/pnpm-lock.yaml` | パッケージロック更新（自動） |
+| `boardflow/src/components/tokens/create-token-dialog.tsx` | TanStack Form + zod へのリファクタリング |
+
+**変更しないファイル:**
+- `boardflow/src/components/tokens/revoke-token-dialog.tsx`
+- その他すべてのファイル
+
+### 設計方針
+
+#### CreateTokenDialog 移行後の構造
+
+```tsx
+'use client';
+
+import { useForm } from '@tanstack/react-form';
+import { z } from 'zod';
+import {
+  Box, Button, Clipboard, Dialog, Field, HStack, Input, Portal, Text,
+} from '@chakra-ui/react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useState } from 'react';
+import { $api } from '@/lib/api/react-query';
+
+const createTokenSchema = z.object({
+  name: z.string()
+    .min(1, '名前は1文字以上で入力してください')
+    .max(100, '名前は100文字以内で入力してください'),
+});
+
+interface Props {
+  repositoryId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CreateTokenDialog({ repositoryId, open, onOpenChange }: Props) {
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [serverError, setServerError] = useState('');
+  const queryClient = useQueryClient();
+
+  const { mutateAsync } = $api.useMutation(
+    'post',
+    '/api/v1/repositories/{github_repository_id}/api-tokens',
+  );
+
+  const form = useForm({
+    defaultValues: { name: '' },
+    validators: {
+      onChange: createTokenSchema,
+    },
+    onSubmit: async ({ value }) => {
+      setServerError('');
+      try {
+        const data = await mutateAsync({
+          params: { path: { github_repository_id: Number(repositoryId) } },
+          body: { name: value.name.trim() },
+        });
+        if (!data?.token) {
+          setServerError('トークンの作成に失敗しました');
+          return;
+        }
+        setCreatedToken(data.token);
+        queryClient.invalidateQueries({
+          queryKey: ['get', '/api/v1/repositories/{github_repository_id}/api-tokens'],
+        });
+      } catch (err: unknown) {
+        const apiErr = err as { error?: { message?: string } };
+        setServerError(apiErr.error?.message ?? 'トークンの作成に失敗しました');
+      }
+    },
+  });
+
+  const handleClose = (open: boolean) => {
+    if (!open) {
+      form.reset();
+      setServerError('');
+      setCreatedToken(null);
+    }
+    onOpenChange(open);
+  };
+
+  // JSX: form.Field, form.Subscribe を使った宣言的 UI
+}
+```
+
+#### 主な変更ポイント
+
+1. **import 変更**: `useForm` (from `@tanstack/react-form`), `z` (from `zod`) を追加
+2. **useState 削減**: `name`, `error` → 削除。`serverError`（API エラー専用）と `createdToken` の2つに
+3. **mutation 変更**: `mutate` → `mutateAsync`、コールバック削除
+4. **フォーム入力部分**: `<form>` タグで囲み、`form.Field` render props で Input をバインド
+5. **エラー表示**: クライアントエラーは `field.state.meta.errors`、サーバーエラーは `serverError` state
+6. **ボタン制御**: `form.Subscribe` で `canSubmit`/`isSubmitting` を監視
+
+### 実装ステップ
+
+#### Step 1: ブランチ作成
+```bash
+git checkout main && git pull origin main
+git checkout -b feature/79-tanstack-form
+```
+
+#### Step 2: パッケージインストール
+```bash
+cd boardflow && pnpm add @tanstack/react-form zod
+```
+- `@tanstack/zod-form-adapter` は**インストールしない**（zod 3.24+ Standard Schema 対応）
+- `@tanstack/react-form-nextjs` も**インストールしない**（Server Actions 不要）
+
+#### Step 3: CreateTokenDialog のリファクタリング
+
+**ファイル**: `boardflow/src/components/tokens/create-token-dialog.tsx`
+
+**3a. import 更新**
+- 追加: `import { useForm } from '@tanstack/react-form'`, `import { z } from 'zod'`
+- 削除なし（`useState` は `createdToken` と `serverError` 用に残す）
+
+**3b. zod スキーマ定義**
+- コンポーネント外に `createTokenSchema` を定義
+- `z.string().min(1).max(100)` で日本語エラーメッセージ付き
+- `z.string().trim()` は使わない（Standard Schema の transform 挙動が未検証のため）
+
+**3c. useState 変更**
+- 削除: `const [name, setName] = useState('')`
+- 削除: `const [error, setError] = useState('')`
+- 追加: `const [serverError, setServerError] = useState('')`
+- 維持: `const [createdToken, setCreatedToken] = useState<string | null>(null)`
+
+**3d. mutation 変更**
+- `const { mutate, isPending }` → `const { mutateAsync }`
+- `onSuccess`/`onError` コールバックを削除
+
+**3e. useForm 追加**
+- `defaultValues: { name: '' }`
+- `validators: { onChange: createTokenSchema }`
+- `onSubmit`: `mutateAsync` を呼び、成功時 `setCreatedToken`、失敗時 `setServerError`
+
+**3f. handleCreate 削除**
+- `handleCreate` 関数を削除（`form.onSubmit` に統合済み）
+
+**3g. handleClose 変更**
+- `setName('')`/`setError('')` → `form.reset()`/`setServerError('')`
+
+**3h. JSX 変更**
+
+- フォーム入力部分を `<form onSubmit={...}>` で囲む
+- `<Input>` を `<form.Field name="name">` の render props 内に配置
+- `Field.Root` の `invalid` を `field.state.meta.isTouched && field.state.meta.errors.length > 0` に変更
+- エラー表示: `field.state.meta.errors` + `serverError`
+- `closeOnInteractOutside`/`closeOnEscape`: `!createdToken && !form.state.isSubmitting`
+- 作成ボタン: `form.Subscribe` で `canSubmit`/`isSubmitting` を監視
+- キャンセルボタン: `disabled={form.state.isSubmitting}`
+
+**注意点:**
+- `form.Field` render props の `children` は関数（biome が lint エラーを出さないか確認）
+- `field.state.meta.errors` は `ValidationError[]` 型。`join(', ')` で文字列化
+- `form.Subscribe` の `selector` は配列を返す。型推論が正しく効くか確認
+
+#### Step 4: 検証
+
+```bash
+cd boardflow
+pnpm typecheck   # TypeScript の型チェック
+pnpm lint        # biome lint
+pnpm build       # Next.js ビルド
+```
+
+- 3つすべてがパスすることを確認
+- lint 違反があれば `pnpm lint --write` で自動修正
+
+#### Step 5: コミット & プッシュ
+
+```bash
+git add -A
+git commit -m "feat(frontend): migrate CreateTokenDialog to TanStack Form + zod
+
+- Replace useState(name, error) with useForm + zod schema validation
+- Use mutateAsync in onSubmit instead of mutate with callbacks  
+- Declarative field validation with field.state.meta.errors
+- Keep createdToken as useState (not a form field)
+- Add @tanstack/react-form and zod dependencies
+
+Closes #79"
+git push origin feature/79-tanstack-form
+```
+
+### テスト観点
+
+| 観点 | 確認方法 |
+|---|---|
+| 型安全性 | `pnpm typecheck` パス |
+| lint | `pnpm lint` パス |
+| ビルド | `pnpm build` パス |
+| バリデーション: 空文字 | 名前未入力で「作成」ボタンが disabled |
+| バリデーション: 100文字超 | 100文字超入力でエラーメッセージ表示 |
+| 正常系: トークン作成 | 名前入力→作成→トークン表示画面に遷移 |
+| 異常系: API エラー | サーバーエラー時にエラーメッセージ表示 |
+| ダイアログ close | close 時にフォームがリセットされる |
+| ローディング状態 | 作成中にボタンが loading 表示、ダイアログが閉じない |
+| RevokeTokenDialog | 変更されていないこと |
+
+### ドキュメント更新対象
+
+| ドキュメント | 更新内容 |
+|---|---|
+| `docs/logs/79/worklog.md` | 実装計画（本セクション）、実装後に結果追記 |
+
+**更新不要:**
+- `docs/spec.md` — フォームライブラリの選択は仕様変更ではない
+- `docs/frontend/` — 技術選定ドキュメントがあれば更新するが、現在フォーム関連の記述なし
+- `docs/technology.md` — TanStack Form / zod を追記する場合は実装完了後に判断
+
+### 実装要否
+
+**`implementation_required`**
+
+### 未解決の疑問
+
+なし。research agent の調査が十分であり、ユーザー判断が必要な項目はない。
+
+### 更新した作業ログパス
+
+`docs/logs/79/worklog.md`


### PR DESCRIPTION
## 概要

CreateTokenDialogをTanStack Form + zodに移行し、宣言的バリデーションと型安全なフォーム状態管理を実現しました。

## 要件

- フォームの状態管理をTanStack Formに統一
- \`useState\` 手動管理からの脱却
- zod バリデーション統合
- TanStack Query mutation との連携

## 調査結果

- \`@tanstack/zod-form-adapter\` は廃止済み（TanStack Form v1 より Standard Schema で直接 zod 統合可能）
- \`z.string().trim()\` は transform 扱いのため \`onSubmit\` 内で明示的に \`.trim()\` する方針を採用
- Chakra UI v3 \`Field.Root\`/\`Input\` との統合パターンを確認
- RevokeTokenDialog はフォームフィールドが0個のため移行対象外

外部調査メモ: \`docs/external/tanstack-form-chakra-integration.md\`

## 実装概要

- \`@tanstack/react-form\` v1.29.1 + \`zod\` v4.4.3 を追加
- CreateTokenDialog: \`useState(name, error)\` → \`useForm\` + zod スキーマバリデーション
- \`mutate\` → \`mutateAsync\` (onSubmit内try/catch)
- \`form.Field\` / \`form.Subscribe\` による宣言的UI
- Chakra UI v3 \`Field.Root\`/\`Input\` との統合
- \`Dialog.Footer\` は \`Dialog.Content\` 直下に配置（form id + form属性で関連付け）

### 対象外

- RevokeTokenDialog（フォームフィールドが0個の確認ダイアログのため）

## テスト結果

- [x] \`pnpm typecheck\` パス
- [x] \`pnpm lint --write --unsafe\` パス (0 errors)
- [x] \`pnpm build\` パス (Next.js Turbopack)

## ドキュメント更新

- \`docs/external/tanstack-form-chakra-integration.md\` — 調査メモ（新規作成）
- \`docs/frontend/summary.md\` — 採用スタック表にTanStack Form + zod行を追加
- \`docs/logs/79/worklog.md\` — 作業ログ

## 外部調査メモ

- https://tanstack.com/form/v1/docs/framework/react/guides/validation
- https://tanstack.com/form/v1/docs/framework/react/guides/ui-libraries
- https://github.com/TanStack/form/issues/1136 (zod-form-adapter 廃止情報)

## 残リスク

- 将来のフォーム追加時のスキーマ分割方針は未定（現時点ではフォームが1つのみのため先送り）

## レビュー/ドキュメント判定

- review: \`pr_ready: true\`
- docs: \`docs_ready: true\`

Closes #79