### PR TITLE
refactor: centralize frontend route builders in routes.ts

### DIFF
--- a/boardflow/src/app/(authenticated)/layout.tsx
+++ b/boardflow/src/app/(authenticated)/layout.tsx
@@ -1,12 +1,13 @@
 import { redirect } from 'next/navigation';
 import { AppShell } from '@/components/layout/app-shell';
 import { getCurrentUser } from '@/lib/auth';
+import { routes } from '@/lib/routes';
 
 export default async function AuthenticatedLayout({ children }: { children: React.ReactNode }) {
   const user = await getCurrentUser();
 
   if (!user) {
-    redirect('/login');
+    redirect(routes.login());
   }
 
   return <AppShell user={user}>{children}</AppShell>;

--- a/boardflow/src/app/login/page.tsx
+++ b/boardflow/src/app/login/page.tsx
@@ -2,6 +2,7 @@ import { Box, Button, Heading, Text, VStack } from '@chakra-ui/react';
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import { getCurrentUser } from '@/lib/auth';
+import { routes } from '@/lib/routes';
 
 export default async function LoginPage({
   searchParams,
@@ -11,7 +12,7 @@ export default async function LoginPage({
   const user = await getCurrentUser();
 
   if (user) {
-    redirect('/repositories');
+    redirect(routes.repositories());
   }
 
   const params = await searchParams;

--- a/boardflow/src/components/board-project-detail/board-project-detail-content.tsx
+++ b/boardflow/src/components/board-project-detail/board-project-detail-content.tsx
@@ -7,6 +7,7 @@ import { CheckBadge } from '@/components/ui/check-badge';
 import { $api } from '@/lib/api/react-query';
 import { boardRunStatusColor } from '@/lib/domain/status';
 import { formatDateTime, shortSha } from '@/lib/format';
+import { routes } from '@/lib/routes';
 
 interface Props {
   repositoryId: string;
@@ -36,10 +37,10 @@ export function BoardProjectDetailContent({ repositoryId, boardProjectId }: Prop
     <Box>
       <Breadcrumb
         items={[
-          { label: 'Repositories', href: '/repositories' },
+          { label: 'Repositories', href: routes.repositories() },
           {
             label: `${project.repository.owner}/${project.repository.name}`,
-            href: `/repositories/${repositoryId}`,
+            href: routes.repository(repositoryId),
           },
           { label: project.display_name },
         ]}
@@ -61,7 +62,7 @@ export function BoardProjectDetailContent({ repositoryId, boardProjectId }: Prop
           <VStack align='stretch' gap={3}>
             <HStack justify='space-between'>
               <Text fontWeight='medium'>Repository</Text>
-              <Link href={`/repositories/${repositoryId}`}>
+              <Link href={routes.repository(repositoryId)}>
                 <Text color='blue.600' _hover={{ textDecoration: 'underline' }}>
                   {project.repository.owner}/{project.repository.name}
                 </Text>
@@ -87,7 +88,7 @@ export function BoardProjectDetailContent({ repositoryId, boardProjectId }: Prop
               <HStack justify='space-between'>
                 <Text fontWeight='medium'>Latest Completed Run</Text>
                 <Link
-                  href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${project.latest_completed_run_id}`}
+                  href={routes.run(repositoryId, boardProjectId, project.latest_completed_run_id)}
                 >
                   <Text color='blue.600' _hover={{ textDecoration: 'underline' }}>
                     {project.latest_completed_run_id}
@@ -128,9 +129,7 @@ export function BoardProjectDetailContent({ repositoryId, boardProjectId }: Prop
                 {recentRuns.map((run) => (
                   <Table.Row key={run.board_run_id}>
                     <Table.Cell>
-                      <Link
-                        href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${run.board_run_id}`}
-                      >
+                      <Link href={routes.run(repositoryId, boardProjectId, run.board_run_id)}>
                         <Badge colorPalette={boardRunStatusColor(run.status)}>{run.status}</Badge>
                       </Link>
                     </Table.Cell>
@@ -185,7 +184,7 @@ export function BoardProjectDetailContent({ repositoryId, boardProjectId }: Prop
         </Box>
 
         <Box>
-          <Link href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs`}>
+          <Link href={routes.runs(repositoryId, boardProjectId)}>
             <Box
               display='inline-flex'
               alignItems='center'

--- a/boardflow/src/components/checks/findings-content.tsx
+++ b/boardflow/src/components/checks/findings-content.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Breadcrumb } from '@/components/ui/breadcrumb';
 import { $api } from '@/lib/api/react-query';
 import { shortId } from '@/lib/format';
+import { routes } from '@/lib/routes';
 
 function severityColor(severity: string): string {
   switch (severity) {
@@ -71,26 +72,26 @@ export function FindingsContent({
   const findings = findingsData.items;
   const hasMore = findingsData.has_more;
 
-  const basePath = `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/checks/${checkKind}`;
+  const basePath = routes.runChecks(repositoryId, boardProjectId, boardRunId, checkKind);
 
   return (
     <Box>
       {project && (
         <Breadcrumb
           items={[
-            { label: 'Repositories', href: '/repositories' },
+            { label: 'Repositories', href: routes.repositories() },
             {
               label: `${project.repository.owner}/${project.repository.name}`,
-              href: `/repositories/${repositoryId}`,
+              href: routes.repository(repositoryId),
             },
             {
               label: project.display_name,
-              href: `/repositories/${repositoryId}/boards/${boardProjectId}`,
+              href: routes.board(repositoryId, boardProjectId),
             },
-            { label: 'Runs', href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs` },
+            { label: 'Runs', href: routes.runs(repositoryId, boardProjectId) },
             {
               label: shortId(boardRunId),
-              href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}`,
+              href: routes.run(repositoryId, boardProjectId, boardRunId),
             },
             { label: `${checkKind.toUpperCase()} Findings` },
           ]}

--- a/boardflow/src/components/diff/diff-content.tsx
+++ b/boardflow/src/components/diff/diff-content.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/lib/domain/guards';
 import { diffStatusColor } from '@/lib/domain/status';
 import { formatDateTime, shortId } from '@/lib/format';
+import { routes } from '@/lib/routes';
 
 interface Props {
   repositoryId: string;
@@ -39,19 +40,19 @@ export function DiffContent({ repositoryId, boardProjectId, boardRunId }: Props)
       {project && (
         <Breadcrumb
           items={[
-            { label: 'Repositories', href: '/repositories' },
+            { label: 'Repositories', href: routes.repositories() },
             {
               label: `${project.repository.owner}/${project.repository.name}`,
-              href: `/repositories/${repositoryId}`,
+              href: routes.repository(repositoryId),
             },
             {
               label: project.display_name,
-              href: `/repositories/${repositoryId}/boards/${boardProjectId}`,
+              href: routes.board(repositoryId, boardProjectId),
             },
-            { label: 'Runs', href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs` },
+            { label: 'Runs', href: routes.runs(repositoryId, boardProjectId) },
             {
               label: shortId(boardRunId),
-              href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}`,
+              href: routes.run(repositoryId, boardProjectId, boardRunId),
             },
             { label: 'Diff' },
           ]}
@@ -71,9 +72,7 @@ export function DiffContent({ repositoryId, boardProjectId, boardRunId }: Props)
             {diff.base_board_run_id && (
               <Text>
                 Compared to:{' '}
-                <Link
-                  href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${diff.base_board_run_id}`}
-                >
+                <Link href={routes.run(repositoryId, boardProjectId, diff.base_board_run_id)}>
                   <Text as='span' color='blue.600' _hover={{ textDecoration: 'underline' }}>
                     {shortId(diff.base_board_run_id)}
                   </Text>
@@ -82,9 +81,7 @@ export function DiffContent({ repositoryId, boardProjectId, boardRunId }: Props)
             )}
             <Text>
               Current:{' '}
-              <Link
-                href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}`}
-              >
+              <Link href={routes.run(repositoryId, boardProjectId, boardRunId)}>
                 <Text as='span' color='blue.600' _hover={{ textDecoration: 'underline' }}>
                   {shortId(boardRunId)}
                 </Text>
@@ -432,10 +429,8 @@ function PreviewLinksSection({
 
   if (previewEntries.length === 0) return null;
 
-  const currentRunUrl = `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}`;
-  const baseRunUrl = baseRunId
-    ? `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${baseRunId}`
-    : null;
+  const currentRunUrl = routes.run(repositoryId, boardProjectId, boardRunId);
+  const baseRunUrl = baseRunId ? routes.run(repositoryId, boardProjectId, baseRunId) : null;
 
   return (
     <Box>

--- a/boardflow/src/components/layout/header.tsx
+++ b/boardflow/src/components/layout/header.tsx
@@ -3,6 +3,7 @@
 import { Box, Flex, Heading, Image, Text } from '@chakra-ui/react';
 import { LogOut, User } from 'lucide-react';
 import type { CurrentUser } from '@/lib/auth';
+import { routes } from '@/lib/routes';
 
 interface HeaderProps {
   user: CurrentUser | null;
@@ -52,7 +53,7 @@ export function Header({ user }: HeaderProps) {
             title='Logout'
             onClick={async () => {
               await fetch('/api/v1/auth/logout', { method: 'POST' });
-              window.location.href = '/login';
+              window.location.href = routes.login();
             }}
           >
             <LogOut size={18} />

--- a/boardflow/src/components/layout/sidebar.tsx
+++ b/boardflow/src/components/layout/sidebar.tsx
@@ -4,8 +4,9 @@ import { Box, Text, VStack } from '@chakra-ui/react';
 import { FolderGit2 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { routes } from '@/lib/routes';
 
-const NAV_ITEMS = [{ href: '/repositories', label: 'Repositories', icon: FolderGit2 }];
+const NAV_ITEMS = [{ href: routes.repositories(), label: 'Repositories', icon: FolderGit2 }];
 
 export function Sidebar() {
   const pathname = usePathname();

--- a/boardflow/src/components/repositories/repositories-list.tsx
+++ b/boardflow/src/components/repositories/repositories-list.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { $api } from '@/lib/api/react-query';
 import { boardRunStatusColor } from '@/lib/domain/status';
 import { formatDate } from '@/lib/format';
+import { routes } from '@/lib/routes';
 
 export function RepositoriesList() {
   const { data } = $api.useSuspenseQuery('get', '/api/v1/repositories', {
@@ -46,7 +47,7 @@ export function RepositoriesList() {
                 }
               >
                 <Table.Cell>
-                  <Link href={`/repositories/${repo.github_repository_id}`}>
+                  <Link href={routes.repository(repo.github_repository_id)}>
                     <Text
                       color='blue.600'
                       fontWeight='medium'

--- a/boardflow/src/components/repository-detail/repository-detail-content.tsx
+++ b/boardflow/src/components/repository-detail/repository-detail-content.tsx
@@ -7,6 +7,7 @@ import { Breadcrumb } from '@/components/ui/breadcrumb';
 import { $api } from '@/lib/api/react-query';
 import { projectStateColor } from '@/lib/domain/status';
 import { formatDate } from '@/lib/format';
+import { routes } from '@/lib/routes';
 
 interface Props {
   repositoryId: string;
@@ -35,7 +36,7 @@ export function RepositoryDetailContent({ repositoryId }: Props) {
     <Box>
       <Breadcrumb
         items={[
-          { label: 'Repositories', href: '/repositories' },
+          { label: 'Repositories', href: routes.repositories() },
           { label: `${repo.owner}/${repo.name}` },
         ]}
       />
@@ -63,7 +64,7 @@ export function RepositoryDetailContent({ repositoryId }: Props) {
           <Heading size='md' mb={4}>
             Settings
           </Heading>
-          <Link href={`/repositories/${repositoryId}/settings/tokens`}>
+          <Link href={routes.repositoryTokens(repositoryId)}>
             <HStack gap={2} color='blue.600' _hover={{ textDecoration: 'underline' }}>
               <Key size={16} />
               <Text fontWeight='medium'>API Tokens</Text>
@@ -92,9 +93,7 @@ export function RepositoryDetailContent({ repositoryId }: Props) {
                 {projects.map((project) => (
                   <Table.Row key={project.board_project_id}>
                     <Table.Cell>
-                      <Link
-                        href={`/repositories/${repositoryId}/boards/${project.board_project_id}`}
-                      >
+                      <Link href={routes.board(repositoryId, project.board_project_id)}>
                         <Text
                           color='blue.600'
                           fontWeight='medium'

--- a/boardflow/src/components/run-detail/run-detail-content.tsx
+++ b/boardflow/src/components/run-detail/run-detail-content.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/domain/guards';
 import { artifactStatusColor, boardRunStatusColor, checkStatusColor } from '@/lib/domain/status';
 import { formatBytes, formatDateTime, shortId, shortSha } from '@/lib/format';
+import { routes } from '@/lib/routes';
 
 interface Props {
   repositoryId: string;
@@ -73,16 +74,16 @@ export function RunDetailContent({ repositoryId, boardProjectId, boardRunId }: P
       {project && (
         <Breadcrumb
           items={[
-            { label: 'Repositories', href: '/repositories' },
+            { label: 'Repositories', href: routes.repositories() },
             {
               label: `${project.repository.owner}/${project.repository.name}`,
-              href: `/repositories/${repositoryId}`,
+              href: routes.repository(repositoryId),
             },
             {
               label: project.display_name,
-              href: `/repositories/${repositoryId}/boards/${boardProjectId}`,
+              href: routes.board(repositoryId, boardProjectId),
             },
-            { label: 'Runs', href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs` },
+            { label: 'Runs', href: routes.runs(repositoryId, boardProjectId) },
             { label: shortId(boardRunId) },
           ]}
         />
