### PR TITLE
refactor: split RunDetailContent into section components (#110)

### DIFF
--- a/boardflow/src/components/run-detail/artifact-summary-section.tsx
+++ b/boardflow/src/components/run-detail/artifact-summary-section.tsx
@@ -1,0 +1,28 @@
+import { Badge, Box, Heading, HStack } from '@chakra-ui/react';
+import type { ArtifactSummary } from '@/lib/api/schema-types';
+
+interface ArtifactSummarySectionProps {
+  artifactSummary: ArtifactSummary;
+}
+
+export function ArtifactSummarySection({ artifactSummary }: ArtifactSummarySectionProps) {
+  return (
+    <Box>
+      <Heading size='md' mb={3}>
+        Artifact Summary
+      </Heading>
+      <HStack gap={4} fontSize='sm'>
+        <Badge colorPalette='green'>{artifactSummary.available} available</Badge>
+        {artifactSummary.missing > 0 && (
+          <Badge colorPalette='orange'>{artifactSummary.missing} missing</Badge>
+        )}
+        {artifactSummary.failed > 0 && (
+          <Badge colorPalette='red'>{artifactSummary.failed} failed</Badge>
+        )}
+        {artifactSummary.skipped > 0 && (
+          <Badge colorPalette='gray'>{artifactSummary.skipped} skipped</Badge>
+        )}
+      </HStack>
+    </Box>
+  );
+}

--- a/boardflow/src/components/run-detail/artifacts-table.tsx
+++ b/boardflow/src/components/run-detail/artifacts-table.tsx
@@ -1,0 +1,54 @@
+import { Badge, Box, Heading, Table, Text } from '@chakra-ui/react';
+import type { Artifact } from '@/lib/api/schema-types';
+import { artifactStatusColor } from '@/lib/domain/status';
+import { formatBytes } from '@/lib/format';
+
+interface ArtifactsTableProps {
+  artifacts: Artifact[];
+}
+
+export function ArtifactsTable({ artifacts }: ArtifactsTableProps) {
+  if (artifacts.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <Heading size='md' mb={3}>
+        Artifacts
+      </Heading>
+      <Table.Root size='sm' variant='outline'>
+        <Table.Header>
+          <Table.Row>
+            <Table.ColumnHeader>Type</Table.ColumnHeader>
+            <Table.ColumnHeader>Status</Table.ColumnHeader>
+            <Table.ColumnHeader>Filename</Table.ColumnHeader>
+            <Table.ColumnHeader>Size</Table.ColumnHeader>
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {artifacts.map((artifact, idx) => (
+            <Table.Row key={artifact.artifact_id ?? idx}>
+              <Table.Cell>
+                <Text fontSize='sm'>{artifact.type}</Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Badge colorPalette={artifactStatusColor(artifact.status)}>{artifact.status}</Badge>
+              </Table.Cell>
+              <Table.Cell>
+                <Text fontSize='sm' fontFamily='mono'>
+                  {artifact.filename ?? artifact.status_reason ?? '—'}
+                </Text>
+              </Table.Cell>
+              <Table.Cell>
+                <Text fontSize='sm' color='gray.600'>
+                  {artifact.size_bytes ? formatBytes(artifact.size_bytes) : '—'}
+                </Text>
+              </Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    </Box>
+  );
+}

--- a/boardflow/src/components/run-detail/run-checks-section.tsx
+++ b/boardflow/src/components/run-detail/run-checks-section.tsx
@@ -1,0 +1,65 @@
+import { Badge, Box, Heading, HStack, Text } from '@chakra-ui/react';
+import Link from 'next/link';
+import type { CheckInfo } from '@/lib/api/schema-types';
+import { checkStatusColor } from '@/lib/domain/status';
+import { routes } from '@/lib/routes';
+
+interface RunChecksSectionProps {
+  checks: CheckInfo[];
+  repositoryId: string;
+  boardProjectId: string;
+  boardRunId: string;
+}
+
+export function RunChecksSection({
+  checks,
+  repositoryId,
+  boardProjectId,
+  boardRunId,
+}: RunChecksSectionProps) {
+  if (checks.length === 0) {
+    return null;
+  }
+
+  return (
+    <Box>
+      <Heading size='md' mb={3}>
+        Checks
+      </Heading>
+      <HStack gap={4}>
+        {checks.map((check) => (
+          <Box key={check.kind} borderWidth='1px' borderRadius='md' p={4} bg='white' minW='200px'>
+            <HStack justify='space-between' mb={2}>
+              <Text fontWeight='bold' textTransform='uppercase'>
+                {check.kind}
+              </Text>
+              <Badge colorPalette={checkStatusColor(check.status)}>{check.status}</Badge>
+            </HStack>
+            <HStack gap={3} fontSize='sm'>
+              {check.error_count > 0 && <Text color='red.500'>{check.error_count} errors</Text>}
+              {check.warning_count > 0 && (
+                <Text color='orange.500'>{check.warning_count} warnings</Text>
+              )}
+              {check.notice_count > 0 && <Text color='gray.500'>{check.notice_count} notices</Text>}
+              {check.error_count === 0 && check.warning_count === 0 && check.notice_count === 0 && (
+                <Text color='green.500'>No issues</Text>
+              )}
+            </HStack>
+            {check.error_count + check.warning_count + check.notice_count > 0 && (
+              <Link href={routes.runChecks(repositoryId, boardProjectId, boardRunId, check.kind)}>
+                <Text
+                  color='blue.600'
+                  fontSize='sm'
+                  mt={2}
+                  _hover={{ textDecoration: 'underline' }}
+                >
+                  View {check.error_count + check.warning_count + check.notice_count} findings
+                </Text>
+              </Link>
+            )}
+          </Box>
+        ))}
+      </HStack>
+    </Box>
+  );
+}

--- a/boardflow/src/components/run-detail/run-detail-content.tsx
+++ b/boardflow/src/components/run-detail/run-detail-content.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { Badge, Box, Heading, HStack, Table, Text, VStack } from '@chakra-ui/react';
-import Link from 'next/link';
+import { Box, VStack } from '@chakra-ui/react';
 import { ArtifactViewerSection } from '@/components/artifact-viewer/artifact-viewer-section';
+import { ArtifactSummarySection } from '@/components/run-detail/artifact-summary-section';
+import { ArtifactsTable } from '@/components/run-detail/artifacts-table';
+import { RunChecksSection } from '@/components/run-detail/run-checks-section';
+import { RunDiffSummaryCard } from '@/components/run-detail/run-diff-summary-card';
+import { RunHeader } from '@/components/run-detail/run-header';
 import { Breadcrumb } from '@/components/ui/breadcrumb';
 import { $api } from '@/lib/api/react-query';
 import type { Artifact, DiffResponse, ViewerEntry } from '@/lib/api/schema-types';
-import { parseDiffSummary } from '@/lib/domain/diff-summary';
-import { artifactStatusColor, boardRunStatusColor, checkStatusColor } from '@/lib/domain/status';
-import { formatBytes, formatDateTime, shortId, shortSha } from '@/lib/format';
+import { shortId } from '@/lib/format';
 import { routes } from '@/lib/routes';
 
 interface Props {
@@ -83,264 +85,22 @@ export function RunDetailContent({ repositoryId, boardProjectId, boardRunId }: P
         />
       )}
       <VStack align='stretch' gap={6}>
-        {/* Header */}
-        <Box>
-          <HStack gap={3} mb={2}>
-            <Heading size='lg'>Run {run.board_run_id}</Heading>
-            <Badge colorPalette={boardRunStatusColor(run.status)} size='lg'>
-              {run.status}
-            </Badge>
-          </HStack>
-          <HStack gap={4} fontSize='sm' color='gray.600'>
-            <Text fontFamily='mono'>{shortSha(run.commit_sha)}</Text>
-            <Text>{run.branch}</Text>
-            <Text>Created {formatDateTime(run.created_at)}</Text>
-            {run.completed_at && <Text>Completed {formatDateTime(run.completed_at)}</Text>}
-          </HStack>
-        </Box>
-
-        {/* Checks */}
-        {run.checks.length > 0 && (
-          <Box>
-            <Heading size='md' mb={3}>
-              Checks
-            </Heading>
-            <HStack gap={4}>
-              {run.checks.map((check) => (
-                <Box
-                  key={check.kind}
-                  borderWidth='1px'
-                  borderRadius='md'
-                  p={4}
-                  bg='white'
-                  minW='200px'
-                >
-                  <HStack justify='space-between' mb={2}>
-                    <Text fontWeight='bold' textTransform='uppercase'>
-                      {check.kind}
-                    </Text>
-                    <Badge colorPalette={checkStatusColor(check.status)}>{check.status}</Badge>
-                  </HStack>
-                  <HStack gap={3} fontSize='sm'>
-                    {check.error_count > 0 && (
-                      <Text color='red.500'>{check.error_count} errors</Text>
-                    )}
-                    {check.warning_count > 0 && (
-                      <Text color='orange.500'>{check.warning_count} warnings</Text>
-                    )}
-                    {check.notice_count > 0 && (
-                      <Text color='gray.500'>{check.notice_count} notices</Text>
-                    )}
-                    {check.error_count === 0 &&
-                      check.warning_count === 0 &&
-                      check.notice_count === 0 && <Text color='green.500'>No issues</Text>}
-                  </HStack>
-                  {check.error_count + check.warning_count + check.notice_count > 0 && (
-                    <Link
-                      href={routes.runChecks(repositoryId, boardProjectId, boardRunId, check.kind)}
-                    >
-                      <Text
-                        color='blue.600'
-                        fontSize='sm'
-                        mt={2}
-                        _hover={{ textDecoration: 'underline' }}
-                      >
-                        View {check.error_count + check.warning_count + check.notice_count} findings
-                      </Text>
-                    </Link>
-                  )}
-                </Box>
-              ))}
-            </HStack>
-          </Box>
-        )}
-
-        {/* Artifact Summary */}
-        <Box>
-          <Heading size='md' mb={3}>
-            Artifact Summary
-          </Heading>
-          <HStack gap={4} fontSize='sm'>
-            <Badge colorPalette='green'>{run.artifact_summary.available} available</Badge>
-            {run.artifact_summary.missing > 0 && (
-              <Badge colorPalette='orange'>{run.artifact_summary.missing} missing</Badge>
-            )}
-            {run.artifact_summary.failed > 0 && (
-              <Badge colorPalette='red'>{run.artifact_summary.failed} failed</Badge>
-            )}
-            {run.artifact_summary.skipped > 0 && (
-              <Badge colorPalette='gray'>{run.artifact_summary.skipped} skipped</Badge>
-            )}
-          </HStack>
-        </Box>
-
-        {/* Artifacts Table */}
-        {artifacts.length > 0 && (
-          <Box>
-            <Heading size='md' mb={3}>
-              Artifacts
-            </Heading>
-            <Table.Root size='sm' variant='outline'>
-              <Table.Header>
-                <Table.Row>
-                  <Table.ColumnHeader>Type</Table.ColumnHeader>
-                  <Table.ColumnHeader>Status</Table.ColumnHeader>
-                  <Table.ColumnHeader>Filename</Table.ColumnHeader>
-                  <Table.ColumnHeader>Size</Table.ColumnHeader>
-                </Table.Row>
-              </Table.Header>
-              <Table.Body>
-                {artifacts.map((artifact, idx) => (
-                  <Table.Row key={artifact.artifact_id ?? idx}>
-                    <Table.Cell>
-                      <Text fontSize='sm'>{artifact.type}</Text>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Badge colorPalette={artifactStatusColor(artifact.status)}>
-                        {artifact.status}
-                      </Badge>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text fontSize='sm' fontFamily='mono'>
-                        {artifact.filename ?? artifact.status_reason ?? '—'}
-                      </Text>
-                    </Table.Cell>
-                    <Table.Cell>
-                      <Text fontSize='sm' color='gray.600'>
-                        {artifact.size_bytes ? formatBytes(artifact.size_bytes) : '—'}
-                      </Text>
-                    </Table.Cell>
-                  </Table.Row>
-                ))}
-              </Table.Body>
-            </Table.Root>
-          </Box>
-        )}
-
-        {/* Changes from Baseline */}
-        {diffErrorMessage && (
-          <Box>
-            <Heading size='md' mb={3}>
-              Changes from Baseline
-            </Heading>
-            <Box borderWidth='1px' borderRadius='md' p={4} bg='white'>
-              <Text fontSize='sm' color='red.500'>
-                {diffErrorMessage}
-              </Text>
-            </Box>
-          </Box>
-        )}
-        {diff && (
-          <Box>
-            <Heading size='md' mb={3}>
-              Changes from Baseline
-            </Heading>
-            <Box borderWidth='1px' borderRadius='md' p={4} bg='white'>
-              {diff.status === 'ready' &&
-                diff.summary != null &&
-                (() => {
-                  const summary = parseDiffSummary(diff.summary);
-                  return (
-                    <VStack align='stretch' gap={2}>
-                      {diff.base_board_run_id && (
-                        <Text fontSize='sm' color='gray.600'>
-                          Compared to run:{' '}
-                          <Link
-                            href={routes.run(repositoryId, boardProjectId, diff.base_board_run_id)}
-                          >
-                            <Text
-                              as='span'
-                              color='blue.600'
-                              _hover={{ textDecoration: 'underline' }}
-                            >
-                              {shortId(diff.base_board_run_id)}
-                            </Text>
-                          </Link>
-                        </Text>
-                      )}
-                      {summary.fileChanges ? (
-                        <HStack gap={4} fontSize='sm'>
-                          <Text>
-                            Files: +{summary.fileChanges.added} -{summary.fileChanges.removed} ~
-                            {summary.fileChanges.changed} ({summary.fileChanges.unchanged}{' '}
-                            unchanged)
-                          </Text>
-                        </HStack>
-                      ) : (
-                        <Text fontSize='sm' color='gray.500'>
-                          File changes: data format not recognized
-                        </Text>
-                      )}
-                      {summary.bomChanges ? (
-                        <HStack gap={4} fontSize='sm'>
-                          <Text>
-                            BOM: +{summary.bomChanges.added} -{summary.bomChanges.removed} ~
-                            {summary.bomChanges.changed}
-                          </Text>
-                        </HStack>
-                      ) : (
-                        <Text fontSize='sm' color='gray.500'>
-                          BOM changes: data format not recognized
-                        </Text>
-                      )}
-                      {summary.checks != null && summary.checks.length > 0 && (
-                        <HStack gap={4} fontSize='sm' flexWrap='wrap'>
-                          <Text>Checks:</Text>
-                          {summary.checks.map(([kind, check]) => (
-                            <Text key={kind}>
-                              {kind.toUpperCase()} {check.status_change} (
-                              {check.error_delta >= 0 ? '+' : ''}
-                              {check.error_delta}E, {check.warning_delta >= 0 ? '+' : ''}
-                              {check.warning_delta}W)
-                            </Text>
-                          ))}
-                        </HStack>
-                      )}
-                      {summary.artifactChanges ? (
-                        <HStack gap={4} fontSize='sm'>
-                          <Text>
-                            Artifacts: +{summary.artifactChanges.added} -
-                            {summary.artifactChanges.removed} ~{summary.artifactChanges.changed}
-                          </Text>
-                        </HStack>
-                      ) : (
-                        <Text fontSize='sm' color='gray.500'>
-                          Artifact changes: data format not recognized
-                        </Text>
-                      )}
-                      <Link href={routes.runDiff(repositoryId, boardProjectId, boardRunId)}>
-                        <Text
-                          color='blue.600'
-                          fontSize='sm'
-                          mt={2}
-                          _hover={{ textDecoration: 'underline' }}
-                        >
-                          View full diff →
-                        </Text>
-                      </Link>
-                    </VStack>
-                  );
-                })()}
-              {diff.status === 'no_baseline' && (
-                <Text fontSize='sm' color='gray.500'>
-                  This is the first run. No baseline for comparison.
-                </Text>
-              )}
-              {diff.status === 'failed' && (
-                <Text fontSize='sm' color='red.500'>
-                  {diff.error_message ?? 'Diff computation failed.'}
-                </Text>
-              )}
-              {diff.status === 'unavailable' && (
-                <Text fontSize='sm' color='gray.500'>
-                  Diff data is not available.
-                </Text>
-              )}
-            </Box>
-          </Box>
-        )}
-
-        {/* Viewers */}
+        <RunHeader run={run} />
+        <RunChecksSection
+          checks={run.checks}
+          repositoryId={repositoryId}
+          boardProjectId={boardProjectId}
+          boardRunId={boardRunId}
+        />
+        <ArtifactSummarySection artifactSummary={run.artifact_summary} />
+        <ArtifactsTable artifacts={artifacts} />
+        <RunDiffSummaryCard
+          diff={diff}
+          diffErrorMessage={diffErrorMessage}
+          repositoryId={repositoryId}
+          boardProjectId={boardProjectId}
+          boardRunId={boardRunId}
+        />
         <ArtifactViewerSection
           viewers={viewers}
           expiresAt={viewerData?.expires_at}

--- a/boardflow/src/components/run-detail/run-diff-summary-card.tsx
+++ b/boardflow/src/components/run-detail/run-diff-summary-card.tsx
@@ -1,0 +1,147 @@
+import { Box, Heading, HStack, Text, VStack } from '@chakra-ui/react';
+import Link from 'next/link';
+import type { DiffResponse } from '@/lib/api/schema-types';
+import { parseDiffSummary } from '@/lib/domain/diff-summary';
+import { shortId } from '@/lib/format';
+import { routes } from '@/lib/routes';
+
+interface RunDiffSummaryCardProps {
+  diff: DiffResponse | null;
+  diffErrorMessage: string | null;
+  repositoryId: string;
+  boardProjectId: string;
+  boardRunId: string;
+}
+
+export function RunDiffSummaryCard({
+  diff,
+  diffErrorMessage,
+  repositoryId,
+  boardProjectId,
+  boardRunId,
+}: RunDiffSummaryCardProps) {
+  if (diff === null && diffErrorMessage === null) {
+    return null;
+  }
+
+  return (
+    <>
+      {diffErrorMessage && (
+        <Box>
+          <Heading size='md' mb={3}>
+            Changes from Baseline
+          </Heading>
+          <Box borderWidth='1px' borderRadius='md' p={4} bg='white'>
+            <Text fontSize='sm' color='red.500'>
+              {diffErrorMessage}
+            </Text>
+          </Box>
+        </Box>
+      )}
+      {diff && (
+        <Box>
+          <Heading size='md' mb={3}>
+            Changes from Baseline
+          </Heading>
+          <Box borderWidth='1px' borderRadius='md' p={4} bg='white'>
+            {diff.status === 'ready' &&
+              diff.summary != null &&
+              (() => {
+                const summary = parseDiffSummary(diff.summary);
+                return (
+                  <VStack align='stretch' gap={2}>
+                    {diff.base_board_run_id && (
+                      <Text fontSize='sm' color='gray.600'>
+                        Compared to run:{' '}
+                        <Link
+                          href={routes.run(repositoryId, boardProjectId, diff.base_board_run_id)}
+                        >
+                          <Text as='span' color='blue.600' _hover={{ textDecoration: 'underline' }}>
+                            {shortId(diff.base_board_run_id)}
+                          </Text>
+                        </Link>
+                      </Text>
+                    )}
+                    {summary.fileChanges ? (
+                      <HStack gap={4} fontSize='sm'>
+                        <Text>
+                          Files: +{summary.fileChanges.added} -{summary.fileChanges.removed} ~
+                          {summary.fileChanges.changed} ({summary.fileChanges.unchanged} unchanged)
+                        </Text>
+                      </HStack>
+                    ) : (
+                      <Text fontSize='sm' color='gray.500'>
+                        File changes: data format not recognized
+                      </Text>
+                    )}
+                    {summary.bomChanges ? (
+                      <HStack gap={4} fontSize='sm'>
+                        <Text>
+                          BOM: +{summary.bomChanges.added} -{summary.bomChanges.removed} ~
+                          {summary.bomChanges.changed}
+                        </Text>
+                      </HStack>
+                    ) : (
+                      <Text fontSize='sm' color='gray.500'>
+                        BOM changes: data format not recognized
+                      </Text>
+                    )}
+                    {summary.checks != null && summary.checks.length > 0 && (
+                      <HStack gap={4} fontSize='sm' flexWrap='wrap'>
+                        <Text>Checks:</Text>
+                        {summary.checks.map(([kind, check]) => (
+                          <Text key={kind}>
+                            {kind.toUpperCase()} {check.status_change} (
+                            {check.error_delta >= 0 ? '+' : ''}
+                            {check.error_delta}E, {check.warning_delta >= 0 ? '+' : ''}
+                            {check.warning_delta}W)
+                          </Text>
+                        ))}
+                      </HStack>
+                    )}
+                    {summary.artifactChanges ? (
+                      <HStack gap={4} fontSize='sm'>
+                        <Text>
+                          Artifacts: +{summary.artifactChanges.added} -
+                          {summary.artifactChanges.removed} ~{summary.artifactChanges.changed}
+                        </Text>
+                      </HStack>
+                    ) : (
+                      <Text fontSize='sm' color='gray.500'>
+                        Artifact changes: data format not recognized
+                      </Text>
+                    )}
+                    <Link href={routes.runDiff(repositoryId, boardProjectId, boardRunId)}>
+                      <Text
+                        color='blue.600'
+                        fontSize='sm'
+                        mt={2}
+                        _hover={{ textDecoration: 'underline' }}
+                      >
+                        View full diff →
+                      </Text>
+                    </Link>
+                  </VStack>
+                );
+              })()}
+            {diff.status === 'no_baseline' && (
+              <Text fontSize='sm' color='gray.500'>
+                This is the first run. No baseline for comparison.
+              </Text>
+            )}
+            {diff.status === 'failed' && (
+              <Text fontSize='sm' color='red.500'>
+                {diff.error_message ?? 'Diff computation failed.'}
+              </Text>
+            )}
+            {diff.status === 'unavailable' && (
+              <Text fontSize='sm' color='gray.500'>
+                Diff data is not available.
+              </Text>
+            )}
+          </Box>
+        </Box>
+      )}
+    </>
+  );
+}

--- a/boardflow/src/components/run-detail/run-header.tsx
+++ b/boardflow/src/components/run-detail/run-header.tsx
@@ -1,0 +1,27 @@
+import { Badge, Box, Heading, HStack, Text } from '@chakra-ui/react';
+import type { BoardRunDetail } from '@/lib/api/schema-types';
+import { boardRunStatusColor } from '@/lib/domain/status';
+import { formatDateTime, shortSha } from '@/lib/format';
+
+interface RunHeaderProps {
+  run: BoardRunDetail;
+}
+
+export function RunHeader({ run }: RunHeaderProps) {
+  return (
+    <Box>
+      <HStack gap={3} mb={2}>
+        <Heading size='lg'>Run {run.board_run_id}</Heading>
+        <Badge colorPalette={boardRunStatusColor(run.status)} size='lg'>
+          {run.status}
+        </Badge>
+      </HStack>
+      <HStack gap={4} fontSize='sm' color='gray.600'>
+        <Text fontFamily='mono'>{shortSha(run.commit_sha)}</Text>
+        <Text>{run.branch}</Text>
+        <Text>Created {formatDateTime(run.created_at)}</Text>
+        {run.completed_at && <Text>Completed {formatDateTime(run.completed_at)}</Text>}
+      </HStack>
+    </Box>
+  );
+}

--- a/boardflow/src/lib/api/schema-types.ts
+++ b/boardflow/src/lib/api/schema-types.ts
@@ -18,6 +18,10 @@ export type ViewerEntry = components['schemas']['ViewerStatus'];
 export type ViewerSource = components['schemas']['ViewerSource'];
 export type ViewerSourcesResponse = components['schemas']['ViewerSourcesResponse'];
 
+export type ArtifactSummary = components['schemas']['ArtifactSummary'];
+export type BoardRunDetail = components['schemas']['BoardRunDetailResponse'];
+export type CheckInfo = components['schemas']['CheckInfo'];
+
 /**
  * Frontend-defined shape for diff summary (backend returns as unknown JSON).
  * Fields are validated at runtime with type guards before access.

--- a/docs/logs/110/worklog.md
+++ b/docs/logs/110/worklog.md
@@ -1,0 +1,251 @@
+# Issue #110 — frontend: RunDetailContent をセクション単位に分割する
+
+## Issueまでの経緯
+
+- `RunDetailContent` (約350行) がデータ取得、breadcrumb、ヘッダー、checks、artifact summary、artifacts table、diff summary、viewer 接続を1ファイルで担っている
+- #107 で status/format 関数を `@/lib/domain/status`, `@/lib/format` に集約済み
+- #109 で DiffSummary パース処理を `@/lib/domain/diff-summary` に共通化済み
+- これらの前提を踏まえ、表示セクションをコンポーネント分割するリファクタリング
+
+## ユーザー要望
+
+- `run-detail/` 配下にセクションコンポーネントを切り出す
+  - RunHeader, RunChecksSection, ArtifactSummarySection, ArtifactsTable, RunDiffSummaryCard
+- `RunDetailContent` はデータ取得とセクション配置を中心に薄くする
+- 表示仕様は変えない（純粋なコード移動・分割）
+
+## 調査結果 (リサーチフェーズ: 2026-05-14)
+
+### 外部調査の必要性判断
+
+**不要**。理由：
+
+1. 新規外部ライブラリの導入なし — Chakra UI v3, Next.js, TanStack React Query はすべて既存導入済み
+2. 外部API変更なし — バックエンドエンドポイントの変更は不要
+3. 既存コンポーネントの移動・分割のみ — フレームワーク固有のパターン調査も不要（既にプロジェクト内で同様のパターンが確立されている）
+
+### 現状のファイル構成
+
+- `boardflow/src/components/run-detail/run-detail-content.tsx` (約350行、1ファイルのみ)
+- データ取得: `useSuspenseQuery` × 4 + `useQuery` × 1 (diff)
+- 表示セクション: Breadcrumb → Header → Checks → ArtifactSummary → ArtifactsTable → DiffSummary → ArtifactViewerSection
+
+### 分割計画（実装エージェント向け）
+
+| 新コンポーネント | 担当セクション | 主なprops |
+|---|---|---|
+| `RunHeader` | HStack(Heading + Badge) + メタ情報 | `run` |
+| `RunChecksSection` | Checks カード群 | `checks`, `repositoryId`, `boardProjectId`, `boardRunId` |
+| `ArtifactSummarySection` | Artifact Summary バッジ群 | `artifactSummary` |
+| `ArtifactsTable` | Artifacts テーブル | `artifacts` |
+| `RunDiffSummaryCard` | Changes from Baseline セクション全体 | `diff`, `diffErrorMessage`, `repositoryId`, `boardProjectId`, `boardRunId` |
+
+- `RunDetailContent` はデータ取得 (5 queries) + Breadcrumb + 上記コンポーネントの配置のみに留める
+- `ArtifactViewerSection` は既に別コンポーネントなのでそのまま
+
+## 結論ステータス
+
+**`implementation_required`** — 外部調査不要。実装エージェントへの引き渡しで完了。
+
+## 計画 (planフェーズ: 2026-05-14)
+
+### 目的
+
+`RunDetailContent` (約290行) を5つのセクションコンポーネントに分割し、各セクションの責務を明確にする。`RunDetailContent` はデータ取得 + Breadcrumb + セクション配置のオーケストレーターに薄くする。
+
+### 非目的
+
+- 表示仕様の変更
+- データ取得ロジックの変更（クエリは `RunDetailContent` に残す）
+- `ArtifactViewerSection` の変更（既に分離済み）
+- 新しい外部ライブラリの導入
+- テストの追加（表示仕様が変わらないため）
+
+### 受け入れ条件
+
+1. `pnpm lint` がパスすること
+2. `pnpm typecheck` がパスすること
+3. `pnpm build` がパスすること
+4. ブラウザでの表示が変わらないこと（目視確認）
+5. `RunDetailContent` がデータ取得 + Breadcrumb + セクション配置のみになること
+
+### 詳細要件
+
+#### 1. 型エイリアスの追加 (`boardflow/src/lib/api/schema-types.ts`)
+
+既存パターンに合わせ、セクションコンポーネントの Props で使う型エイリアスを3つ追加:
+
+```ts
+export type ArtifactSummary = components['schemas']['ArtifactSummary'];
+export type BoardRunDetail = components['schemas']['BoardRunDetailResponse'];
+export type CheckInfo = components['schemas']['CheckInfo'];
+```
+
+#### 2. 新規ファイル一覧とProps定義
+
+すべて `boardflow/src/components/run-detail/` 配下にフラット配置。
+
+##### (a) `run-header.tsx` — Run ID + ステータスバッジ + コミット/ブランチ/日時情報
+
+```ts
+interface RunHeaderProps {
+  run: BoardRunDetail;
+}
+```
+
+現在のコード L89–L102 を移動。import: `BoardRunDetail` from schema-types, `boardRunStatusColor` from status, `shortSha`, `formatDateTime` from format, Chakra UI コンポーネント。
+
+##### (b) `run-checks-section.tsx` — Checks カード群
+
+```ts
+interface RunChecksSectionProps {
+  checks: CheckInfo[];
+  repositoryId: string;
+  boardProjectId: string;
+  boardRunId: string;
+}
+```
+
+現在のコード L105–L146 を移動。`checks.length === 0` のときは `null` を返す。import: `CheckInfo` from schema-types, `checkStatusColor` from status, `routes` from routes, Link, Chakra UI コンポーネント。
+
+##### (c) `artifact-summary-section.tsx` — Artifact Summary バッジ群
+
+```ts
+interface ArtifactSummarySectionProps {
+  artifactSummary: ArtifactSummary;
+}
+```
+
+現在のコード L148–L163 を移動。import: `ArtifactSummary` from schema-types, Chakra UI コンポーネント。
+
+##### (d) `artifacts-table.tsx` — Artifacts テーブル
+
+```ts
+interface ArtifactsTableProps {
+  artifacts: Artifact[];
+}
+```
+
+現在のコード L165–L200 を移動。`artifacts.length === 0` のときは `null` を返す。import: `Artifact` from schema-types, `artifactStatusColor` from status, `formatBytes` from format, Chakra UI コンポーネント。
+
+##### (e) `run-diff-summary-card.tsx` — Changes from Baseline セクション全体
+
+```ts
+interface RunDiffSummaryCardProps {
+  diff: DiffResponse | null;
+  diffErrorMessage: string | null;
+  repositoryId: string;
+  boardProjectId: string;
+  boardRunId: string;
+}
+```
+
+現在のコード L202–L284 を移動。`diff === null && diffErrorMessage === null` のときは `null` を返す。import: `DiffResponse` from schema-types, `parseDiffSummary` from diff-summary, `shortId` from format, `routes` from routes, Link, Chakra UI コンポーネント。
+
+#### 3. `RunDetailContent` の変更
+
+変更後の構造:
+
+```tsx
+export function RunDetailContent({ repositoryId, boardProjectId, boardRunId }: Props) {
+  // データ取得 (5 queries) — 変更なし
+  // derived data — 変更なし
+
+  return (
+    <Box>
+      {project && <Breadcrumb items={[...]} />}
+      <VStack align='stretch' gap={6}>
+        <RunHeader run={run} />
+        <RunChecksSection checks={run.checks} repositoryId={...} boardProjectId={...} boardRunId={...} />
+        <ArtifactSummarySection artifactSummary={run.artifact_summary} />
+        <ArtifactsTable artifacts={artifacts} />
+        <RunDiffSummaryCard diff={diff} diffErrorMessage={diffErrorMessage} repositoryId={...} boardProjectId={...} boardRunId={...} />
+        <ArtifactViewerSection viewers={viewers} expiresAt={viewerData?.expires_at} boardRunId={boardRunId} />
+      </VStack>
+    </Box>
+  );
+}
+```
+
+不要になった import を削除: `Table`, `Link` (Breadcrumb内では残る), status/format関数のうちセクションに移ったもの。ただし `shortId` は Breadcrumb で使っているため残る。
+
+### 影響範囲
+
+- **変更ファイル**: `run-detail-content.tsx`, `schema-types.ts`
+- **新規ファイル**: 5ファイル (`run-header.tsx`, `run-checks-section.tsx`, `artifact-summary-section.tsx`, `artifacts-table.tsx`, `run-diff-summary-card.tsx`)
+- **削除ファイル**: なし
+- **他コンポーネントへの影響**: なし（`RunDetailContent` の外部インターフェース（Props）は変更なし）
+
+### 設計方針
+
+1. **条件付きレンダリングはセクション内部で行う**: `RunChecksSection` は `checks.length === 0` なら `null`、`ArtifactsTable` は `artifacts.length === 0` なら `null`、`RunDiffSummaryCard` は `diff === null && diffErrorMessage === null` なら `null` を返す。親の条件分岐を不要にして `RunDetailContent` を薄くする。
+2. **`'use client'` ディレクティブは不要**: セクションコンポーネントは hooks を使わない（データは props 経由）。`RunDetailContent` のみ `'use client'` を持つ。
+3. **export は named export**: 既存プロジェクトパターンに合わせる。
+4. **ファイル命名はkebab-case**: 既存パターン (`run-detail-content.tsx`, `artifact-viewer-section.tsx`) に合わせる。
+
+### テスト観点
+
+- **既存テスト**: フロントエンドにはユニットテストフレームワークが導入されていないため、既存テストへの影響なし
+- **新規テスト**: 表示仕様が変わらない純粋リファクタリングのため不要
+- **検証方法**: `pnpm lint && pnpm typecheck && pnpm build` の3コマンドで静的検証
+
+### ドキュメント更新対象
+
+- なし（内部リファクタリングのため API/仕様ドキュメントの変更なし）
+
+### 実装要否
+
+**`implementation_required`**
+
+### 未解決の疑問
+
+- なし（純粋な内部リファクタリングのため仕様判断が不要）
+
+### 検証手順
+
+```bash
+cd boardflow
+pnpm lint
+pnpm typecheck
+pnpm build
+```
+
+### 実装順序
+
+1. `schema-types.ts` に型エイリアス追加
+2. 5つのセクションコンポーネントを新規作成（順序不問、並行可能）
+3. `run-detail-content.tsx` を変更（セクションコンポーネントに切り替え、不要importを削除）
+4. `pnpm lint && pnpm typecheck && pnpm build` で検証
+
+## 残リスク
+
+- なし（表示仕様変更なしの純粋リファクタリング）
+
+## 実装 (implフェーズ: 2026-05-14)
+
+### ブランチ
+`refactor/run-detail-sections`
+
+### 変更ファイル
+
+#### 新規作成
+- `boardflow/src/components/run-detail/run-header.tsx` — Run ヘッダー (ステータスバッジ, SHA, ブランチ, 日時)
+- `boardflow/src/components/run-detail/run-checks-section.tsx` — Checks セクション (ERC/DRC カード)
+- `boardflow/src/components/run-detail/artifact-summary-section.tsx` — Artifact Summary バッジ群
+- `boardflow/src/components/run-detail/artifacts-table.tsx` — Artifacts テーブル
+- `boardflow/src/components/run-detail/run-diff-summary-card.tsx` — Changes from Baseline カード
+
+#### 変更
+- `boardflow/src/lib/api/schema-types.ts` — `ArtifactSummary`, `BoardRunDetail`, `CheckInfo` 型エイリアス追加
+- `boardflow/src/components/run-detail/run-detail-content.tsx` — セクションコンポーネント呼び出しに置換、不要 import 削除
+
+### テスト結果
+- `pnpm lint` — PASS (Biome format 自動修正後)
+- `pnpm typecheck` — PASS
+- `pnpm build` — PASS (全ルート正常ビルド)
+
+### ドキュメント更新
+- 本 worklog への追記のみ (API/仕様ドキュメント更新不要)
+
+### 実装後の残リスク
+- なし。純粋なリファクタリングで挙動変更なし。

--- a/docs/logs/110/worklog.md
+++ b/docs/logs/110/worklog.md
@@ -331,3 +331,26 @@ pnpm build
 ### 残リスク
 
 - UI 仕様変更はない前提だが、PR本文未確認のため、実際にPRを作る際は更新ドキュメントが「worklog のみ」であることを明示しないと読み手に更新漏れと誤解される余地がある
+
+## PR/完了結果 (prフェーズ: 2026-05-14)
+
+### PRリンク
+
+https://github.com/f0reachARR/boardflow/pull/124
+
+### PR作成条件確認
+
+- review: `pr_ready: true` ✅
+- docs: `docs_ready: true` ✅
+- 未コミット変更: なし（worklogコミット後にpush）✅
+- テスト (pnpm lint / typecheck / build): PASS ✅
+
+### PR概要
+
+- タイトル: `refactor: split RunDetailContent into section components (#110)`
+- ベース: `main` ← `refactor/run-detail-sections`
+- Closes #110
+
+### 残リスク
+
+- UI の微細な崩れは静的検証・差分レビューでは検出できないが、表示ロジックは移動のみのため実質的リスクは低い

--- a/docs/logs/110/worklog.md
+++ b/docs/logs/110/worklog.md
@@ -249,3 +249,85 @@ pnpm build
 
 ### 実装後の残リスク
 - なし。純粋なリファクタリングで挙動変更なし。
+
+## レビュー結果 (reviewフェーズ: 2026-05-14)
+
+### 総評
+
+- Issue #110 の目的である `RunDetailContent` の責務分離は達成されている
+- `run-detail-content.tsx` はデータ取得 + breadcrumb + セクション配置に整理され、表示ロジックの大半は意図した5コンポーネントへ移っている
+- `pnpm lint`, `pnpm typecheck`, `pnpm build` を再確認し、いずれも成功した
+- ベースとの差分確認でも、表示仕様は JSX の抽出が中心で、不必要な仕様変更は見当たらなかった
+
+### 指摘事項
+
+- blocking な指摘はなし
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- `RunHeader` は [boardflow/src/components/run-detail/run-header.tsx](boardflow/src/components/run-detail/run-header.tsx) で `BoardRunDetail` 全体を受け取っており、他セクションほど厳密に props を絞ってはいない。計画とは整合しているため修正必須ではないが、将来的にさらに疎結合にするなら header 表示に必要なフィールドへ絞ってもよい
+- [boardflow/src/components/run-detail/run-detail-content.tsx](boardflow/src/components/run-detail/run-detail-content.tsx#L62) の `diffError` 取り出しには依然として型キャストが残っている。Issue の主目的は満たしているが、型安全性をもう一段上げる余地はある
+
+### テスト結果
+
+- `cd boardflow && pnpm lint` — PASS
+- `cd boardflow && pnpm typecheck` — PASS
+- `cd boardflow && pnpm build` — PASS
+
+### ドキュメント確認
+
+- [docs/spec.md](docs/spec.md) と Issue 本文の観点では、今回の変更は内部リファクタリングに留まり、仕様差分は確認されなかった
+- 更新対象として妥当だったのは本 worklog のみで、README などの追加更新は不要と判断した
+
+### PR/完了結果
+
+- `pr_ready: true`
+
+### 残リスク
+
+- 表示不変性の確認は差分レビューと静的検証が中心で、視覚回帰テストや画面確認ログはない。そのため UI の微細な崩れはレビュー上の残留リスクとして残る
+
+## ドキュメント確認 (docsフェーズ: 2026-05-14)
+
+### 総評
+
+- Issue #110 の変更は `RunDetailContent` の内部責務分割に留まり、仕様、API、運用手順、外部調査メモの更新を要する差分は確認されなかった
+- [AGENTS.md](AGENTS.md) の frontend 配置方針、命名、検証コマンドと今回の変更内容は整合している
+- [docs/frontend/summary.md](docs/frontend/summary.md) の画面責務・UI 方針とも矛盾はなく、追記必須の利用者向け仕様変更はない
+
+### docs_ready
+
+- `docs_ready: true`
+
+### 必須修正
+
+- なし
+
+### 任意改善
+
+- PR本文を作成する場合は、`.github/agents/pr.agent.md` の要件どおり、要件・調査結果・実装概要・テスト結果・更新ドキュメント・残リスク・review/docs 判定を明記するとよい
+
+### 不整合のあるドキュメント
+
+- なし
+
+### 不足しているドキュメント
+
+- なし
+
+### 外部調査メモに関する指摘
+
+- 外部調査不要という判断と実装内容に矛盾はない。新規ライブラリ導入や外部API変更がなく、`docs/external/` の追加更新は不要
+
+### PR/完了結果
+
+- PR本文案はワークスペース内で確認できず、本文そのもののレビューは未実施
+- ドキュメント観点では PR 作成に進めてよい
+
+### 残リスク
+
+- UI 仕様変更はない前提だが、PR本文未確認のため、実際にPRを作る際は更新ドキュメントが「worklog のみ」であることを明示しないと読み手に更新漏れと誤解される余地がある


### PR DESCRIPTION
## 要件

Issue #110:  (~350行) を5つのセクションコンポーネントに分割し、親コンポーネントをデータ取得 + Breadcrumb + 配置のオーケストレーターに薄くする。

## 調査結果

外部調査不要。純粋な内部リファクタリング。新規ライブラリ導入なし、バックエンドエンドポイント変更なし。

## 実装概要

### 新規作成 (5ファイル)
- `boardflow/src/components/run-detail/run-header.tsx` — Run ID + ステータスバッジ + メタ情報
- `boardflow/src/components/run-detail/run-checks-section.tsx` — Checks カード群
- `boardflow/src/components/run-detail/artifact-summary-section.tsx` — Artifact Summary バッジ群
- `boardflow/src/components/run-detail/artifacts-table.tsx` — Artifacts テーブル
- `boardflow/src/components/run-detail/run-diff-summary-card.tsx` — Changes from Baseline カード

### 変更 (2ファイル)
- `boardflow/src/lib/api/schema-types.ts` — `ArtifactSummary`, `BoardRunDetail`, `CheckInfo` 型エイリアス追加
- `boardflow/src/components/run-detail/run-detail-content.tsx` — ~350行 → ~112行に削減（セクションコンポーネント呼び出しに置換）

## テスト結果

| チェック | 結果 |
|---|---|
| `pnpm lint` | PASS |
| `pnpm typecheck` | PASS |
| `pnpm build` | PASS |

## 更新ドキュメント

- `docs/logs/110/worklog.md`（作業ログのみ）
- API仕様・README等の更新は不要（内部リファクタリングのため）

## 外部調査メモ

外部調査なし。

## 挙動変更について

**挙動変更なし。** JSX の抽出・移動のみで、表示仕様は一切変更していない。

## 残リスク

- UI の微細な崩れは静的検証・差分レビューでは検出できないが、表示ロジックは移動のみのため実質的リスクは低い
- `RunHeader` の props は `BoardRunDetail` 全体を受け取る粒度（将来の改善余地あり、今回は必須修正なし）

## review/docs OK判定

- review: `pr_ready: true`（blocking指摘なし）
- docs: `docs_ready: true`（更新対象ドキュメントなし）

Closes #110