### PR TITLE
feat(api): add OpenAPI schema snapshot test for CI type consistency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,7 +2292,6 @@ checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
- "serde",
  "similar",
  "tempfile",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http-body-util",
+ "insta",
  "rand 0.8.6",
  "reqwest",
  "serde",
@@ -1045,6 +1046,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1451,6 +1463,12 @@ dependencies = [
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2267,6 +2285,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,7 +2975,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.40",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror",
  "tokio",
  "tracing",
@@ -2981,7 +3012,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -3637,6 +3668,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ globset = "0.4"
 walkdir = "2"
 tempfile = "3"
 anyhow = "1"
-insta = { version = "1", features = ["yaml"] }
+insta = { version = "1" }
 boardflow-api-types = { path = "crates/api-types" }
 
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ globset = "0.4"
 walkdir = "2"
 tempfile = "3"
 anyhow = "1"
+insta = { version = "1", features = ["yaml"] }
 boardflow-api-types = { path = "crates/api-types" }
 
 [workspace.lints.clippy]

--- a/README.md
+++ b/README.md
@@ -97,3 +97,19 @@ pnpm typecheck
 ```
 
 `schema.d.ts` は自動生成ファイルのため、手動編集しないでください。
+
+### OpenAPI スキーマのスナップショット更新
+
+バックエンドの API エンドポイントやリクエスト/レスポンス型を変更した場合、OpenAPI スナップショットテストが失敗します。意図的な変更であれば以下の手順でスナップショットを更新してください。
+
+```bash
+# 1. テスト実行（失敗を確認）
+mise exec -- cargo test -p boardflow-api --test openapi_schema_test
+
+# 2. スナップショットの差分を確認・承認
+mise exec -- cargo insta review
+
+# 3. 更新された .snap ファイルをコミット
+git add crates/api/tests/snapshots/
+git commit -m "update OpenAPI schema snapshot"
+```

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -33,6 +33,7 @@ rand = { workspace = true }
 
 [dev-dependencies]
 boardflow-config = { path = "../config" }
+insta = { workspace = true }
 http-body-util = "0.1"
 serial_test = { workspace = true }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -40,30 +40,7 @@ pub fn create_app_with_config(
     webhook_secret: Option<String>,
     github_app_id: Option<u64>,
 ) -> Router {
-    let (router, api) = OpenApiRouter::with_openapi(ApiDoc::openapi())
-        .routes(routes!(routes::health::healthz))
-        .routes(routes!(routes::plan::plan_run))
-        .routes(routes!(routes::board_run::create_board_run))
-        .routes(routes!(routes::board_run::fail_board_run))
-        .routes(routes!(routes::board_run::import_artifact_bundle))
-        .routes(routes!(routes::read::list_repositories))
-        .routes(routes!(routes::read::get_repository))
-        .routes(routes!(routes::read::list_board_projects))
-        .routes(routes!(routes::read::get_board_project))
-        .routes(routes!(routes::read::list_board_runs))
-        .routes(routes!(routes::read::get_board_run))
-        .routes(routes!(routes::read::list_artifacts))
-        .routes(routes!(routes::read::get_viewer_sources))
-        .routes(routes!(routes::read::get_board_run_diff))
-        .routes(routes!(routes::read::list_findings))
-        .routes(routes!(routes::auth::login))
-        .routes(routes!(routes::auth::callback))
-        .routes(routes!(routes::auth::logout))
-        .routes(routes!(routes::auth::me))
-        .routes(routes!(routes::api_token::create_api_token))
-        .routes(routes!(routes::api_token::list_api_tokens))
-        .routes(routes!(routes::api_token::revoke_api_token))
-        .split_for_parts();
+    let (router, api) = openapi_router().split_for_parts();
 
     let oauth = oauth_config.unwrap_or_else(|| OAuthConfig {
         client_id: optional_env("GITHUB_CLIENT_ID").unwrap_or_default(),
@@ -161,6 +138,39 @@ pub struct GithubAppId(pub Option<u64>);
     modifiers(&SecurityAddon)
 )]
 struct ApiDoc;
+
+fn openapi_router() -> OpenApiRouter<PgPool> {
+    OpenApiRouter::with_openapi(ApiDoc::openapi())
+        .routes(routes!(routes::health::healthz))
+        .routes(routes!(routes::plan::plan_run))
+        .routes(routes!(routes::board_run::create_board_run))
+        .routes(routes!(routes::board_run::fail_board_run))
+        .routes(routes!(routes::board_run::import_artifact_bundle))
+        .routes(routes!(routes::read::list_repositories))
+        .routes(routes!(routes::read::get_repository))
+        .routes(routes!(routes::read::list_board_projects))
+        .routes(routes!(routes::read::get_board_project))
+        .routes(routes!(routes::read::list_board_runs))
+        .routes(routes!(routes::read::get_board_run))
+        .routes(routes!(routes::read::list_artifacts))
+        .routes(routes!(routes::read::get_viewer_sources))
+        .routes(routes!(routes::read::get_board_run_diff))
+        .routes(routes!(routes::read::list_findings))
+        .routes(routes!(routes::auth::login))
+        .routes(routes!(routes::auth::callback))
+        .routes(routes!(routes::auth::logout))
+        .routes(routes!(routes::auth::me))
+        .routes(routes!(routes::api_token::create_api_token))
+        .routes(routes!(routes::api_token::list_api_tokens))
+        .routes(routes!(routes::api_token::revoke_api_token))
+}
+
+/// Returns the full OpenAPI schema including all registered routes.
+/// Used for snapshot testing and documentation generation.
+pub fn openapi_schema() -> utoipa::openapi::OpenApi {
+    let (_router, api) = openapi_router().split_for_parts();
+    api
+}
 
 struct SecurityAddon;
 

--- a/crates/api/tests/openapi_schema_test.rs
+++ b/crates/api/tests/openapi_schema_test.rs
@@ -1,0 +1,10 @@
+use insta::assert_snapshot;
+
+/// OpenAPIスキーマのスナップショットテスト。
+/// APIの型やエンドポイント定義が意図せず変更された場合にCIで検出する。
+#[test]
+fn test_openapi_schema_snapshot() {
+    let schema = boardflow_api::openapi_schema();
+    let json = serde_json::to_string_pretty(&schema).unwrap();
+    assert_snapshot!("openapi_schema", json);
+}

--- a/crates/api/tests/snapshots/openapi_schema_test__openapi_schema.snap
+++ b/crates/api/tests/snapshots/openapi_schema_test__openapi_schema.snap
@@ -1,0 +1,3064 @@
+---
+source: crates/api/tests/openapi_schema_test.rs
+expression: json
+---
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "BoardFlow API",
+    "description": "",
+    "license": {
+      "name": ""
+    },
+    "version": "0.1.0"
+  },
+  "paths": {
+    "/api/v1/auth/callback": {
+      "get": {
+        "operationId": "callback",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect after successful OAuth"
+          },
+          "401": {
+            "description": "OAuth failed"
+          },
+          "403": {
+            "description": "CSRF state mismatch"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "get": {
+        "operationId": "login",
+        "parameters": [
+          {
+            "name": "redirect_to",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "Redirect to GitHub OAuth"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "operationId": "logout",
+        "responses": {
+          "200": {
+            "description": "Logged out"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/auth/me": {
+      "get": {
+        "operationId": "me",
+        "responses": {
+          "200": {
+            "description": "Current user info",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MeResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        }
+      }
+    },
+    "/api/v1/board-projects/{board_project_id}": {
+      "get": {
+        "operationId": "get_board_project",
+        "parameters": [
+          {
+            "name": "board_project_id",
+            "in": "path",
+            "description": "BoardProject ID (bp_ prefix)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "BoardProject detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardProjectDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/board-projects/{board_project_id}/board-runs": {
+      "get": {
+        "operationId": "list_board_runs",
+        "parameters": [
+          {
+            "name": "board_project_id",
+            "in": "path",
+            "description": "BoardProject ID (bp_ prefix)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "BoardRun list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_BoardRunListItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/board-runs": {
+      "post": {
+        "operationId": "create_board_run",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateBoardRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Board run created or existing returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateBoardRunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/board-runs/{board_run_id}": {
+      "get": {
+        "operationId": "get_board_run",
+        "parameters": [
+          {
+            "name": "board_run_id",
+            "in": "path",
+            "description": "BoardRun ID (br_ prefix)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "BoardRun detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardRunDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/board-runs/{board_run_id}/artifact-bundles/import": {
+      "post": {
+        "operationId": "import_artifact_bundle",
+        "parameters": [
+          {
+            "name": "board_run_id",
+            "in": "path",
+            "description": "Board run ID with br_ prefix",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ImportArtifactBundleRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Import queued or existing returned",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ImportArtifactBundleResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/board-runs/{board_run_id}/artifacts": {
+      "get": {
+        "operationId": "list_artifacts",
+        "parameters": [
+          {
+            "name": "board_run_id",
+            "in": "path",
+            "description": "BoardRun ID (br_ prefix)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Artifact list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtifactListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/board-runs/{board_run_id}/checks/{check_kind}/findings": {
+      "get": {
+        "operationId": "list_findings",
+        "parameters": [
+          {
+            "name": "board_run_id",
+            "in": "path",
+            "description": "BoardRun ID (br_ prefix)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "check_kind",
+            "in": "path",
+            "description": "Check kind: erc or drc",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          {
+            "name": "severity",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Findings list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_FindingListItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/board-runs/{board_run_id}/diff": {
+      "get": {
+        "operationId": "get_board_run_diff",
+        "parameters": [
+          {
+            "name": "board_run_id",
+            "in": "path",
+            "description": "Board run ID (br_<uuid>)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Diff details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BoardRunDiffResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/board-runs/{board_run_id}/fail": {
+      "post": {
+        "operationId": "fail_board_run",
+        "parameters": [
+          {
+            "name": "board_run_id",
+            "in": "path",
+            "description": "Board run ID with br_ prefix",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FailBoardRunRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Board run marked as failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FailBoardRunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/api/v1/board-runs/{board_run_id}/viewer-sources": {
+      "get": {
+        "operationId": "get_viewer_sources",
+        "parameters": [
+          {
+            "name": "board_run_id",
+            "in": "path",
+            "description": "BoardRun ID (br_ prefix)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Viewer sources",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ViewerSourcesResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repositories": {
+      "get": {
+        "operationId": "list_repositories",
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Repository list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_RepositoryListItem"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repositories/{github_repository_id}": {
+      "get": {
+        "operationId": "get_repository",
+        "parameters": [
+          {
+            "name": "github_repository_id",
+            "in": "path",
+            "description": "GitHub repository ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Repository detail",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositoryDetailResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repositories/{github_repository_id}/api-tokens": {
+      "get": {
+        "operationId": "list_api_tokens",
+        "parameters": [
+          {
+            "name": "github_repository_id",
+            "in": "path",
+            "description": "GitHub repository ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiTokenListResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "create_api_token",
+        "parameters": [
+          {
+            "name": "github_repository_id",
+            "in": "path",
+            "description": "GitHub repository ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateApiTokenRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Token created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateApiTokenResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repositories/{github_repository_id}/api-tokens/{token_id}/revoke": {
+      "post": {
+        "operationId": "revoke_api_token",
+        "parameters": [
+          {
+            "name": "github_repository_id",
+            "in": "path",
+            "description": "GitHub repository ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "token_id",
+            "in": "path",
+            "description": "API token ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Token revoked",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiTokenDetailResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/repositories/{github_repository_id}/board-projects": {
+      "get": {
+        "operationId": "list_board_projects",
+        "parameters": [
+          {
+            "name": "github_repository_id",
+            "in": "path",
+            "description": "GitHub repository ID",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "int64",
+              "default": 50,
+              "maximum": 100,
+              "minimum": 1
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "BoardProject list",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedResponse_BoardProjectListItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/runs/plan": {
+      "post": {
+        "operationId": "plan_run",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PlanRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Plan decisions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlanResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Validation error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "bearer_auth": []
+          }
+        ]
+      }
+    },
+    "/healthz": {
+      "get": {
+        "operationId": "healthz",
+        "responses": {
+          "200": {
+            "description": "Service is healthy",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Service is unhealthy"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiTokenDetailResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "last_used_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "revoked_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ApiTokenListItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "last_used_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "revoked_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ApiTokenListResponse": {
+        "type": "object",
+        "required": [
+          "items",
+          "has_more"
+        ],
+        "properties": {
+          "has_more": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ApiTokenListItem"
+            }
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ArtifactBundleInfo": {
+        "type": "object",
+        "required": [
+          "upload_mode",
+          "object_key",
+          "upload_url",
+          "method",
+          "expires_at"
+        ],
+        "properties": {
+          "expires_at": {
+            "type": "string"
+          },
+          "method": {
+            "type": "string"
+          },
+          "object_key": {
+            "type": "string"
+          },
+          "upload_mode": {
+            "type": "string"
+          },
+          "upload_url": {
+            "type": "string"
+          }
+        }
+      },
+      "ArtifactListItem": {
+        "type": "object",
+        "required": [
+          "type",
+          "status"
+        ],
+        "properties": {
+          "artifact_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "content_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "filename": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "logical_name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "sha256": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "size_bytes": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int64"
+          },
+          "source_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "status_reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "type": {
+            "type": "string"
+          }
+        }
+      },
+      "ArtifactListResponse": {
+        "type": "object",
+        "required": [
+          "items"
+        ],
+        "properties": {
+          "items": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ArtifactListItem"
+            }
+          }
+        }
+      },
+      "ArtifactSummary": {
+        "type": "object",
+        "required": [
+          "available",
+          "missing",
+          "failed",
+          "skipped"
+        ],
+        "properties": {
+          "available": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "failed": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "missing": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "skipped": {
+            "type": "integer",
+            "format": "int64"
+          }
+        }
+      },
+      "BoardProjectDetailResponse": {
+        "type": "object",
+        "required": [
+          "board_project_id",
+          "repository",
+          "project_path",
+          "project_dir",
+          "display_name",
+          "state",
+          "recreate_issue_on_update",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "board_project_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "issue_number": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "format": "int32"
+          },
+          "issue_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latest_completed_run_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latest_tree_hash": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "project_dir": {
+            "type": "string"
+          },
+          "project_path": {
+            "type": "string"
+          },
+          "recreate_issue_on_update": {
+            "type": "boolean"
+          },
+          "repository": {
+            "$ref": "#/components/schemas/RepositoryRef"
+          },
+          "state": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "BoardProjectListItem": {
+        "type": "object",
+        "required": [
+          "board_project_id",
+          "project_path",
+          "project_dir",
+          "display_name",
+          "state",
+          "updated_at"
+        ],
+        "properties": {
+          "board_project_id": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "issue_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latest_completed_run_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "latest_tree_hash": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "project_dir": {
+            "type": "string"
+          },
+          "project_path": {
+            "type": "string"
+          },
+          "state": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "BoardRunDetailResponse": {
+        "type": "object",
+        "required": [
+          "board_run_id",
+          "board_project_id",
+          "status",
+          "commit_sha",
+          "branch",
+          "ref",
+          "github_run_id",
+          "github_run_attempt",
+          "checks",
+          "artifact_summary",
+          "created_at"
+        ],
+        "properties": {
+          "artifact_summary": {
+            "$ref": "#/components/schemas/ArtifactSummary"
+          },
+          "board_project_id": {
+            "type": "string"
+          },
+          "board_run_id": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "checks": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CheckInfo"
+            }
+          },
+          "commit_sha": {
+            "type": "string"
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "github_run_attempt": {
+            "type": "string"
+          },
+          "github_run_id": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "tree_hash": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "BoardRunDiffResponse": {
+        "type": "object",
+        "required": [
+          "board_run_id",
+          "status",
+          "created_at"
+        ],
+        "properties": {
+          "base_board_run_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "board_run_id": {
+            "type": "string"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "error_message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "metadata": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/DiffMetadataResponse"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          },
+          "summary": {}
+        }
+      },
+      "BoardRunListItem": {
+        "type": "object",
+        "required": [
+          "board_run_id",
+          "status",
+          "commit_sha",
+          "branch",
+          "ref",
+          "github_run_id",
+          "github_run_attempt",
+          "erc_errors",
+          "erc_warnings",
+          "drc_errors",
+          "drc_warnings",
+          "created_at"
+        ],
+        "properties": {
+          "board_run_id": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "commit_sha": {
+            "type": "string"
+          },
+          "completed_at": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "drc_errors": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "drc_status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "drc_warnings": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "erc_errors": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "erc_status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "erc_warnings": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "github_run_attempt": {
+            "type": "string"
+          },
+          "github_run_id": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "tree_hash": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "CheckInfo": {
+        "type": "object",
+        "required": [
+          "kind",
+          "status",
+          "error_count",
+          "warning_count",
+          "notice_count"
+        ],
+        "properties": {
+          "error_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "notice_count": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "status": {
+            "type": "string"
+          },
+          "warning_count": {
+            "type": "integer",
+            "format": "int32"
+          }
+        }
+      },
+      "CoordinateMmResponse": {
+        "type": "object",
+        "required": [
+          "x",
+          "y"
+        ],
+        "properties": {
+          "x": {
+            "type": "number",
+            "format": "double"
+          },
+          "y": {
+            "type": "number",
+            "format": "double"
+          }
+        }
+      },
+      "CreateApiTokenRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateApiTokenResponse": {
+        "type": "object",
+        "required": [
+          "id",
+          "name",
+          "token",
+          "created_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateBoardRunRequest": {
+        "type": "object",
+        "required": [
+          "board_project_id",
+          "project_path",
+          "tree_hash",
+          "commit_sha",
+          "branch",
+          "ref",
+          "github_run_id",
+          "github_run_attempt"
+        ],
+        "properties": {
+          "board_project_id": {
+            "type": "string"
+          },
+          "branch": {
+            "type": "string"
+          },
+          "commit_sha": {
+            "type": "string"
+          },
+          "github_run_attempt": {
+            "type": "string"
+          },
+          "github_run_id": {
+            "type": "string"
+          },
+          "project_path": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          },
+          "tree_hash": {
+            "type": "string"
+          }
+        }
+      },
+      "CreateBoardRunResponse": {
+        "type": "object",
+        "required": [
+          "board_run_id",
+          "status"
+        ],
+        "properties": {
+          "artifact_bundle": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ArtifactBundleInfo"
+              }
+            ]
+          },
+          "board_run_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "DiffMetadataResponse": {
+        "type": "object",
+        "properties": {
+          "artifacts_summary": {},
+          "bom_summary": {},
+          "checks_summary": {},
+          "file_hashes": {},
+          "previews": {}
+        }
+      },
+      "ErrorBody": {
+        "type": "object",
+        "required": [
+          "code",
+          "message",
+          "request_id"
+        ],
+        "properties": {
+          "code": {
+            "type": "string"
+          },
+          "details": {},
+          "message": {
+            "type": "string"
+          },
+          "request_id": {
+            "type": "string"
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "required": [
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/ErrorBody"
+          }
+        }
+      },
+      "FailBoardRunRequest": {
+        "type": "object",
+        "required": [
+          "status",
+          "error"
+        ],
+        "properties": {
+          "error": {
+            "$ref": "#/components/schemas/FailErrorInfo"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "FailBoardRunResponse": {
+        "type": "object",
+        "required": [
+          "board_run_id",
+          "status",
+          "failed_at"
+        ],
+        "properties": {
+          "board_run_id": {
+            "type": "string"
+          },
+          "failed_at": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "FailErrorInfo": {
+        "type": "object",
+        "required": [
+          "message"
+        ],
+        "properties": {
+          "details": {},
+          "message": {
+            "type": "string"
+          }
+        }
+      },
+      "FindingListItem": {
+        "type": "object",
+        "required": [
+          "id",
+          "severity"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "message": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pcb_layer": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pos_mm": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CoordinateMmResponse"
+              }
+            ]
+          },
+          "rule_code": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "severity": {
+            "type": "string"
+          },
+          "sheet_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subject_kind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subject_ref": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "title": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "HealthResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "ImportArtifactBundleRequest": {
+        "type": "object",
+        "required": [
+          "staging_object_key",
+          "bundle_sha256",
+          "bundle_size_bytes"
+        ],
+        "properties": {
+          "bundle_sha256": {
+            "type": "string"
+          },
+          "bundle_size_bytes": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "staging_object_key": {
+            "type": "string"
+          }
+        }
+      },
+      "ImportArtifactBundleResponse": {
+        "type": "object",
+        "required": [
+          "bundle_id",
+          "status"
+        ],
+        "properties": {
+          "bundle_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      },
+      "MeResponse": {
+        "type": "object",
+        "required": [
+          "user_id",
+          "github_login"
+        ],
+        "properties": {
+          "github_avatar_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "github_login": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "string"
+          }
+        }
+      },
+      "PaginatedResponse_BoardProjectListItem": {
+        "type": "object",
+        "required": [
+          "items",
+          "has_more"
+        ],
+        "properties": {
+          "has_more": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "board_project_id",
+                "project_path",
+                "project_dir",
+                "display_name",
+                "state",
+                "updated_at"
+              ],
+              "properties": {
+                "board_project_id": {
+                  "type": "string"
+                },
+                "display_name": {
+                  "type": "string"
+                },
+                "issue_url": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "latest_completed_run_id": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "latest_tree_hash": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "project_dir": {
+                  "type": "string"
+                },
+                "project_path": {
+                  "type": "string"
+                },
+                "state": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "PaginatedResponse_BoardRunListItem": {
+        "type": "object",
+        "required": [
+          "items",
+          "has_more"
+        ],
+        "properties": {
+          "has_more": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "board_run_id",
+                "status",
+                "commit_sha",
+                "branch",
+                "ref",
+                "github_run_id",
+                "github_run_attempt",
+                "erc_errors",
+                "erc_warnings",
+                "drc_errors",
+                "drc_warnings",
+                "created_at"
+              ],
+              "properties": {
+                "board_run_id": {
+                  "type": "string"
+                },
+                "branch": {
+                  "type": "string"
+                },
+                "commit_sha": {
+                  "type": "string"
+                },
+                "completed_at": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "created_at": {
+                  "type": "string"
+                },
+                "drc_errors": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "drc_status": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "drc_warnings": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "erc_errors": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "erc_status": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "erc_warnings": {
+                  "type": "integer",
+                  "format": "int32"
+                },
+                "github_run_attempt": {
+                  "type": "string"
+                },
+                "github_run_id": {
+                  "type": "string"
+                },
+                "ref": {
+                  "type": "string"
+                },
+                "status": {
+                  "type": "string"
+                },
+                "tree_hash": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "PaginatedResponse_FindingListItem": {
+        "type": "object",
+        "required": [
+          "items",
+          "has_more"
+        ],
+        "properties": {
+          "has_more": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "id",
+                "severity"
+              ],
+              "properties": {
+                "id": {
+                  "type": "string"
+                },
+                "message": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pcb_layer": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "pos_mm": {
+                  "oneOf": [
+                    {
+                      "type": "null"
+                    },
+                    {
+                      "$ref": "#/components/schemas/CoordinateMmResponse"
+                    }
+                  ]
+                },
+                "rule_code": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "severity": {
+                  "type": "string"
+                },
+                "sheet_path": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "subject_kind": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "subject_ref": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "title": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                }
+              }
+            }
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "PaginatedResponse_RepositoryListItem": {
+        "type": "object",
+        "required": [
+          "items",
+          "has_more"
+        ],
+        "properties": {
+          "has_more": {
+            "type": "boolean"
+          },
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": [
+                "github_repository_id",
+                "owner",
+                "name",
+                "installation_id",
+                "board_project_count",
+                "updated_at"
+              ],
+              "properties": {
+                "board_project_count": {
+                  "type": "integer",
+                  "format": "int64"
+                },
+                "github_repository_id": {
+                  "type": "string"
+                },
+                "installation_id": {
+                  "type": "string"
+                },
+                "latest_run_status": {
+                  "type": [
+                    "string",
+                    "null"
+                  ]
+                },
+                "name": {
+                  "type": "string"
+                },
+                "owner": {
+                  "type": "string"
+                },
+                "updated_at": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "next_cursor": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "PlanActionInput": {
+        "type": "object",
+        "required": [
+          "workflow",
+          "run_id",
+          "run_attempt"
+        ],
+        "properties": {
+          "run_attempt": {
+            "type": "string"
+          },
+          "run_id": {
+            "type": "string"
+          },
+          "workflow": {
+            "type": "string"
+          }
+        }
+      },
+      "PlanDecision": {
+        "type": "string",
+        "enum": [
+          "build",
+          "skip",
+          "error"
+        ]
+      },
+      "PlanGitInput": {
+        "type": "object",
+        "required": [
+          "ref",
+          "branch",
+          "commit_sha",
+          "event_name"
+        ],
+        "properties": {
+          "branch": {
+            "type": "string"
+          },
+          "commit_sha": {
+            "type": "string"
+          },
+          "event_name": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          }
+        }
+      },
+      "PlanMode": {
+        "type": "string",
+        "enum": [
+          "auto",
+          "all"
+        ]
+      },
+      "PlanProjectFile": {
+        "type": "object",
+        "required": [
+          "path",
+          "sha256"
+        ],
+        "properties": {
+          "path": {
+            "type": "string"
+          },
+          "sha256": {
+            "type": "string"
+          }
+        }
+      },
+      "PlanProjectInput": {
+        "type": "object",
+        "required": [
+          "project_path",
+          "config_path",
+          "project_dir",
+          "tree_hash",
+          "files"
+        ],
+        "properties": {
+          "config_path": {
+            "type": "string"
+          },
+          "files": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlanProjectFile"
+            }
+          },
+          "project_dir": {
+            "type": "string"
+          },
+          "project_path": {
+            "type": "string"
+          },
+          "tree_hash": {
+            "type": "string"
+          }
+        }
+      },
+      "PlanProjectOutput": {
+        "type": "object",
+        "required": [
+          "project_path",
+          "board_project_id",
+          "decision",
+          "reason"
+        ],
+        "properties": {
+          "board_project_id": {
+            "type": "string"
+          },
+          "decision": {
+            "$ref": "#/components/schemas/PlanDecision"
+          },
+          "latest_completed_run_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "project_path": {
+            "type": "string"
+          },
+          "reason": {
+            "$ref": "#/components/schemas/PlanReason"
+          }
+        }
+      },
+      "PlanReason": {
+        "type": "string",
+        "enum": [
+          "new_project",
+          "hash_changed",
+          "config_changed",
+          "manual_dispatch",
+          "unchanged",
+          "previous_failed",
+          "no_previous_snapshot",
+          "duplicate_project_path",
+          "invalid_project_path",
+          "invalid_tree_hash",
+          "invalid_config_path"
+        ]
+      },
+      "PlanRepositoryInput": {
+        "type": "object",
+        "required": [
+          "owner",
+          "name"
+        ],
+        "properties": {
+          "github_repository_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      },
+      "PlanRepositoryOutput": {
+        "type": "object",
+        "required": [
+          "github_repository_id",
+          "owner",
+          "name"
+        ],
+        "properties": {
+          "github_repository_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      },
+      "PlanRequest": {
+        "type": "object",
+        "required": [
+          "repository",
+          "git",
+          "action",
+          "mode",
+          "projects"
+        ],
+        "properties": {
+          "action": {
+            "$ref": "#/components/schemas/PlanActionInput"
+          },
+          "git": {
+            "$ref": "#/components/schemas/PlanGitInput"
+          },
+          "mode": {
+            "$ref": "#/components/schemas/PlanMode"
+          },
+          "projects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlanProjectInput"
+            }
+          },
+          "repository": {
+            "$ref": "#/components/schemas/PlanRepositoryInput"
+          }
+        }
+      },
+      "PlanResponse": {
+        "type": "object",
+        "required": [
+          "repository",
+          "projects"
+        ],
+        "properties": {
+          "projects": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PlanProjectOutput"
+            }
+          },
+          "repository": {
+            "$ref": "#/components/schemas/PlanRepositoryOutput"
+          }
+        }
+      },
+      "RepositoryDetailResponse": {
+        "type": "object",
+        "required": [
+          "github_repository_id",
+          "owner",
+          "name",
+          "installation_id",
+          "html_url",
+          "board_project_count",
+          "created_at",
+          "updated_at"
+        ],
+        "properties": {
+          "board_project_count": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "github_repository_id": {
+            "type": "string"
+          },
+          "html_url": {
+            "type": "string"
+          },
+          "installation_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "RepositoryListItem": {
+        "type": "object",
+        "required": [
+          "github_repository_id",
+          "owner",
+          "name",
+          "installation_id",
+          "board_project_count",
+          "updated_at"
+        ],
+        "properties": {
+          "board_project_count": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "github_repository_id": {
+            "type": "string"
+          },
+          "installation_id": {
+            "type": "string"
+          },
+          "latest_run_status": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "RepositoryRef": {
+        "type": "object",
+        "required": [
+          "github_repository_id",
+          "owner",
+          "name"
+        ],
+        "properties": {
+          "github_repository_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "type": "string"
+          }
+        }
+      },
+      "ViewerDownload": {
+        "type": "object",
+        "required": [
+          "artifact_type",
+          "status"
+        ],
+        "properties": {
+          "artifact_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "artifact_type": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "status_reason": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ViewerMap": {
+        "type": "object",
+        "required": [
+          "kicanvas",
+          "schematic",
+          "pcb_preview",
+          "ibom",
+          "bom",
+          "fabrication"
+        ],
+        "properties": {
+          "bom": {
+            "$ref": "#/components/schemas/ViewerStatus"
+          },
+          "fabrication": {
+            "$ref": "#/components/schemas/ViewerStatus"
+          },
+          "ibom": {
+            "$ref": "#/components/schemas/ViewerStatus"
+          },
+          "kicanvas": {
+            "$ref": "#/components/schemas/ViewerStatus"
+          },
+          "pcb_preview": {
+            "$ref": "#/components/schemas/ViewerStatus"
+          },
+          "schematic": {
+            "$ref": "#/components/schemas/ViewerStatus"
+          }
+        }
+      },
+      "ViewerSource": {
+        "type": "object",
+        "properties": {
+          "artifact_id": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "artifact_type": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "kind": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "name": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "source_path": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      },
+      "ViewerSourcesResponse": {
+        "type": "object",
+        "required": [
+          "board_run_id",
+          "expires_at",
+          "viewers"
+        ],
+        "properties": {
+          "board_run_id": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "string"
+          },
+          "viewers": {
+            "$ref": "#/components/schemas/ViewerMap"
+          }
+        }
+      },
+      "ViewerStatus": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "downloads": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ViewerDownload"
+            }
+          },
+          "iframe_url": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "primary": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/ViewerSource"
+              }
+            ]
+          },
+          "sources": {
+            "type": [
+              "array",
+              "null"
+            ],
+            "items": {
+              "$ref": "#/components/schemas/ViewerSource"
+            }
+          },
+          "status": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "securitySchemes": {
+      "bearer_auth": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}

--- a/docs/logs/91/worklog.md
+++ b/docs/logs/91/worklog.md
@@ -2,19 +2,52 @@
 
 ## 経緯
 
-- 共有型移行後も、将来の変更で型の乖離を防ぐ仕組みが必要
+- #89 (api-types crateの分離) と #90 (action-runnerのapi-types利用) が完了済み
+- api-types crateでAPI/action-runner間の型が共有されているが、OpenAPIスキーマレベルでの整合性は未検証
 
 ## ユーザー要望
 
-- 型の整合性が継続的に保証される仕組み
+- 型の整合性が継続的に保証される仕組みの構築
+- APIサーバ起動なしで実行可能なテスト
+- 既存CIに追加する形
 
-## Issue作成内容
+## 調査結果 (2026-05-05)
 
-OpenAPIスキーマのスナップショットテストまたは整合性テストをCIに追加。
+- `crates/api/src/lib.rs` の `ApiDoc::openapi()` でスキーマ取得可能（サーバ起動不要）
+- `insta` は未導入 → 今回導入
+- CI (`cargo test --workspace`) で自動実行される
+- action-runner は `boardflow-api-types` を使って API と型を共有
+- OpenAPI スキーマのスナップショットを取れば、型変更時に差分検出可能
 
-## 後続処理タイプ
+## 計画 (2026-05-05)
 
-`implementation_required`
+1. workspace Cargo.toml に `insta` を追加（features: yaml）
+2. crates/api/Cargo.toml に dev-dependency として `insta` を追加
+3. crates/api/tests/openapi_schema_test.rs を作成
+   - `ApiDoc::openapi()` を呼び出してスキーマJSON取得
+   - `insta::assert_snapshot!` でスナップショット保存
+4. スナップショットファイルを生成・コミット
+5. CIでは既存の `cargo test --workspace` で自動検証される（追加設定不要）
+
+## 実装内容
+
+TBD
+
+## テスト結果
+
+TBD
+
+## レビュー結果
+
+TBD
+
+## ドキュメント確認
+
+TBD
+
+## PR/完了結果
+
+TBD
 
 ## 残リスク
 

--- a/docs/logs/91/worklog.md
+++ b/docs/logs/91/worklog.md
@@ -180,4 +180,16 @@
 - review: pr_ready: true
 - docs: docs_ready: true（README追記済み）
 - 未使用yaml feature: 修正済み（`insta = "1"` に変更）
-- PR作成: 次ステップ
+- PR作成: 完了
+
+## PR/完了結果 (2026-05-05, PR作成)
+
+- PR URL: https://github.com/f0reachARR/boardflow/pull/93
+- タイトル: `feat(api): add OpenAPI schema snapshot test for CI type consistency`
+- ベースブランチ: main
+- Closes #91
+
+## 残リスク (最終)
+
+- API全体スナップショットのため、action-runner契約と無関係なAPI変更でもCIが落ちる（シグナルがやや広い）
+- 将来的にスナップショット対象をaction-runner関連パスに絞るかは別Issueで整理

--- a/docs/logs/91/worklog.md
+++ b/docs/logs/91/worklog.md
@@ -29,25 +29,39 @@
 4. スナップショットファイルを生成・コミット
 5. CIでは既存の `cargo test --workspace` で自動検証される（追加設定不要）
 
-## 実装内容
+## 実装内容 (2026-05-05)
 
-TBD
+1. **workspace Cargo.toml**: `insta = { version = "1", features = ["yaml"] }` 追加
+2. **crates/api/Cargo.toml**: `[dev-dependencies]` に `insta = { workspace = true }` 追加
+3. **crates/api/src/lib.rs**:
+   - `pub fn openapi_schema()` 追加（全ルート登録済みの完全なOpenAPIスキーマを返す）
+   - `fn openapi_router() -> OpenApiRouter<PgPool>` を抽出し、`create_app_with_config` と `openapi_schema` でルート定義を共有（重複排除）
+4. **crates/api/tests/openapi_schema_test.rs**: スナップショットテスト作成
+5. **crates/api/tests/snapshots/openapi_schema_test__openapi_schema.snap**: 3064行のスナップショット（全paths + components含む）
 
-## テスト結果
+## テスト結果 (2026-05-05)
 
-TBD
+- `cargo test -p boardflow-api --test openapi_schema_test` → 1 passed
+- `cargo test -p boardflow-api --lib` → 29 passed（既存テスト全パス）
+- `cargo clippy -p boardflow-api --all-targets -- -D warnings` → 警告なし
 
 ## レビュー結果
 
-TBD
+- ルート登録の重複を `openapi_router()` 関数で解消済み
+- DBやサーバ起動不要で実行可能
 
 ## ドキュメント確認
 
-TBD
+- 特に追加ドキュメント不要（CIに設定変更なし、`cargo test --workspace` で自動検証される）
 
 ## PR/完了結果
 
-TBD
+- ブランチ: `feat/91-openapi-schema-snapshot-test`
+- コミット: `feat(api): add OpenAPI schema snapshot test (#91)`
+
+## 残リスク
+
+- OpenAPIスキーマの変更が意図的な場合は `cargo insta review` でスナップショットを更新する必要あり（READMEやCONTRIBUTINGへの手順追記は未実施）
 
 ## 残リスク
 

--- a/docs/logs/91/worklog.md
+++ b/docs/logs/91/worklog.md
@@ -59,11 +59,125 @@
 - ブランチ: `feat/91-openapi-schema-snapshot-test`
 - コミット: `feat(api): add OpenAPI schema snapshot test (#91)`
 
-## 残リスク
+## 残リスク (初期整理)
 
 - OpenAPIスキーマの変更が意図的な場合は `cargo insta review` でスナップショットを更新する必要あり（READMEやCONTRIBUTINGへの手順追記は未実施）
 
-## 残リスク
+## 残リスク (実装後)
 
 - スナップショットテストの保守コスト
 - APIスキーマ変更時のワークフロー（意図的な変更 vs 意図しない変更の区別）
+
+## レビュー結果 (2026-05-05, Copilot review)
+
+### 総評
+
+- 実装は Issue #91 の主目的である「CI 上で OpenAPI 契約差分を検出する」仕組みとしては成立している。
+- `openapi_router()` 抽出により、API 実装とスキーマ生成で同じルート定義を共有しており、重複定義による乖離リスクは下がっている。
+- `cargo test -p boardflow-api --test openapi_schema_test` を再実行し、DB 接続不要で 1 件成功を確認した。
+- `cargo test -p boardflow-api --lib` を再実行し、29 件成功で既存 lib テストのリグレッションなしを確認した。
+
+### 指摘事項
+
+1. 中: スナップショットの対象が Issue の目的に対して広すぎる。
+   - [crates/api/src/lib.rs](crates/api/src/lib.rs#L142) から [crates/api/src/lib.rs](crates/api/src/lib.rs#L166) の `openapi_router()` は health/read/auth/api_token を含む API 全体を登録している。
+   - [crates/api/tests/openapi_schema_test.rs](crates/api/tests/openapi_schema_test.rs#L7) から [crates/api/tests/openapi_schema_test.rs](crates/api/tests/openapi_schema_test.rs#L9) はその全スキーマを丸ごとスナップショット化している。
+   - その結果、action-runner とは無関係な read API や auth API の変更でも snapshot 更新が必須になり、Issue #91 の「action-runner と API 間の型整合性確認」という目的に対してシグナルがやや鈍る。
+   - ただし契約差分の検出自体は機能しており、PR ブロッカーとまでは判断しない。
+
+2. 低: `insta` の `yaml` feature 追加と実装内容が一致していない。
+   - [Cargo.toml](Cargo.toml#L64) では `insta` に `yaml` feature を追加しているが、実際のテストは [crates/api/tests/openapi_schema_test.rs](crates/api/tests/openapi_schema_test.rs#L8) で JSON を文字列化し、[crates/api/tests/openapi_schema_test.rs](crates/api/tests/openapi_schema_test.rs#L9) の `assert_snapshot!` を使っている。
+   - 現状でも問題はないが、依存の意図が曖昧なので `assert_json_snapshot!` へ寄せるか、未使用 feature を外すかのどちらかに揃えた方が保守しやすい。
+
+### PR/完了結果 (Copilot review)
+
+- pr_ready: true
+
+### テスト結果
+
+- `mise exec -- cargo test -p boardflow-api --test openapi_schema_test` : passed
+- `mise exec -- cargo test -p boardflow-api --lib` : passed
+
+### ドキュメント確認 (Copilot review)
+
+- [docs/spec.md](docs/spec.md) と [docs/backend/api.md](docs/backend/api.md) を確認し、Issue #91 に対して必須の仕様差分や追加説明は見当たらなかった。
+- 一方で snapshot 更新手順 (`cargo insta review`) を案内する恒久ドキュメントは見当たらず、運用手順は作業ログ依存のまま。
+
+### 残リスク (Copilot review)
+
+- API 全体 snapshot のため、action-runner 契約と無関係な API 変更でも CI が落ちる。
+- snapshot 更新ワークフローが README 等に載っていないため、将来の変更者が `.snap` 更新手順を探しにくい。
+
+## ドキュメント確認 (2026-05-05, docs review)
+
+### 対象 Issue
+
+- #91: CIでaction-runnerとAPI間の型整合性を検証するテストを追加する
+
+### 確認対象
+
+- `docs/spec.md`
+- `docs/technology.md`
+- `docs/backend/summary.md`
+- `README.md`
+- `docs/logs/91/worklog.md`
+
+### 総評 (docs review)
+
+- 実装自体は `crates/api/src/lib.rs` の `openapi_schema()` と `crates/api/tests/openapi_schema_test.rs` の snapshot test で説明可能で、既存の仕様・技術方針文書と矛盾は見当たらない。
+- 一方で、OpenAPI を意図的に変更した際の snapshot 更新手順が恒久ドキュメントに存在せず、作業ログ内でも「追加ドキュメント不要」と「README等への手順追記は未実施」が併存している。
+- このため、PR 前のドキュメント判定は `docs_ready: false` とする。
+
+### 必須修正
+
+1. `README.md` に OpenAPI schema snapshot test の更新手順を追記する。
+   - 少なくとも `mise exec -- cargo test -p boardflow-api --test openapi_schema_test` と `cargo insta review` を、OpenAPI 変更時の更新フローとして明示する必要がある。
+   - 既存の「API型定義の再生成」セクションに近接配置し、`pnpm generate:api` と合わせて contributor が一連の更新作業を把握できる形が自然。
+2. `docs/logs/91/worklog.md` の「ドキュメント確認」記述を今回の結論に合わせる。
+   - 現在の「特に追加ドキュメント不要」は今回のレビュー結論と不整合。
+
+### 任意改善
+
+1. PR 本文に snapshot 更新手順を 1 行入れる。
+   - OpenAPI 変更時は `.snap` の更新が必要であることを reviewer が即座に把握しやすくなる。
+2. 将来的に snapshot 対象を action-runner 契約に近い path 群へ絞るかどうかを別 Issue で整理する。
+
+### 不整合のあるドキュメント
+
+- `docs/logs/91/worklog.md`
+  - 「特に追加ドキュメント不要」と「READMEやCONTRIBUTINGへの手順追記は未実施」が同居しており、運用判断が揃っていない。
+
+### 不足しているドキュメント
+
+- `README.md`
+  - OpenAPI schema snapshot の更新・レビュー手順
+
+### 外部調査メモに関する指摘
+
+- Issue #91 で参照必須の `docs/external/` 成果物はなく、外部調査メモとの不整合は見当たらない。
+
+### PR/完了結果への示唆
+
+- PR 本文には、Issue 要件、実装概要、実行テストに加え、OpenAPI 変更時の snapshot 更新手順を明記した方がよい。
+- 現時点では docs 観点では README 追記後に PR 作成が妥当。
+
+### 判定
+
+- docs_ready: false
+
+### 残リスク (docs review)
+
+- snapshot 更新手順が README に入るまでは、意図的な OpenAPI 変更時に contributor が CI failure の解き方を作業ログ依存で探すことになる。
+
+## README追記完了 (2026-05-05)
+
+- README.md の「API型定義の再生成」セクション直後に「OpenAPI スキーマのスナップショット更新」セクションを追記
+- `cargo test` → `cargo insta review` → `git add/commit` の手順を明示
+- docs_ready: true（必須修正対応済み）
+
+## 最終ステータス
+
+- review: pr_ready: true
+- docs: docs_ready: true（README追記済み）
+- 未使用yaml feature: 修正済み（`insta = "1"` に変更）
+- PR作成: 次ステップ


### PR DESCRIPTION
## 要件

CIでaction-runnerとAPI間の型整合性を継続的に検証する仕組みを追加する。
APIサーバー起動不要で実行できること。既存 \`cargo test --workspace\` で自動検証されること。

Closes #91

## 調査結果

- \`crates/api/src/lib.rs\` の \`ApiDoc::openapi()\` でDB・サーバー起動なしにOpenAPIスキーマ取得可能
- \`insta\` crate（snapshot testing）は未導入 → 今回追加
- action-runner は \`boardflow-api-types\` crate で型を共有済み（#89, #90）
- OpenAPIスキーマのスナップショットを取ることで、型変更時の差分をCI上で検出可能

## 実装概要

### 変更ファイル

| ファイル | 内容 |
|---|---|
| \`Cargo.toml\` | workspace dependencies に \`insta = "1"\` 追加 |
| \`Cargo.lock\` | ロックファイル更新 |
| \`crates/api/Cargo.toml\` | dev-dependencies に \`insta\` 追加 |
| \`crates/api/src/lib.rs\` | \`openapi_router()\` 関数抽出 + \`pub fn openapi_schema()\` 追加 |
| \`crates/api/tests/openapi_schema_test.rs\` | スナップショットテスト追加 |
| \`crates/api/tests/snapshots/openapi_schema_test__openapi_schema.snap\` | スナップショットファイル（3064行） |
| \`README.md\` | OpenAPI snapshot 更新手順を追記 |

### 設計判断

- \`openapi_router()\` を抽出し、\`create_app_with_config\` とスキーマ生成でルート定義を共有（重複排除）
- API全体のスキーマをスナップショット対象とした（action-runner契約のみに限定せず）
- DBやサーバー起動不要で実行可能

## テスト結果

- \`cargo test -p boardflow-api --test openapi_schema_test\` → 1 passed
- \`cargo test -p boardflow-api --lib\` → 29 passed（既存テスト全パスでリグレッションなし）
- \`cargo clippy -p boardflow-api --all-targets -- -D warnings\` → 警告なし

## 更新ドキュメント

- \`README.md\`: 「OpenAPI スキーマのスナップショット更新」セクションを追加
  - 意図的にAPIを変更した場合のスナップショット更新手順（\`cargo test\` → \`cargo insta review\` → \`git add/commit\`）を明記

## OpenAPI変更時の対応

意図的にAPIを変更した場合は以下でスナップショットを更新:

\`\`\`bash
mise exec -- cargo test -p boardflow-api --test openapi_schema_test
mise exec -- cargo insta review
git add crates/api/tests/snapshots/ && git commit -m 'update OpenAPI schema snapshot'
\`\`\`

## 残リスク

- API全体スナップショットのため、action-runner契約と無関係なAPI変更でもCIが落ちる（シグナルがやや広い）
- 将来的にスナップショット対象をaction-runner関連パスに絞るかは別Issueで整理

## レビュー結果

- code review: **pr_ready: true**
- docs review: **docs_ready: true**（README追記済み）