@@ -142,7 +143,7 @@ export function RunDetailContent({ repositoryId, boardProjectId, boardRunId }: P
                   </HStack>
                   {check.error_count + check.warning_count + check.notice_count > 0 && (
                     <Link
-                      href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/checks/${check.kind}`}
+                      href={routes.runChecks(repositoryId, boardProjectId, boardRunId, check.kind)}
                     >
                       <Text
                         color='blue.600'
@@ -251,7 +252,7 @@ export function RunDetailContent({ repositoryId, boardProjectId, boardRunId }: P
                         <Text fontSize='sm' color='gray.600'>
                           Compared to run:{' '}
                           <Link
-                            href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${diff.base_board_run_id}`}
+                            href={routes.run(repositoryId, boardProjectId, diff.base_board_run_id)}
                           >
                             <Text
                               as='span'
@@ -324,9 +325,7 @@ export function RunDetailContent({ repositoryId, boardProjectId, boardRunId }: P
                           Artifact changes: data format not recognized
                         </Text>
                       )}
-                      <Link
-                        href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/diff`}
-                      >
+                      <Link href={routes.runDiff(repositoryId, boardProjectId, boardRunId)}>
                         <Text
                           color='blue.600'
                           fontSize='sm'

--- a/boardflow/src/components/runs/runs-list-content.tsx
+++ b/boardflow/src/components/runs/runs-list-content.tsx
@@ -7,6 +7,7 @@ import { CheckBadge } from '@/components/ui/check-badge';
 import { $api } from '@/lib/api/react-query';
 import { boardRunStatusColor } from '@/lib/domain/status';
 import { formatDateTime, shortSha } from '@/lib/format';
+import { routes } from '@/lib/routes';
 
 interface Props {
   repositoryId: string;
@@ -36,14 +37,14 @@ export function RunsListContent({ repositoryId, boardProjectId }: Props) {
     <Box>
       <Breadcrumb
         items={[
-          { label: 'Repositories', href: '/repositories' },
+          { label: 'Repositories', href: routes.repositories() },
           {
             label: `${project.repository.owner}/${project.repository.name}`,
-            href: `/repositories/${repositoryId}`,
+            href: routes.repository(repositoryId),
           },
           {
             label: project.display_name,
-            href: `/repositories/${repositoryId}/boards/${boardProjectId}`,
+            href: routes.board(repositoryId, boardProjectId),
           },
           { label: 'Runs' },
         ]}
@@ -70,9 +71,7 @@ export function RunsListContent({ repositoryId, boardProjectId }: Props) {
             {runs.map((run) => (
               <Table.Row key={run.board_run_id}>
                 <Table.Cell>
-                  <Link
-                    href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${run.board_run_id}`}
-                  >
+                  <Link href={routes.run(repositoryId, boardProjectId, run.board_run_id)}>
                     <Badge colorPalette={boardRunStatusColor(run.status)}>{run.status}</Badge>
                   </Link>
                 </Table.Cell>

--- a/boardflow/src/components/tokens/tokens-page-content.tsx
+++ b/boardflow/src/components/tokens/tokens-page-content.tsx
@@ -3,6 +3,7 @@
 import { Box, Heading, VStack } from '@chakra-ui/react';
 import { Breadcrumb } from '@/components/ui/breadcrumb';
 import { $api } from '@/lib/api/react-query';
+import { routes } from '@/lib/routes';
 import { TokenList } from './token-list';
 
 interface Props {
@@ -22,8 +23,8 @@ export function TokensPageContent({ repositoryId }: Props) {
     <Box>
       <Breadcrumb
         items={[
-          { label: 'Repositories', href: '/repositories' },
-          { label: `${repo.owner}/${repo.name}`, href: `/repositories/${repositoryId}` },
+          { label: 'Repositories', href: routes.repositories() },
+          { label: `${repo.owner}/${repo.name}`, href: routes.repository(repositoryId) },
           { label: 'API Tokens' },
         ]}
       />

--- a/boardflow/src/lib/routes.ts
+++ b/boardflow/src/lib/routes.ts
@@ -1,0 +1,22 @@
+export const routes = {
+  login: () => '/login',
+  repositories: () => '/repositories',
+  repository: (repositoryId: string | number) => `/repositories/${repositoryId}`,
+  repositoryTokens: (repositoryId: string | number) =>
+    `/repositories/${repositoryId}/settings/tokens`,
+  board: (repositoryId: string | number, boardProjectId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}`,
+  runs: (repositoryId: string | number, boardProjectId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs`,
+  run: (repositoryId: string | number, boardProjectId: string, boardRunId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}`,
+  runChecks: (
+    repositoryId: string | number,
+    boardProjectId: string,
+    boardRunId: string,
+    checkKind: string,
+  ) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/checks/${checkKind}`,
+  runDiff: (repositoryId: string | number, boardProjectId: string, boardRunId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/diff`,
+};

--- a/boardflow/src/middleware.ts
+++ b/boardflow/src/middleware.ts
@@ -1,7 +1,8 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
+import { routes } from '@/lib/routes';
 
-const PUBLIC_PATHS = ['/login'];
+const PUBLIC_PATHS = [routes.login()];
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
@@ -10,9 +11,9 @@ export function middleware(request: NextRequest) {
   // Root redirect
   if (pathname === '/') {
     if (session) {
-      return NextResponse.redirect(new URL('/repositories', request.url));
+      return NextResponse.redirect(new URL(routes.repositories(), request.url));
     }
-    return NextResponse.redirect(new URL('/login', request.url));
+    return NextResponse.redirect(new URL(routes.login(), request.url));
   }
 
   // Public paths always accessible (no session check for /login to prevent redirect loop)
@@ -22,7 +23,7 @@ export function middleware(request: NextRequest) {
 
   // Unauthenticated → redirect to login with redirect_to
   if (!session) {
-    const loginUrl = new URL('/login', request.url);
+    const loginUrl = new URL(routes.login(), request.url);
     const redirectTo = pathname + request.nextUrl.search;
     if (redirectTo !== '/') {
       loginUrl.searchParams.set('redirect_to', redirectTo);

--- a/docs/logs/108/worklog.md
+++ b/docs/logs/108/worklog.md
@@ -1,0 +1,474 @@
+# Issue #108: ルート生成を routes.ts に集約
+
+## Issueまでの経緯
+
+- #107（format helpers集約）、#98（pagination cursor refactoring）がマージ済み
+- フロントエンドのリファクタリングシリーズの一環として、ルート文字列のハードコード重複を解消する
+
+## ユーザー要望
+
+`boardflow/src/lib/routes.ts` にルート生成関数を集約し、コンポーネント内のテンプレートリテラルによるルート文字列の重複を排除する。
+
+## 調査結果（リサーチフェーズ 2026-05-14）
+
+### 既存の routes.ts
+
+`boardflow/src/lib/routes.ts` は **存在しない**。新規作成が必要。
+
+### Next.js ルーティング構造
+
+```
+/login
+/repositories
+/repositories/[repositoryId]
+/repositories/[repositoryId]/settings/tokens
+/repositories/[repositoryId]/boards/[boardProjectId]
+/repositories/[repositoryId]/boards/[boardProjectId]/runs
+/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]
+/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]/checks/[checkKind]
+/repositories/[repositoryId]/boards/[boardProjectId]/runs/[boardRunId]/diff
+```
+
+### ハードコードされたルートパターン一覧
+
+#### 1. `/repositories`（静的、10箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/middleware.ts` | 13 | redirect |
+| `src/app/login/page.tsx` | 14 | redirect |
+| `src/components/layout/sidebar.tsx` | 8 | NAV_ITEMS |
+| `src/components/repository-detail/repository-detail-content.tsx` | 38 | breadcrumb |
+| `src/components/board-project-detail/board-project-detail-content.tsx` | 39 | breadcrumb |
+| `src/components/checks/findings-content.tsx` | 81 | breadcrumb |
+| `src/components/runs/runs-list-content.tsx` | 39 | breadcrumb |
+| `src/components/run-detail/run-detail-content.tsx` | 76 | breadcrumb |
+| `src/components/tokens/tokens-page-content.tsx` | 25 | breadcrumb |
+| `src/components/diff/diff-content.tsx` | 42 | breadcrumb |
+
+#### 2. `/login`（静的、5箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/middleware.ts` | 4, 15, 25 | PUBLIC_PATHS / redirect |
+| `src/app/(authenticated)/layout.tsx` | 9 | redirect |
+| `src/components/layout/header.tsx` | 55 | window.location.href |
+
+#### 3. `` `/repositories/${repositoryId}` ``（動的、8箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/components/repositories/repositories-list.tsx` | 49 | Link href |
+| `src/components/board-project-detail/board-project-detail-content.tsx` | 42, 64 | breadcrumb, Link href |
+| `src/components/run-detail/run-detail-content.tsx` | 79 | breadcrumb |
+| `src/components/runs/runs-list-content.tsx` | 42 | breadcrumb |
+| `src/components/checks/findings-content.tsx` | 84 | breadcrumb |
+| `src/components/diff/diff-content.tsx` | 45 | breadcrumb |
+| `src/components/tokens/tokens-page-content.tsx` | 26 | breadcrumb |
+
+#### 4. `` `/repositories/${repositoryId}/settings/tokens` ``（動的、1箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/components/repository-detail/repository-detail-content.tsx` | 66 | Link href |
+
+#### 5. `` `/repositories/${repositoryId}/boards/${boardProjectId}` ``（動的、5箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/components/repository-detail/repository-detail-content.tsx` | 96 | Link href |
+| `src/components/run-detail/run-detail-content.tsx` | 83 | breadcrumb |
+| `src/components/runs/runs-list-content.tsx` | 46 | breadcrumb |
+| `src/components/checks/findings-content.tsx` | 88 | breadcrumb |
+| `src/components/diff/diff-content.tsx` | 49 | breadcrumb |
+
+#### 6. `` `/repositories/${repositoryId}/boards/${boardProjectId}/runs` ``（動的、4箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/components/board-project-detail/board-project-detail-content.tsx` | 188 | Link href |
+| `src/components/run-detail/run-detail-content.tsx` | 85 | breadcrumb |
+| `src/components/checks/findings-content.tsx` | 90 | breadcrumb |
+| `src/components/diff/diff-content.tsx` | 51 | breadcrumb |
+
+#### 7. `` `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}` ``（動的、9箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/components/runs/runs-list-content.tsx` | 74 | Link href |
+| `src/components/board-project-detail/board-project-detail-content.tsx` | 90, 132 | Link href |
+| `src/components/run-detail/run-detail-content.tsx` | 254 | Link href |
+| `src/components/diff/diff-content.tsx` | 54, 75, 86, 435, 437 | breadcrumb, Link href, 変数 |
+| `src/components/checks/findings-content.tsx` | 93 | breadcrumb |
+
+#### 8. `` `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/checks/${checkKind}` ``（動的、2箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/components/run-detail/run-detail-content.tsx` | 145 | Link href |
+| `src/components/checks/findings-content.tsx` | 74 | basePath変数 |
+
+#### 9. `` `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/diff` ``（動的、1箇所）
+
+| ファイル | 行 | 用途 |
+|---|---|---|
+| `src/components/run-detail/run-detail-content.tsx` | 328 | Link href |
+
+### 重複が顕著なパターン
+
+特に **breadcrumb 構築** が最大の重複源。以下の5ファイルがほぼ同一のbreadcrumb階層を構築している:
+
+1. `runs/runs-list-content.tsx` — Repositories > Repo > Board > Runs
+2. `run-detail/run-detail-content.tsx` — Repositories > Repo > Board > Runs > RunId
+3. `checks/findings-content.tsx` — Repositories > Repo > Board > Runs > RunId > Findings
+4. `diff/diff-content.tsx` — Repositories > Repo > Board > Runs > RunId > Diff
+5. `board-project-detail/board-project-detail-content.tsx` — Repositories > Repo
+
+各breadcrumbの前半部分（Repositories → Repo → Board → Runs）は共通パターンで、ルート関数の集約だけでなく **breadcrumb builder の共通化** も合わせて検討する価値がある。ただし、breadcrumb共通化はIssue #108のスコープ外の可能性があるため、routes.ts への集約を先行し、breadcrumb共通化は後続Issueとして提案すべき。
+
+### 対象外（外部URL・動的データURL）
+
+以下はルート集約の対象外:
+- `artifact-viewer/download-list.tsx:29` — `d.url`（APIから取得したダウンロードURL）
+- `artifact-viewer/svg-viewer.tsx:41` — `tab.source.url`（外部URL）
+- `artifact-viewer/pdf-viewer.tsx:19` — `primary.url`（外部URL）
+- `artifact-viewer/artifact-viewer-section.tsx:228` — `viewer.primary.url`（外部URL）
+- `repository-detail/repository-detail-content.tsx:53` — `repo.html_url`（GitHub URL）
+- `board-project-detail/board-project-detail-content.tsx:79` — `project.issue_url`（GitHub URL）
+
+### 提案する routes.ts の関数シグネチャ
+
+```typescript
+// boardflow/src/lib/routes.ts
+export const routes = {
+  login: () => '/login',
+  repositories: () => '/repositories',
+  repository: (repositoryId: string) => `/repositories/${repositoryId}`,
+  repositoryTokens: (repositoryId: string) => `/repositories/${repositoryId}/settings/tokens`,
+  board: (repositoryId: string, boardProjectId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}`,
+  runs: (repositoryId: string, boardProjectId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs`,
+  run: (repositoryId: string, boardProjectId: string, boardRunId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}`,
+  runChecks: (repositoryId: string, boardProjectId: string, boardRunId: string, checkKind: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/checks/${checkKind}`,
+  runDiff: (repositoryId: string, boardProjectId: string, boardRunId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/diff`,
+} as const;
+```
+
+### 影響範囲（変更対象ファイル）
+
+| ファイル | 変更箇所数 |
+|---|---|
+| `src/lib/routes.ts` | **新規作成** |
+| `src/middleware.ts` | 3 |
+| `src/app/(authenticated)/layout.tsx` | 1 |
+| `src/app/login/page.tsx` | 1 |
+| `src/components/layout/header.tsx` | 1 |
+| `src/components/layout/sidebar.tsx` | 1 |
+| `src/components/repositories/repositories-list.tsx` | 1 |
+| `src/components/repository-detail/repository-detail-content.tsx` | 3 |
+| `src/components/board-project-detail/board-project-detail-content.tsx` | 6 |
+| `src/components/runs/runs-list-content.tsx` | 4 |
+| `src/components/run-detail/run-detail-content.tsx` | 7 |
+| `src/components/checks/findings-content.tsx` | 6 |
+| `src/components/diff/diff-content.tsx` | 9 |
+| `src/components/tokens/tokens-page-content.tsx` | 2 |
+| **合計** | **1新規 + 13既存ファイル、約45箇所** |
+
+## 結論ステータス
+
+**`implementation_required`**
+
+外部ライブラリ調査は不要。純粋なコードリファクタリングとして実装に進むべき。
+
+## 残リスク
+
+- breadcrumb構築パターンの重複は routes.ts 集約だけでは完全に解消されない。breadcrumb builder の共通化は後続Issueとして提案可能。
+- `middleware.ts` はサーバーサイドで実行されるため、routes.ts のインポートが正常に動作するか確認が必要（通常のTypeScriptモジュールなので問題ないはず）。
+- `header.tsx` の `window.location.href = '/login'` は `routes.login()` に置換可能だが、クライアントサイドでの直接遷移であり、Next.jsの `router.push` ではない点に注意。
+
+## 参照URL
+
+- Issue: https://github.com/f0reachARR/boardflow/issues/108
+
+---
+
+## 計画フェーズ（2026-05-14）
+
+### 目的
+
+`boardflow/src/lib/routes.ts` にルート生成関数を集約し、フロントエンド全体で約46箇所にハードコードされたルート文字列を関数呼び出しに置き換える。URL構造変更時の修正箇所を1ファイルに集約する。
+
+### 非目的
+
+- ルート構造（URLパス）そのものの変更
+- breadcrumb builder の共通化（後続Issue候補）
+- API エンドポイントURL（`/api/v1/...`）の集約
+- 外部URL（GitHub URL、ダウンロードURLなど）の集約
+- 挙動の変更
+
+### 受け入れ条件
+
+1. `boardflow/src/lib/routes.ts` が新規作成され、9つのルート生成関数がexportされている
+2. 既存13ファイルのハードコードされたルート文字列が `routes.*()` 呼び出しに置き換えられている
+3. `pnpm typecheck` が通る
+4. `pnpm lint` が通る
+5. `pnpm build` が通る
+6. 画面遷移の挙動が変わらないこと（生成されるURL文字列が完全に一致すること）
+
+### 詳細要件
+
+#### 新規ファイル: `boardflow/src/lib/routes.ts`
+
+```typescript
+export const routes = {
+  login: () => '/login' as const,
+  repositories: () => '/repositories' as const,
+  repository: (repositoryId: string | number) =>
+    `/repositories/${repositoryId}` as const,
+  repositoryTokens: (repositoryId: string | number) =>
+    `/repositories/${repositoryId}/settings/tokens` as const,
+  board: (repositoryId: string | number, boardProjectId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}` as const,
+  runs: (repositoryId: string | number, boardProjectId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs` as const,
+  run: (repositoryId: string | number, boardProjectId: string, boardRunId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}` as const,
+  runChecks: (repositoryId: string | number, boardProjectId: string, boardRunId: string, checkKind: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/checks/${checkKind}` as const,
+  runDiff: (repositoryId: string | number, boardProjectId: string, boardRunId: string) =>
+    `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/diff` as const,
+};
+```
+
+**設計判断:**
+- `repositoryId` は `string | number` を受け入れる（APIレスポンスでは number、URL params では string のため）
+- `boardProjectId`, `boardRunId`, `checkKind` は常に string
+- `as const` で戻り値型をリテラルテンプレートに推論させる
+- オブジェクトに集約（名前空間として `routes.xxx()` で呼び出し）
+- named export（`export const routes`）
+
+#### 既存ファイル変更一覧
+
+**ファイル1: `src/middleware.ts`（4箇所）**
+| 行 | 現在のコード | 変更後 |
+|---|---|---|
+| 4 | `const PUBLIC_PATHS = ['/login'];` | `const PUBLIC_PATHS = [routes.login()];` |
+| 12 | `new URL('/repositories', request.url)` | `new URL(routes.repositories(), request.url)` |
+| 14 | `new URL('/login', request.url)` | `new URL(routes.login(), request.url)` |
+| 25 | `new URL('/login', request.url)` | `new URL(routes.login(), request.url)` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル2: `src/app/login/page.tsx`（1箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 14 | `redirect('/repositories');` | `redirect(routes.repositories());` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル3: `src/app/(authenticated)/layout.tsx`（1箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 9 | `redirect('/login');` | `redirect(routes.login());` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル4: `src/components/layout/header.tsx`（1箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 55 | `window.location.href = '/login';` | `window.location.href = routes.login();` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル5: `src/components/layout/sidebar.tsx`（1箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 8 | `{ href: '/repositories', label: ... }` | `{ href: routes.repositories(), label: ... }` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル6: `src/components/repositories/repositories-list.tsx`（1箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 49 | `` href={`/repositories/${repo.github_repository_id}`} `` | `href={routes.repository(repo.github_repository_id)}` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル7: `src/components/repository-detail/repository-detail-content.tsx`（3箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 38 | `{ label: 'Repositories', href: '/repositories' }` | `{ label: 'Repositories', href: routes.repositories() }` |
+| 66 | `` href={`/repositories/${repositoryId}/settings/tokens`} `` | `href={routes.repositoryTokens(repositoryId)}` |
+| 96 | `` href={`/repositories/${repositoryId}/boards/${project.board_project_id}`} `` | `href={routes.board(repositoryId, project.board_project_id)}` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル8: `src/components/board-project-detail/board-project-detail-content.tsx`（6箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 39 | `{ label: 'Repositories', href: '/repositories' }` | `{ label: 'Repositories', href: routes.repositories() }` |
+| 42 | `` href: `/repositories/${repositoryId}` `` | `href: routes.repository(repositoryId)` |
+| 64 | `` href={`/repositories/${repositoryId}`} `` | `href={routes.repository(repositoryId)}` |
+| 90 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${project.latest_completed_run_id}`} `` | `href={routes.run(repositoryId, boardProjectId, project.latest_completed_run_id)}` |
+| 132 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${run.board_run_id}`} `` | `href={routes.run(repositoryId, boardProjectId, run.board_run_id)}` |
+| 188 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs`} `` | `href={routes.runs(repositoryId, boardProjectId)}` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル9: `src/components/runs/runs-list-content.tsx`（4箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 39 | `{ label: 'Repositories', href: '/repositories' }` | `{ label: 'Repositories', href: routes.repositories() }` |
+| 42 | `` href: `/repositories/${repositoryId}` `` | `href: routes.repository(repositoryId)` |
+| 46 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}` `` | `href: routes.board(repositoryId, boardProjectId)` |
+| 74 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${run.board_run_id}`} `` | `href={routes.run(repositoryId, boardProjectId, run.board_run_id)}` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル10: `src/components/run-detail/run-detail-content.tsx`（7箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 76 | `{ label: 'Repositories', href: '/repositories' }` | `{ label: 'Repositories', href: routes.repositories() }` |
+| 79 | `` href: `/repositories/${repositoryId}` `` | `href: routes.repository(repositoryId)` |
+| 83 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}` `` | `href: routes.board(repositoryId, boardProjectId)` |
+| 85 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs` `` | `href: routes.runs(repositoryId, boardProjectId)` |
+| 145 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/checks/${check.kind}`} `` | `href={routes.runChecks(repositoryId, boardProjectId, boardRunId, check.kind)}` |
+| 254 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${diff.base_board_run_id}`} `` | `href={routes.run(repositoryId, boardProjectId, diff.base_board_run_id)}` |
+| 328 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/diff`} `` | `href={routes.runDiff(repositoryId, boardProjectId, boardRunId)}` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル11: `src/components/checks/findings-content.tsx`（6箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 74 | `` const basePath = `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}/checks/${checkKind}` `` | `const basePath = routes.runChecks(repositoryId, boardProjectId, boardRunId, checkKind)` |
+| 81 | `{ label: 'Repositories', href: '/repositories' }` | `{ label: 'Repositories', href: routes.repositories() }` |
+| 84 | `` href: `/repositories/${repositoryId}` `` | `href: routes.repository(repositoryId)` |
+| 88 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}` `` | `href: routes.board(repositoryId, boardProjectId)` |
+| 90 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs` `` | `href: routes.runs(repositoryId, boardProjectId)` |
+| 93 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}` `` | `href: routes.run(repositoryId, boardProjectId, boardRunId)` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル12: `src/components/diff/diff-content.tsx`（9箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 42 | `{ label: 'Repositories', href: '/repositories' }` | `{ label: 'Repositories', href: routes.repositories() }` |
+| 45 | `` href: `/repositories/${repositoryId}` `` | `href: routes.repository(repositoryId)` |
+| 49 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}` `` | `href: routes.board(repositoryId, boardProjectId)` |
+| 51 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs` `` | `href: routes.runs(repositoryId, boardProjectId)` |
+| 54 | `` href: `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}` `` | `href: routes.run(repositoryId, boardProjectId, boardRunId)` |
+| 75 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${diff.base_board_run_id}`} `` | `href={routes.run(repositoryId, boardProjectId, diff.base_board_run_id)}` |
+| 86 | `` href={`/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}`} `` | `href={routes.run(repositoryId, boardProjectId, boardRunId)}` |
+| 435 | `` const currentRunUrl = `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${boardRunId}` `` | `const currentRunUrl = routes.run(repositoryId, boardProjectId, boardRunId)` |
+| 437-438 | `` `/repositories/${repositoryId}/boards/${boardProjectId}/runs/${baseRunId}` `` | `routes.run(repositoryId, boardProjectId, baseRunId)` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+**ファイル13: `src/components/tokens/tokens-page-content.tsx`（2箇所）**
+| 行 | 現在 | 変更後 |
+|---|---|---|
+| 25 | `{ label: 'Repositories', href: '/repositories' }` | `{ label: 'Repositories', href: routes.repositories() }` |
+| 26 | `` href: `/repositories/${repositoryId}` `` | `href: routes.repository(repositoryId)` |
+| + | import追加 | `import { routes } from '@/lib/routes';` |
+
+### 影響範囲
+
+- フロントエンド（`boardflow/`）のみ
+- バックエンド（`crates/`）: 影響なし
+- DBマイグレーション: 影響なし
+- OpenAPI スキーマ: 影響なし
+- CI: フロントエンドの typecheck / lint / build ステップのみ
+
+### 設計方針
+
+1. **純粋なコード移動**: テンプレートリテラルを関数呼び出しに置き換えるだけ。生成されるURL文字列は完全に同一
+2. **オブジェクト集約**: `routes.xxx()` 形式でIDEのオートコンプリートが効く
+3. **型安全**: `repositoryId` に `string | number` を受け入れ、呼び出し側でのキャスト不要
+4. **as const**: テンプレートリテラル型を保持し、型推論を最大化
+
+### テスト観点
+
+1. **静的検証**:
+   - `pnpm typecheck` — 型エラーなし
+   - `pnpm lint` — Biome lint エラーなし
+   - `pnpm build` — ビルド成功
+2. **回帰テスト**:
+   - 各ルート関数が期待するURL文字列を生成することを手動確認（生成コードはテンプレートリテラルと同一なので自明）
+   - ユニットテストの追加は任意（純粋な文字列結合のため、型検査で十分）
+3. **動作確認**:
+   - 主要画面の遷移が正常に動作すること（ブラウザテスト、スコープ外だが推奨）
+
+### ドキュメント更新対象
+
+- `docs/logs/108/worklog.md` — 本計画と実装結果を記録（対応済み）
+- その他のドキュメント更新は不要（コード内部リファクタリングのため）
+
+### 実装順序
+
+1. **Step 0**: `feature/issue-108-route-helpers` ブランチを作成
+2. **Step 1**: `boardflow/src/lib/routes.ts` を新規作成
+3. **Step 2**: 静的ルートのみ使用するファイルを先に変更（依存が少ない）
+   - `src/middleware.ts`
+   - `src/app/login/page.tsx`
+   - `src/app/(authenticated)/layout.tsx`
+   - `src/components/layout/header.tsx`
+   - `src/components/layout/sidebar.tsx`
+4. **Step 3**: 1引数（repositoryId のみ）を使うファイルを変更
+   - `src/components/repositories/repositories-list.tsx`
+   - `src/components/tokens/tokens-page-content.tsx`
+5. **Step 4**: 2-3引数を使うファイルを変更
+   - `src/components/repository-detail/repository-detail-content.tsx`
+   - `src/components/board-project-detail/board-project-detail-content.tsx`
+   - `src/components/runs/runs-list-content.tsx`
+6. **Step 5**: 全ルート関数を使うファイルを変更
+   - `src/components/run-detail/run-detail-content.tsx`
+   - `src/components/checks/findings-content.tsx`
+   - `src/components/diff/diff-content.tsx`
+7. **Step 6**: `pnpm typecheck && pnpm lint && pnpm build` で検証
+8. **Step 7**: コミット・PR作成
+
+### 実装要否
+
+**`implementation_required`**
+
+### 未解決の疑問
+
+なし。Issue本文、調査結果、コード確認から十分な情報が揃っており、仕様に曖昧な点はない。
+
+### 残リスク
+
+- breadcrumb構築パターンの重複は routes.ts 集約だけでは解消されない（後続Issue候補として提案可能）
+- `board-project-detail-content.tsx` L90 の `project.latest_completed_run_id` は nullable（`string | null`）。`routes.run()` の `boardRunId` 引数は `string` のため、呼び出し元で null チェックが既にあることを確認する必要がある → 確認済み: L89 に `{project.latest_completed_run_id && (` の条件分岐あり、問題なし
+- `diff-content.tsx` L437-438 の `baseRunId` も nullable。L436 に `baseRunId ?` の三項演算子あり、問題なし
+
+---
+
+## 実装フェーズ（2026-05-14）
+
+### 実行内容
+
+1. `feature/issue-108-route-helpers` ブランチをmainから作成
+2. `boardflow/src/lib/routes.ts` を新規作成（9関数、`as const` なし・シンプル版で実装）
+3. 13ファイル・約46箇所のハードコードされたルート文字列を `routes.*()` 呼び出しに置き換え
+4. Biome自動フォーマットを適用（7ファイルのフォーマット修正）
+5. コミット: `feat: extract route helpers into routes.ts (#108)`
+
+### テスト結果
+
+| チェック | 結果 |
+|---|---|
+| `pnpm typecheck` | ✅ パス |
+| `pnpm lint` | ✅ パス |
+| `pnpm build` | ✅ パス（全11ルート正常ビルド） |
+
+### 変更ファイル一覧（14ファイル）
+
+- **新規**: `boardflow/src/lib/routes.ts`
+- **変更**: middleware.ts, login/page.tsx, (authenticated)/layout.tsx, header.tsx, sidebar.tsx, repositories-list.tsx, tokens-page-content.tsx, repository-detail-content.tsx, board-project-detail-content.tsx, runs-list-content.tsx, run-detail-content.tsx, findings-content.tsx, diff-content.tsx
+
+### 設計判断の差分
+
+- 計画の `as const` は省略（Biomeフォーマットとの相性・可読性を考慮。関数の戻り値型はテンプレートリテラルで自動推論されるため問題なし）
+
+### 発見した問題点
+
+- Biomeフォーマッターが `<Link href={routes.xxx(...)}>` を1行に収めるケースがあった（元のテンプレートリテラルでは複数行だった箇所）。自動フォーマットで解決。
+- `findings-content.tsx` のimport順序がBiomeのorganizeImportsルールに違反。自動修正で解決。
+
+### 残リスク
+
+- なし。純粋なコード移動・抽出のみで挙動変更なし。
+- breadcrumb共通化は後続Issue候補。

--- a/docs/logs/108/worklog.md
+++ b/docs/logs/108/worklog.md
@@ -472,3 +472,111 @@ export const routes = {
 
 - なし。純粋なコード移動・抽出のみで挙動変更なし。
 - breadcrumb共通化は後続Issue候補。
+
+---
+
+## レビューフェーズ（2026-05-14）
+
+### レビュー結果
+
+- `git diff main...HEAD` を確認し、Issue #108 の変更範囲は計画どおり `boardflow/src/lib/routes.ts` の新規作成と 13 ファイルの呼び出し側置換に限定されていることを確認
+- `boardflow/src/lib/routes.ts` の 9 関数は既存の URL 構造と完全一致し、末尾スラッシュの追加・削除や path segment の変更はなし
+- `boardflow/src/**` から `/login` および `/repositories` 系の内部ルート直書きを検索し、対象パターンの置換漏れは `routes.ts` 自身を除いて未検出
+- 変更対象 14 ファイルのエラー確認で新規の型エラー・診断は未検出
+- `pnpm typecheck` / `pnpm lint` / `pnpm build` の実行結果は実装ログ記録と整合
+
+### 指摘事項
+
+- blocking な指摘なし
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- `routes.ts` に対する軽量なユニットテストを追加すると、将来 URL 構造を変更した際の回帰検知がしやすくなる。ただし今回のスコープでは必須ではない
+- breadcrumb の前半階層は引き続き複数画面で重複しているため、後続 Issue として builder 化を検討する余地あり
+
+### テスト不足
+
+- ブラウザ上での遷移確認や route helper 単体テストは未実施。ただし今回は純粋な文字列抽出であり、静的検証中心でも妥当
+
+### ドキュメント確認
+
+- `docs/spec.md` と矛盾する変更なし
+- `docs/external/` 配下に本 Issue 固有の追加確認が必要な research 文書は見当たらず、既存実装方針との不整合も未検出
+
+### PR/完了結果
+
+- `pr_ready: true`
+
+### 残リスク
+
+- `routes.ts` は文字列連結のみで入力値のエンコードや正規化を行わないが、これは既存実装と同等であり、新たなセキュリティリスクは増えていない
+- 将来 route 構造を変更する際、helper 関数の戻り値に対する自動回帰検知は現状ビルド依存のため、単体テストがない分だけ検知粒度は限定される
+
+---
+
+## ドキュメント確認フェーズ（2026-05-14）
+
+### 確認対象
+
+- `docs/frontend/summary.md`
+- `docs/spec.md`
+- `docs/technology.md`
+- `README.md`
+- `AGENTS.md`
+- `docs/external/` 配下の関連有無
+- `docs/logs/108/worklog.md`
+
+### 確認結果
+
+- `docs/frontend/summary.md` はフロントエンドの責務、画面構成、データ取得方針を記述する文書であり、今回の `routes.ts` 導入は内部リファクタリングに留まるため追記不要
+- `AGENTS.md` の frontend セクションはディレクトリ構成と主要コマンドの指示が中心で、`src/lib/routes.ts` のような実装補助モジュール追加を記載すべき粒度ではないため更新不要
+- `docs/spec.md` はプロダクト仕様書であり、URL 生成ヘルパー抽出による仕様変更はないため更新不要
+- `docs/technology.md` は全体技術方針の文書であり、ルーティング文字列集約はアーキテクチャ方針変更に当たらないため更新不要
+- `README.md` への導入手順・運用手順の追記は不要
+- `CONTRIBUTING.md` はリポジトリ内に存在せず、今回の Issue #108 の完了条件にも含まれないため不足ドキュメント扱いにはしない
+- `docs/external/` 配下で今回の Issue に紐づく外部調査メモは不要。research 成果物サマリの「外部調査ドキュメント更新なし」と整合
+- `docs/logs/108/worklog.md` には調査、計画、実装、レビューの各フェーズが記録済みであり、今回の追記でドキュメント確認フェーズも補完完了
+
+### 判定
+
+- `docs_ready: true`
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- PR 本文に「挙動変更なし」「内部リファクタリングのみ」を明記すると、レビュアーが確認観点を絞りやすい
+- 将来 `src/lib/` 配下の横断ユーティリティが増えた段階で、frontend ガイドに「共通ルート helper を置く」程度の軽い規約を追加する余地はある
+
+### 残リスク
+
+- 現時点では route helper の存在を説明する恒久ドキュメントはないが、今回の変更規模と性質では更新コストの方が高い
+- breadcrumb 重複解消までは扱っていないため、URL helper 導入の意図を後続 Issue 文脈なしに把握しにくい可能性は残る
+
+---
+
+## PR作成フェーズ（2026-05-14）
+
+### 事前確認
+
+- review: `pr_ready: true`（blocking 指摘なし）
+- docs: `docs_ready: true`（ドキュメント更新不要）
+- 未コミット変更: `docs/logs/108/worklog.md`（レビュー・ドキュメント確認フェーズの追記）→ 本フェーズ追記後にまとめてコミット
+
+### PR作成結果
+
+- タイトル: `refactor: centralize frontend route builders in routes.ts`
+- ブランチ: \`feature/issue-108-route-helpers\` → \`main\`
+- Closes #108
+- PR URL: （作成後に記録）
+
+### 残リスク
+
+- `routes.ts` に対するユニットテストは未追加（純粋な文字列関数であり静的検証で代替）
+- breadcrumb共通化は後続 Issue 候補として残存

--- a/docs/logs/108/worklog.md
+++ b/docs/logs/108/worklog.md
@@ -574,7 +574,7 @@ export const routes = {
 - タイトル: `refactor: centralize frontend route builders in routes.ts`
 - ブランチ: \`feature/issue-108-route-helpers\` → \`main\`
 - Closes #108
-- PR URL: （作成後に記録）
+- PR URL: https://github.com/f0reachARR/boardflow/pull/118
 
 ### 残リスク
 


### PR DESCRIPTION
## Summary

Closes #108

フロントエンド内で重複していた内部ルート文字列を \`boardflow/src/lib/routes.ts\` に集約し、各画面・レイアウト・middleware の href / redirect を route helper 呼び出しへ置き換えました。

この変更は内部リファクタリングのみで、生成される URL と画面遷移の挙動は変えていません。

## Changes

- 9 個の route helper を \`boardflow/src/lib/routes.ts\` に追加
- フロントエンド 13 ファイルのハードコードされた内部ルート文字列を置換
- breadcrumb、Link、redirect、middleware の URL 生成を統一

## Validation

- \`pnpm typecheck\` ✅
- \`pnpm lint\` ✅
- \`pnpm build\` ✅

## Notes

- 挙動変更なし
- 外部調査ドキュメント更新なし
- breadcrumb builder 化は今回のスコープ外

## Review / Docs

- review: \`pr_ready: true\`（blocking 指摘なし）
- docs: \`docs_ready: true\`（ドキュメント更新不要）