### PR TITLE
refactor: extract authorization helpers into services/authz (#97)

### DIFF
--- a/crates/api/src/routes/read/artifacts.rs
+++ b/crates/api/src/routes/read/artifacts.rs
@@ -12,7 +12,7 @@ use crate::extractors::AuthenticatedSession;
 use crate::github_access::DynGithubAccessChecker;
 
 use super::dto::ArtifactListItem;
-use crate::github_access::access_result_to_error;
+use crate::services::authz::ensure_board_run_access;
 
 #[derive(Debug, Serialize, ToSchema)]
 pub struct ArtifactListResponse {
@@ -44,20 +44,14 @@ pub async fn list_artifacts(
         .map_err(|_| AppError::validation_failed("invalid board_run_id format", &request_id))?;
 
     // Check repository access via board_run → board_project → repository
-    let repo = boardflow_db::queries::board_run::find_repository_by_board_run_id(&pool, id)
-        .await
-        .map_err(|e| {
-            tracing::error!("list_artifacts repo lookup failed: {e}");
-            AppError::internal_error("database error", &request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("board run not found", &request_id))?;
-
-    let result = access_checker
-        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "board run not found", &request_id) {
-        return Err(err);
-    }
+    ensure_board_run_access(
+        &pool,
+        &access_checker,
+        &session.user.github_access_token,
+        id,
+        &request_id,
+    )
+    .await?;
 
     let artifacts = boardflow_db::queries::artifact::list_by_board_run(&pool, id)
         .await

--- a/crates/api/src/routes/read/board_projects.rs
+++ b/crates/api/src/routes/read/board_projects.rs
@@ -13,7 +13,7 @@ use super::dto::{
     BoardProjectDetailResponse, BoardProjectListItem, RepositoryRef, derive_board_project_state,
     parse_board_run_status,
 };
-use crate::github_access::access_result_to_error;
+use crate::services::authz::{check_repo_access, ensure_repository_access};
 
 // ─── GET /api/v1/repositories/{github_repository_id}/board-projects ──────────
 
@@ -38,20 +38,14 @@ pub async fn list_board_projects(
     Path(github_repository_id): Path<i64>,
     Query(params): Query<PaginationParams>,
 ) -> Result<Json<PaginatedResponse<BoardProjectListItem>>, AppError> {
-    let repo = boardflow_db::queries::repository::find_by_github_id(&pool, github_repository_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("list_board_projects repo lookup failed: {e}");
-            AppError::internal_error("database error", &request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("repository not found", &request_id))?;
-
-    let result = access_checker
-        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "repository not found", &request_id) {
-        return Err(err);
-    }
+    let repo = ensure_repository_access(
+        &pool,
+        &access_checker,
+        &session.user.github_access_token,
+        github_repository_id,
+        &request_id,
+    )
+    .await?;
 
     let limit = params.effective_limit();
     let cursor = params.decoded_cursor(&request_id)?;
@@ -141,19 +135,15 @@ pub async fn get_board_project(
         })?
         .ok_or_else(|| AppError::not_found("board project not found", &request_id))?;
 
-    if let Some(err) = access_result_to_error(
-        &access_checker
-            .check_access(
-                &session.user.github_access_token,
-                &row.repo_owner,
-                &row.repo_name,
-            )
-            .await,
+    check_repo_access(
+        &access_checker,
+        &session.user.github_access_token,
+        &row.repo_owner,
+        &row.repo_name,
         "board project not found",
         &request_id,
-    ) {
-        return Err(err);
-    }
+    )
+    .await?;
 
     // Get latest run status for state derivation
     let latest_run_status = boardflow_db::queries::board_project::get_latest_run_status(&pool, id)

--- a/crates/api/src/routes/read/board_runs.rs
+++ b/crates/api/src/routes/read/board_runs.rs
@@ -11,7 +11,7 @@ use crate::github_access::DynGithubAccessChecker;
 use crate::pagination::{PaginatedResponse, PaginationParams, encode_cursor};
 
 use super::dto::{ArtifactSummary, BoardRunDetailResponse, BoardRunListItem, CheckInfo};
-use crate::github_access::access_result_to_error;
+use crate::services::authz::{ensure_board_project_access, ensure_board_run_access};
 
 // ─── GET /api/v1/board-projects/{board_project_id}/board-runs ────────────────
 
@@ -42,21 +42,14 @@ pub async fn list_board_runs(
         .map_err(|_| AppError::validation_failed("invalid board_project_id format", &request_id))?;
 
     // Verify board_project exists and check repository access
-    let repo =
-        boardflow_db::queries::board_project::find_repository_by_board_project_id(&pool, bp_id)
-            .await
-            .map_err(|e| {
-                tracing::error!("list_board_runs repo lookup failed: {e}");
-                AppError::internal_error("database error", &request_id)
-            })?
-            .ok_or_else(|| AppError::not_found("board project not found", &request_id))?;
-
-    let result = access_checker
-        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "board project not found", &request_id) {
-        return Err(err);
-    }
+    ensure_board_project_access(
+        &pool,
+        &access_checker,
+        &session.user.github_access_token,
+        bp_id,
+        &request_id,
+    )
+    .await?;
 
     let limit = params.effective_limit();
     let cursor = params.decoded_cursor(&request_id)?;
@@ -134,20 +127,14 @@ pub async fn get_board_run(
         .map_err(|_| AppError::validation_failed("invalid board_run_id format", &request_id))?;
 
     // Check repository access via board_run → board_project → repository
-    let repo = boardflow_db::queries::board_run::find_repository_by_board_run_id(&pool, id)
-        .await
-        .map_err(|e| {
-            tracing::error!("get_board_run repo lookup failed: {e}");
-            AppError::internal_error("database error", &request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("board run not found", &request_id))?;
-
-    let result = access_checker
-        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "board run not found", &request_id) {
-        return Err(err);
-    }
+    ensure_board_run_access(
+        &pool,
+        &access_checker,
+        &session.user.github_access_token,
+        id,
+        &request_id,
+    )
+    .await?;
 
     let run = boardflow_db::queries::board_run::find_by_id(&pool, id)
         .await

--- a/crates/api/src/routes/read/diff.rs
+++ b/crates/api/src/routes/read/diff.rs
@@ -9,7 +9,7 @@ use crate::extractors::AuthenticatedSession;
 use crate::github_access::DynGithubAccessChecker;
 
 use super::dto::{BoardRunDiffResponse, DiffMetadataResponse};
-use crate::github_access::access_result_to_error;
+use crate::services::authz::ensure_board_run_access;
 
 // ─── GET /api/v1/board-runs/{board_run_id}/diff ──────────────────────────────
 
@@ -39,20 +39,14 @@ pub async fn get_board_run_diff(
         .map_err(|_| AppError::validation_failed("invalid board_run_id format", &request_id))?;
 
     // Check repository access via board_run → board_project → repository
-    let repo = boardflow_db::queries::board_run::find_repository_by_board_run_id(&pool, id)
-        .await
-        .map_err(|e| {
-            tracing::error!("get_board_run_diff repo lookup failed: {e}");
-            AppError::internal_error("database error", &request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("board run not found", &request_id))?;
-
-    let result = access_checker
-        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "board run not found", &request_id) {
-        return Err(err);
-    }
+    ensure_board_run_access(
+        &pool,
+        &access_checker,
+        &session.user.github_access_token,
+        id,
+        &request_id,
+    )
+    .await?;
 
     // Get diff
     let diff = boardflow_db::queries::diff::find_diff_by_board_run_id(&pool, id)

--- a/crates/api/src/routes/read/findings.rs
+++ b/crates/api/src/routes/read/findings.rs
@@ -12,7 +12,7 @@ use crate::extractors::AuthenticatedSession;
 use crate::github_access::DynGithubAccessChecker;
 use crate::pagination::{PaginatedResponse, decode_findings_cursor, encode_findings_cursor};
 
-use crate::github_access::access_result_to_error;
+use crate::services::authz::ensure_board_run_access;
 
 fn check_kind_str(kind: CheckKind) -> &'static str {
     match kind {
@@ -142,20 +142,14 @@ pub async fn list_findings(
     };
 
     // 5. Check repository access (same pattern as get_board_run)
-    let repo = boardflow_db::queries::board_run::find_repository_by_board_run_id(&pool, br_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("list_findings repo lookup failed: {e}");
-            AppError::internal_error("database error", &request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("board run not found", &request_id))?;
-
-    let result = access_checker
-        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "board run not found", &request_id) {
-        return Err(err);
-    }
+    ensure_board_run_access(
+        &pool,
+        &access_checker,
+        &session.user.github_access_token,
+        br_id,
+        &request_id,
+    )
+    .await?;
 
     // 6. Find run_check by board_run_id + check_kind
     let run_check = boardflow_db::queries::run_check::find_by_board_run_and_kind(

--- a/crates/api/src/routes/read/repositories.rs
+++ b/crates/api/src/routes/read/repositories.rs
@@ -8,7 +8,8 @@ use crate::github_access::DynGithubAccessChecker;
 use crate::pagination::{PaginatedResponse, PaginationParams, encode_repository_cursor};
 
 use super::dto::{RepositoryDetailResponse, RepositoryListItem, parse_board_run_status};
-use crate::github_access::{access_error_to_app_error, access_result_to_error};
+use crate::github_access::access_error_to_app_error;
+use crate::services::authz::ensure_repository_access;
 
 // ─── GET /api/v1/repositories ────────────────────────────────────────────────
 
@@ -104,20 +105,14 @@ pub async fn get_repository(
     State(pool): State<PgPool>,
     Path(github_repository_id): Path<i64>,
 ) -> Result<Json<RepositoryDetailResponse>, AppError> {
-    let repo = boardflow_db::queries::repository::find_by_github_id(&pool, github_repository_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("get_repository failed: {e}");
-            AppError::internal_error("database error", &request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("repository not found", &request_id))?;
-
-    let result = access_checker
-        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "repository not found", &request_id) {
-        return Err(err);
-    }
+    let repo = ensure_repository_access(
+        &pool,
+        &access_checker,
+        &session.user.github_access_token,
+        github_repository_id,
+        &request_id,
+    )
+    .await?;
 
     let board_project_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM board_projects WHERE repository_id = $1")

--- a/crates/api/src/routes/read/viewer_sources.rs
+++ b/crates/api/src/routes/read/viewer_sources.rs
@@ -15,7 +15,7 @@ use super::dto::{
     ViewerAvailabilityStatus, ViewerDownload, ViewerMap, ViewerSource, ViewerSourceKind,
     ViewerSourcesResponse, ViewerStatus,
 };
-use crate::github_access::access_result_to_error;
+use crate::services::authz::ensure_board_run_access;
 
 fn find_artifact(artifacts: &[Artifact], artifact_type: ArtifactType) -> Option<&Artifact> {
     artifacts
@@ -95,20 +95,14 @@ pub async fn get_viewer_sources(
         .map_err(|_| AppError::validation_failed("invalid board_run_id format", &request_id))?;
 
     // Check repository access via board_run → board_project → repository
-    let repo = boardflow_db::queries::board_run::find_repository_by_board_run_id(&pool, id)
-        .await
-        .map_err(|e| {
-            tracing::error!("get_viewer_sources repo lookup failed: {e}");
-            AppError::internal_error("database error", &request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("board run not found", &request_id))?;
-
-    let result = access_checker
-        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "board run not found", &request_id) {
-        return Err(err);
-    }
+    ensure_board_run_access(
+        &pool,
+        &access_checker,
+        &session.user.github_access_token,
+        id,
+        &request_id,
+    )
+    .await?;
 
     // Verify board_run exists
     boardflow_db::queries::board_run::find_by_id(&pool, id)

--- a/crates/api/src/services/api_token.rs
+++ b/crates/api/src/services/api_token.rs
@@ -7,8 +7,9 @@ use utoipa::ToSchema;
 use uuid::Uuid;
 
 use crate::error::AppError;
-use crate::github_access::{DynGithubAccessChecker, access_result_to_error};
+use crate::github_access::DynGithubAccessChecker;
 use crate::pagination::{PaginatedResponse, PaginationParams, encode_cursor};
+use crate::services::authz::ensure_repository_access;
 
 // ─── Request / Response types ────────────────────────────────────────────────
 
@@ -77,22 +78,15 @@ pub(crate) async fn execute_create_api_token(
         ));
     }
 
-    // Lookup repository
-    let repo = boardflow_db::queries::repository::find_by_github_id(pool, github_repository_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("find_by_github_id failed: {e}");
-            AppError::internal_error("database error", request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("repository not found", request_id))?;
-
-    // Access check
-    let result = access_checker
-        .check_access(github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "repository not found", request_id) {
-        return Err(err);
-    }
+    // Lookup repository + access check
+    let repo = ensure_repository_access(
+        pool,
+        access_checker,
+        github_access_token,
+        github_repository_id,
+        request_id,
+    )
+    .await?;
 
     // Generate token
     let raw_token = generate_raw_token();
@@ -129,22 +123,15 @@ pub(crate) async fn execute_list_api_tokens(
     params: &PaginationParams,
     request_id: &str,
 ) -> Result<PaginatedResponse<ApiTokenListItem>, AppError> {
-    // Lookup repository
-    let repo = boardflow_db::queries::repository::find_by_github_id(pool, github_repository_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("find_by_github_id failed: {e}");
-            AppError::internal_error("database error", request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("repository not found", request_id))?;
-
-    // Access check
-    let result = access_checker
-        .check_access(github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "repository not found", request_id) {
-        return Err(err);
-    }
+    // Lookup repository + access check
+    let repo = ensure_repository_access(
+        pool,
+        access_checker,
+        github_access_token,
+        github_repository_id,
+        request_id,
+    )
+    .await?;
 
     // Pagination
     let limit = params.effective_limit();
@@ -201,22 +188,15 @@ pub(crate) async fn execute_revoke_api_token(
     let token_id = Uuid::parse_str(token_id_str)
         .map_err(|_| AppError::validation_failed("invalid token_id format", request_id))?;
 
-    // Lookup repository
-    let repo = boardflow_db::queries::repository::find_by_github_id(pool, github_repository_id)
-        .await
-        .map_err(|e| {
-            tracing::error!("find_by_github_id failed: {e}");
-            AppError::internal_error("database error", request_id)
-        })?
-        .ok_or_else(|| AppError::not_found("repository not found", request_id))?;
-
-    // Access check
-    let result = access_checker
-        .check_access(github_access_token, &repo.owner, &repo.name)
-        .await;
-    if let Some(err) = access_result_to_error(&result, "repository not found", request_id) {
-        return Err(err);
-    }
+    // Lookup repository + access check
+    let repo = ensure_repository_access(
+        pool,
+        access_checker,
+        github_access_token,
+        github_repository_id,
+        request_id,
+    )
+    .await?;
 
     // Revoke (idempotent: COALESCE keeps existing revoked_at)
     let token = boardflow_db::queries::api_token::revoke(pool, token_id, repo.id)

--- a/crates/api/src/services/authz.rs
+++ b/crates/api/src/services/authz.rs
@@ -1,0 +1,196 @@
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use boardflow_domain::models::repository::Repository;
+
+use crate::error::AppError;
+use crate::github_access::{DynGithubAccessChecker, access_result_to_error};
+
+/// Verify GitHub access for a repository identified by its `github_repository_id`.
+///
+/// Returns the `Repository` row on success.
+pub async fn ensure_repository_access(
+    pool: &PgPool,
+    access_checker: &DynGithubAccessChecker,
+    github_access_token: &str,
+    github_repository_id: i64,
+    request_id: &str,
+) -> Result<Repository, AppError> {
+    let repo = boardflow_db::queries::repository::find_by_github_id(pool, github_repository_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("ensure_repository_access repo lookup failed: {e}");
+            AppError::internal_error("database error", request_id)
+        })?
+        .ok_or_else(|| AppError::not_found("repository not found", request_id))?;
+
+    check_repo_access(
+        access_checker,
+        github_access_token,
+        &repo.owner,
+        &repo.name,
+        "repository not found",
+        request_id,
+    )
+    .await?;
+
+    Ok(repo)
+}
+
+/// Verify GitHub access for the repository that owns a given board run.
+///
+/// Returns the `Repository` row on success.
+pub async fn ensure_board_run_access(
+    pool: &PgPool,
+    access_checker: &DynGithubAccessChecker,
+    github_access_token: &str,
+    board_run_id: Uuid,
+    request_id: &str,
+) -> Result<Repository, AppError> {
+    let repo =
+        boardflow_db::queries::board_run::find_repository_by_board_run_id(pool, board_run_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("ensure_board_run_access repo lookup failed: {e}");
+                AppError::internal_error("database error", request_id)
+            })?
+            .ok_or_else(|| AppError::not_found("board run not found", request_id))?;
+
+    check_repo_access(
+        access_checker,
+        github_access_token,
+        &repo.owner,
+        &repo.name,
+        "board run not found",
+        request_id,
+    )
+    .await?;
+
+    Ok(repo)
+}
+
+/// Verify GitHub access for the repository that owns a given board project.
+///
+/// Returns the `Repository` row on success.
+pub async fn ensure_board_project_access(
+    pool: &PgPool,
+    access_checker: &DynGithubAccessChecker,
+    github_access_token: &str,
+    board_project_id: Uuid,
+    request_id: &str,
+) -> Result<Repository, AppError> {
+    let repo = boardflow_db::queries::board_project::find_repository_by_board_project_id(
+        pool,
+        board_project_id,
+    )
+    .await
+    .map_err(|e| {
+        tracing::error!("ensure_board_project_access repo lookup failed: {e}");
+        AppError::internal_error("database error", request_id)
+    })?
+    .ok_or_else(|| AppError::not_found("board project not found", request_id))?;
+
+    check_repo_access(
+        access_checker,
+        github_access_token,
+        &repo.owner,
+        &repo.name,
+        "board project not found",
+        request_id,
+    )
+    .await?;
+
+    Ok(repo)
+}
+
+/// Low-level access check: call `check_access` and convert the result.
+///
+/// Returns `Ok(())` if access is allowed, or an `AppError` mapping
+/// `Denied` → `not_found` (security: do not reveal repo existence).
+pub async fn check_repo_access(
+    access_checker: &DynGithubAccessChecker,
+    github_access_token: &str,
+    owner: &str,
+    name: &str,
+    not_found_msg: &str,
+    request_id: &str,
+) -> Result<(), AppError> {
+    let result = access_checker
+        .check_access(github_access_token, owner, name)
+        .await;
+    if let Some(err) = access_result_to_error(&result, not_found_msg, request_id) {
+        return Err(err);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::error::ErrorCode;
+    use crate::github_access::{
+        AllowAllGithubAccessChecker, DenyAllGithubAccessChecker, DynGithubAccessChecker,
+        RateLimitedGithubAccessChecker, TokenExpiredGithubAccessChecker,
+        UpstreamErrorGithubAccessChecker,
+    };
+
+    use super::check_repo_access;
+
+    /// Allowed → Ok(())
+    #[tokio::test]
+    async fn check_repo_access_allowed() {
+        let checker: DynGithubAccessChecker = Arc::new(AllowAllGithubAccessChecker);
+        let result =
+            check_repo_access(&checker, "token", "owner", "repo", "not found", "req-1").await;
+        assert!(result.is_ok());
+    }
+
+    /// Denied → not_found with the caller-supplied message (security: hide repo existence)
+    #[tokio::test]
+    async fn check_repo_access_denied_returns_not_found() {
+        let checker: DynGithubAccessChecker = Arc::new(DenyAllGithubAccessChecker);
+        let err = check_repo_access(
+            &checker,
+            "token",
+            "owner",
+            "repo",
+            "board run not found",
+            "req-2",
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::NotFound);
+        assert_eq!(err.message, "board run not found");
+    }
+
+    /// TokenExpired → 401 unauthorized
+    #[tokio::test]
+    async fn check_repo_access_token_expired() {
+        let checker: DynGithubAccessChecker = Arc::new(TokenExpiredGithubAccessChecker);
+        let err = check_repo_access(&checker, "token", "owner", "repo", "not found", "req-3")
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::Unauthorized);
+    }
+
+    /// RateLimited → 429
+    #[tokio::test]
+    async fn check_repo_access_rate_limited() {
+        let checker: DynGithubAccessChecker = Arc::new(RateLimitedGithubAccessChecker);
+        let err = check_repo_access(&checker, "token", "owner", "repo", "not found", "req-4")
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::RateLimited);
+    }
+
+    /// UpstreamError → 500
+    #[tokio::test]
+    async fn check_repo_access_upstream_error() {
+        let checker: DynGithubAccessChecker = Arc::new(UpstreamErrorGithubAccessChecker);
+        let err = check_repo_access(&checker, "token", "owner", "repo", "not found", "req-5")
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::InternalError);
+    }
+}

--- a/crates/api/src/services/mod.rs
+++ b/crates/api/src/services/mod.rs
@@ -1,3 +1,4 @@
 pub mod api_token;
+pub mod authz;
 pub mod board_run;
 pub mod plan;

--- a/docs/logs/97/worklog.md
+++ b/docs/logs/97/worklog.md
@@ -752,3 +752,98 @@ After:
 ### 残リスク
 - `database::tests::from_env_succeeds_when_database_url_set` (boardflow-config) が環境変数未設定で失敗するが、本Issue とは無関係の既存問題。
 - tracing ログメッセージが `ensure_*` 関数のものに統一されたため、既存のログ文字列に依存するモニタリングがあれば調整が必要 (ただし内部ログのため外部影響なし)。
+
+---
+
+## レビュー結果 (review フェーズ)
+
+### 対象Issue
+- Issue #97: APIのrepository access認可処理を共通サービス化する
+
+### 総評
+- 実装は Issue の「挙動変更なしの抽出」という方針に沿っており、`Denied -> not_found` の情報秘匿も維持されている。
+- `services/authz.rs` への集約で、repo lookup + access check + `AppError` 変換の重複は解消されている。
+- blocking な不整合は見つからなかったため、PR 作成は可能と判断する。
+
+### セキュリティ確認
+- `check_repo_access()` は [crates/api/src/services/authz.rs](crates/api/src/services/authz.rs#L110) で `access_result_to_error()` に委譲しており、`Denied` は [crates/api/src/github_access/error_conversion.rs](crates/api/src/github_access/error_conversion.rs#L11) で引き続き `not_found` に変換される。
+- `get_board_project` でも [crates/api/src/routes/read/board_projects.rs](crates/api/src/routes/read/board_projects.rs#L138) から `check_repo_access()` を呼んでおり、JOIN 済みの `repo_owner` / `repo_name` で別クエリなしに同じ秘匿ルールを適用している。
+- `not_found_msg` は各パターンで変更前と同じ固定文字列のまま維持されている。
+
+### 実装確認
+- `ensure_repository_access()` の 5 呼び出し、`ensure_board_run_access()` の 5 呼び出し、`ensure_board_project_access()` の 1 呼び出し、`check_repo_access()` の 1 呼び出しを確認し、Issue 本文の置換対象と一致した。
+- `list_repositories` は [crates/api/src/routes/read/repositories.rs](crates/api/src/routes/read/repositories.rs#L33) で従来どおり `list_accessible_repo_ids` + `access_error_to_app_error` を使っており、共通化対象外の特殊パターンとして適切に維持されている。
+- 置換後に `routes/read` 配下へ `check_access()` / `access_result_to_error()` の直接呼び出しは残っていない。
+
+### テスト確認
+- 実行確認: `mise exec -- cargo test -p boardflow-api check_repo_access --lib` → 5 件 pass。
+- 実行確認: `mise exec -- cargo test -p boardflow-api --test read_api_test denied` → 8 件 pass。
+- 実行確認: `mise exec -- cargo test -p boardflow-api --test read_api_test rate_limited` → 2 件 pass。
+- 実行確認: `mise exec -- cargo test -p boardflow-api --test read_api_test upstream` → 2 件 pass。
+- 実行確認: `mise exec -- cargo test -p boardflow-api --test api_token_test denied` → 3 件 pass。
+- `check_repo_access` の unit test は Allowed / Denied / TokenExpired / RateLimited / Upstream を全て網羅している。
+
+### ドキュメント確認
+- [docs/backend/api.md](docs/backend/api.md#L83) と [docs/backend/api.md](docs/backend/api.md#L567) は、「存在しない resource と閲覧不可 resource をともに `404 not_found` で秘匿してよい」という契約を維持しており、今回の抽出実装と整合している。
+- 本 Issue は純粋な内部リファクタリングのため、追加の公開ドキュメント更新は必須ではない。
+
+### 指摘事項
+- blocking な指摘なし。
+
+### 必須修正
+- なし。
+
+### 任意改善
+- [crates/api/src/services/authz.rs](crates/api/src/services/authz.rs#L110) の `check_repo_access()` は `not_found_msg` を呼び出し側に委ねるため、将来の呼び出し追加時にメッセージ取り違えの余地はある。現状 1 箇所のみで問題はないが、必要なら専用 wrapper を増やしてもよい。
+
+### テスト不足
+- 非 blocking。`TokenExpired -> 401` は unit test で確認済みだが、read API / api_token API の HTTP レベル統合テストには今回直接触れられていない。
+- 非 blocking。`RateLimited -> 429` / `Upstream -> 500` の統合テストは repository endpoint で確認できる一方、board_run 系 endpoint では helper 共有による間接担保に留まる。
+
+### plan / research / docs との不整合
+- なし。計画にあった `services/authz.rs` 追加、11 箇所の置換、`get_board_project` の低レベル helper 利用、`list_repositories` 除外、既存挙動維持は実装と一致している。
+
+### PR/完了結果
+- `pr_ready: true`
+
+### 残リスク
+- 共通 helper の採用で変換ロジックは一箇所化されたが、今後新規 endpoint が `check_repo_access()` を直接使う場合は `not_found_msg` の選定ミスに注意が必要。
+
+---
+
+## ドキュメント確認 (docs フェーズ)
+
+### 対象Issue
+- Issue #97: APIのrepository access認可処理を共通サービス化する
+
+### 確認対象
+- `docs/backend/summary.md`
+- `docs/backend/api.md`
+- `docs/spec.md`
+- `AGENTS.md`
+- `docs/logs/97/worklog.md`
+
+### 確認結果
+- `docs/backend/summary.md`: backend 全体の責務、API 契約、認証/認可方針を記述する高レベル文書であり、`crates/api/src/services/` 配下の個別モジュール一覧は管理していない。`services/authz.rs` 追加を反映しなくても記述粒度として整合している。
+- `docs/backend/api.md`: 外部 API 契約の変更はなく、閲覧不可を `404 not_found` で秘匿する方針とも今回の実装は一致しているため更新不要。
+- `docs/spec.md`: SaaS の責務と GitHub 権限ベースの認可方針に変更はなく、Issue #97 に伴う追記は不要。
+- `AGENTS.md`: リポジトリ構成、開発コマンド、一般的なガイドラインのみを記述しており、内部の service helper 抽出による更新は不要。
+- `docs/logs/97/worklog.md`: research / plan / impl / review は記録済みで、この docs フェーズ追記により最新状態になった。
+
+### 外部調査メモとの整合
+- 本 Issue は内部リファクタリングであり、research フェーズでも外部調査不要と整理されている。`docs/external/` の追加確認は不要で、既存成果物との矛盾もない。
+
+### 必須修正
+- なし。
+
+### 任意改善
+- なし。
+
+### docs_ready
+- `docs_ready: true`
+
+### ドキュメント観点の残リスク
+- なし。公開仕様と運用文書に影響する変更は含まれていない。
+
+### 更新した作業ログパス
+- `docs/logs/97/worklog.md`

--- a/docs/logs/97/worklog.md
+++ b/docs/logs/97/worklog.md
@@ -847,3 +847,23 @@ After:
 
 ### 更新した作業ログパス
 - `docs/logs/97/worklog.md`
+
+---
+
+## PR作成結果 (pr フェーズ)
+
+### PR情報
+- PR #128: https://github.com/f0reachARR/boardflow/pull/128
+- タイトル: `refactor: extract authorization helpers into services/authz (#97)`
+- ブランチ: `issue-97/authz-service` → `main`
+
+### PR作成条件確認
+- review: `pr_ready: true` — blocking な指摘なし ✓
+- docs: `docs_ready: true` — ドキュメント更新不要 ✓
+- 未コミット変更: なし ✓
+- テスト: 63件全パス ✓
+- cargo clippy / fmt: クリーン ✓
+
+### 残リスク
+- `database::tests::from_env_succeeds_when_database_url_set` は環境変数未設定で失敗するが本 Issue とは無関係の既存問題。
+- tracing ログメッセージが `ensure_*` 関数のものに統一されたため、ログ文字列依存のモニタリングがあれば調整が必要（内部ログのため外部影響なし）。

--- a/docs/logs/97/worklog.md
+++ b/docs/logs/97/worklog.md
@@ -1,0 +1,698 @@
+# Issue #97 — APIのrepository access認可処理を共通サービス化する
+
+## 調査対象
+
+- `crates/api/src/routes/read/` 以下の全handler
+- `crates/api/src/services/` 以下の全service
+- `crates/api/src/github_access/` モジュール（types, error_conversion, test_doubles）
+- `crates/api/src/error.rs` の `AppError` 定義
+- `crates/api/tests/` のテスト構造
+
+---
+
+## 調査結果
+
+### 1. 認可チェックが行われている全ファイル・関数
+
+#### `routes/read/` (handler層)
+
+| ファイル | 関数 | パターン | not_found_msg |
+|---------|------|---------|---------------|
+| `repositories.rs` | `list_repositories` | `list_accessible_repo_ids` + `access_error_to_app_error` | ― |
+| `repositories.rs` | `get_repository` | repo by github_id → `check_access` → `access_result_to_error` | `"repository not found"` |
+| `board_projects.rs` | `list_board_projects` | repo by github_id → `check_access` → `access_result_to_error` | `"repository not found"` |
+| `board_projects.rs` | `get_board_project` | `find_by_id_with_repository` → inline `check_access` → `access_result_to_error` | `"board project not found"` |
+| `board_runs.rs` | `list_board_runs` | repo by board_project_id → `check_access` → `access_result_to_error` | `"board project not found"` |
+| `board_runs.rs` | `get_board_run` | repo by board_run_id → `check_access` → `access_result_to_error` | `"board run not found"` |
+| `diff.rs` | `get_board_run_diff` | repo by board_run_id → `check_access` → `access_result_to_error` | `"board run not found"` |
+| `viewer_sources.rs` | `get_viewer_sources` | repo by board_run_id → `check_access` → `access_result_to_error` | `"board run not found"` |
+| `findings.rs` | `list_findings` | repo by board_run_id → `check_access` → `access_result_to_error` | `"board run not found"` |
+| `artifacts.rs` | `list_artifacts` | repo by board_run_id → `check_access` → `access_result_to_error` | `"board run not found"` |
+
+#### `services/` (service層)
+
+| ファイル | 関数 | パターン | not_found_msg |
+|---------|------|---------|---------------|
+| `api_token.rs` | `execute_create_api_token` | repo by github_id → `check_access` → `access_result_to_error` | `"repository not found"` |
+| `api_token.rs` | `execute_list_api_tokens` | repo by github_id → `check_access` → `access_result_to_error` | `"repository not found"` |
+| `api_token.rs` | `execute_revoke_api_token` | repo by github_id → `check_access` → `access_result_to_error` | `"repository not found"` |
+
+**合計: 13箇所** で認可チェックが行われている。
+
+---
+
+### 2. 重複している認可パターン（3パターン + 1特殊パターン）
+
+#### パターンA: github_repository_id → repo lookup → check_access
+**使用箇所**: `list_board_projects`, `get_repository`, `execute_create_api_token`, `execute_list_api_tokens`, `execute_revoke_api_token` (5箇所)
+
+```rust
+let repo = boardflow_db::queries::repository::find_by_github_id(&pool, github_repository_id)
+    .await
+    .map_err(|e| {
+        tracing::error!("... repo lookup failed: {e}");
+        AppError::internal_error("database error", &request_id)
+    })?
+    .ok_or_else(|| AppError::not_found("repository not found", &request_id))?;
+
+let result = access_checker
+    .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
+    .await;
+if let Some(err) = access_result_to_error(&result, "repository not found", &request_id) {
+    return Err(err);
+}
+```
+
+#### パターンB: board_run_id → repo lookup → check_access
+**使用箇所**: `get_board_run`, `get_board_run_diff`, `get_viewer_sources`, `list_findings`, `list_artifacts` (5箇所)
+
+```rust
+let repo = boardflow_db::queries::board_run::find_repository_by_board_run_id(&pool, id)
+    .await
+    .map_err(|e| {
+        tracing::error!("... repo lookup failed: {e}");
+        AppError::internal_error("database error", &request_id)
+    })?
+    .ok_or_else(|| AppError::not_found("board run not found", &request_id))?;
+
+let result = access_checker
+    .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
+    .await;
+if let Some(err) = access_result_to_error(&result, "board run not found", &request_id) {
+    return Err(err);
+}
+```
+
+#### パターンC: board_project_id → repo lookup → check_access
+**使用箇所**: `list_board_runs` (1箇所)
+
+```rust
+let repo = boardflow_db::queries::board_project::find_repository_by_board_project_id(&pool, bp_id)
+    .await
+    .map_err(|e| {
+        tracing::error!("list_board_runs repo lookup failed: {e}");
+        AppError::internal_error("database error", &request_id)
+    })?
+    .ok_or_else(|| AppError::not_found("board project not found", &request_id))?;
+
+let result = access_checker
+    .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
+    .await;
+if let Some(err) = access_result_to_error(&result, "board project not found", &request_id) {
+    return Err(err);
+}
+```
+
+#### 特殊パターン: list_repositories (pre-filter)
+**使用箇所**: `list_repositories` (1箇所)
+
+```rust
+let accessible_ids = access_checker
+    .list_accessible_repo_ids(token)
+    .await
+    .map_err(|e| access_error_to_app_error(&e, &request_id))?;
+```
+
+`check_access` ではなく `list_accessible_repo_ids` を使用。パターンが異なるため共通化の対象外。
+
+#### get_board_project の変形
+`get_board_project` はパターンAの変形で、`find_by_id_with_repository` クエリの結果から `repo_owner` / `repo_name` を直接取得しているため、別途 repo lookup が不要。
+
+---
+
+### 3. `access_result_to_error` の現在の実装
+
+**場所**: `crates/api/src/github_access/error_conversion.rs`
+
+```rust
+pub fn access_result_to_error(
+    result: &AccessResult,
+    not_found_msg: &str,
+    request_id: &str,
+) -> Option<AppError> {
+    match result {
+        AccessResult::Allowed => None,
+        AccessResult::Denied => Some(AppError::not_found(not_found_msg, request_id)),
+        AccessResult::Error(AccessError::TokenExpired) => Some(AppError::unauthorized(
+            "github session expired, please re-login", request_id,
+        )),
+        AccessResult::Error(AccessError::RateLimited) => Some(AppError::new(
+            crate::error::ErrorCode::RateLimited, "rate limited", request_id,
+        )),
+        AccessResult::Error(AccessError::Upstream(detail)) => {
+            tracing::error!("GitHub API error: {detail}");
+            Some(AppError::internal_error("upstream error", request_id))
+        }
+    }
+}
+
+pub(crate) fn access_error_to_app_error(err: &AccessError, request_id: &str) -> AppError {
+    match err {
+        AccessError::TokenExpired => AppError::unauthorized("github session expired, please re-login", request_id),
+        AccessError::RateLimited => AppError::new(ErrorCode::RateLimited, "rate limited", request_id),
+        AccessError::Upstream(detail) => {
+            tracing::error!("GitHub API error: {detail}");
+            AppError::internal_error("upstream error", request_id)
+        }
+    }
+}
+```
+
+**重要**: `Denied` は `not_found` に変換（forbidden を外部に漏らさない）。この挙動はセキュリティ要件。
+
+---
+
+### 4. `services/` の既存パターン
+
+#### `services/mod.rs`
+```rust
+pub mod api_token;
+pub mod board_run;
+pub mod plan;
+```
+
+#### 構造特徴
+- `plan.rs` / `board_run.rs`: API tokenベースの認可（`token_repository_id` と DB上のrepository_idの一致チェック）。GitHub access checkerは使わない。
+- `api_token.rs`: GitHub session-based認可。`DynGithubAccessChecker` + `access_result_to_error` を使用。handler層と同じパターン。
+
+→ 新しい `services/authz.rs` を追加する場合、`mod.rs` に `pub mod authz;` を追加する形になる。
+
+---
+
+### 5. `AppError` の定義と種別
+
+**場所**: `crates/api/src/error.rs`
+
+```rust
+pub enum ErrorCode {
+    Unauthorized,     // 401
+    Forbidden,        // 403
+    ValidationFailed, // 400
+    NotFound,         // 404
+    Conflict,         // 409
+    Gone,             // 410
+    RateLimited,      // 429
+    InternalError,    // 500
+}
+
+pub struct AppError {
+    pub code: ErrorCode,
+    pub message: String,
+    pub details: Option<serde_json::Value>,
+    pub request_id: String,
+}
+```
+
+便利コンストラクタ: `unauthorized()`, `forbidden()`, `validation_failed()`, `not_found()`, `conflict()`, `gone()`, `internal_error()`, `new()`
+
+`IntoResponse` トレイトでaxum ResponseへHTTP status codeとJSON bodyに変換される。
+
+---
+
+### 6. テストファイルの構造
+
+| ファイル | 内容 |
+|---------|------|
+| `read_api_test.rs` | read系APIの統合テスト。`AllowAll`, `DenyAll`, `RateLimited`, `UpstreamError` の各checker使用。認可テスト含む |
+| `api_token_test.rs` | API tokenのCRUDテスト。`AllowAll`, `DenyAll` 使用 |
+| `proxy_test.rs` | artifact proxy テスト。`AllowAll` 使用 |
+| `github_cache_test.rs` | `CachedGithubAccessChecker` の単体テスト |
+| `auth_test.rs` | ErrorCode, セッション認証テスト |
+| `common.rs` | テストヘルパー（unique ID生成等） |
+
+テストdoubles (`test_doubles.rs`): `AllowAllGithubAccessChecker`, `DenyAllGithubAccessChecker`, `RateLimitedGithubAccessChecker`, `TokenExpiredGithubAccessChecker`, `UpstreamErrorGithubAccessChecker`
+
+---
+
+### 7. 共通化の設計方針
+
+Issueで提案されている `ensure_*` ヘルパーに対応するパターンマッピング:
+
+| 提案ヘルパー | 対応パターン | 使用箇所数 |
+|-------------|------------|----------|
+| `ensure_repository_access(pool, checker, token, github_repo_id, request_id)` | パターンA | 5 |
+| `ensure_board_run_access(pool, checker, token, board_run_id, request_id)` | パターンB | 5 |
+| `ensure_board_project_access(pool, checker, token, board_project_id, request_id)` | パターンC | 1 |
+
+#### 返り値の設計
+- パターンA: `Result<RepositoryRow, AppError>` — 後続処理で `repo.id`, `repo.installation_id` 等を使う
+- パターンB: `Result<RepositoryRow, AppError>` — 後続で `repo` を使う箇所あり（ないものもある）
+- パターンC: `Result<RepositoryRow, AppError>` — 同上
+
+#### 注意点
+- `get_board_project` は `find_by_id_with_repository` で repo 情報を一緒に取得している。repo_owner/repo_nameだけで access check する変形パターン。このhandlerには ensure_board_project_access がそのまま適用できない可能性あり（別クエリで repo を再取得するとN+1になる）。
+- `list_repositories` は `list_accessible_repo_ids` を使う特殊パターン。共通化対象外。
+
+---
+
+## 結論ステータス
+
+**`implementation_required`**
+
+### 根拠
+- 13箇所で認可チェックが重複しており、パターンA/B/Cへの共通化は明確
+- `access_result_to_error` は既にPR #127で抽出済みだが、「repo lookup + access check」の組み合わせがまだ散在
+- 外部ライブラリの調査は不要（純粋な内部リファクタリング）
+
+### 残リスク
+- `get_board_project` の変形パターン：repo情報がすでにJOINで取得済みのため、ensure_board_project_accessを適用すると追加クエリが発生する。handlerの特性に応じて、owner/name を引数に取る低レベル版ヘルパーも検討すべき
+- テスト: `read_api_test.rs` で DenyAll/RateLimited/UpstreamError の統合テストが存在し、リファクタ後も同じ挙動であることを確認可能
+
+### 後続エージェントへの注意点
+1. `services/authz.rs` を新規作成し、`ensure_repository_access`, `ensure_board_run_access`, `ensure_board_project_access` を実装
+2. 各ヘルパーは `Result<RepositoryRow, AppError>` を返し、repo情報を後続処理で使えるようにする
+3. `get_board_project` は独自のクエリ結果（`repo_owner`, `repo_name`）を使うため、低レベルヘルパー（owner/nameだけ受け取る版）を検討
+4. `list_repositories` の `list_accessible_repo_ids` パターンは共通化対象外
+5. 既存の `access_result_to_error` / `access_error_to_app_error` は `error_conversion.rs` に残す（ensure_* から内部で呼ぶ）
+6. テスト: `cargo test --workspace` + 特に `read_api_test.rs`, `api_token_test.rs` の認可テストが通ることを確認
+7. `Denied` → `not_found` 変換のセキュリティ挙動を絶対に変更しない
+
+### 参照URL
+なし（外部調査なし、コードベース内部の調査のみ）
+
+---
+
+---
+
+## 実装計画 (plan フェーズ)
+
+### 目的
+
+handler/service 層に散在する「DB lookup → GitHub access check → AppError 変換」の重複コードを `services/authz.rs` に集約し、認可ロジックの一貫性・保守性を向上させる。
+
+### 非目的
+
+- 認可ロジック自体の挙動変更（Denied → not_found 変換など）
+- `list_repositories` の `list_accessible_repo_ids` パターンの変更
+- `error_conversion.rs` の関数の変更や移動
+- テストの追加（既存テストの通過確認のみ）
+
+### 受け入れ条件
+
+1. `ensure_repository_access` / `ensure_board_run_access` / `ensure_board_project_access` が `services/authz.rs` に実装されている
+2. パターンA/B/C の全11箇所が ensure_* 呼び出しに置き換わっている
+3. `get_board_project` の変形パターンが `check_repo_access` で簡潔に書き直されている
+4. 各 handler/service の not_found_msg 文字列が変更前と完全一致している
+5. `cargo test --workspace` が全パス
+6. `cargo clippy --workspace --all-targets -- -D warnings` が通る
+
+---
+
+### 詳細要件
+
+#### 新規ファイル
+
+**`services/authz.rs`** — 認可ヘルパーモジュール
+
+```rust
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use boardflow_domain::models::repository::Repository;
+
+use crate::error::AppError;
+use crate::github_access::{DynGithubAccessChecker, access_result_to_error};
+
+/// パターンA: github_repository_id → repo lookup → check_access
+/// 使用箇所: get_repository, list_board_projects, execute_create/list/revoke_api_token
+pub async fn ensure_repository_access(
+    pool: &PgPool,
+    access_checker: &DynGithubAccessChecker,
+    github_access_token: &str,
+    github_repository_id: i64,
+    request_id: &str,
+) -> Result<Repository, AppError> {
+    let repo = boardflow_db::queries::repository::find_by_github_id(pool, github_repository_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("repository lookup failed: {e}");
+            AppError::internal_error("database error", request_id)
+        })?
+        .ok_or_else(|| AppError::not_found("repository not found", request_id))?;
+
+    check_repo_access(access_checker, github_access_token, &repo.owner, &repo.name, "repository not found", request_id).await?;
+
+    Ok(repo)
+}
+
+/// パターンB: board_run_id → repo lookup → check_access
+/// 使用箇所: get_board_run, get_board_run_diff, get_viewer_sources, list_findings, list_artifacts
+pub async fn ensure_board_run_access(
+    pool: &PgPool,
+    access_checker: &DynGithubAccessChecker,
+    github_access_token: &str,
+    board_run_id: Uuid,
+    request_id: &str,
+) -> Result<Repository, AppError> {
+    let repo = boardflow_db::queries::board_run::find_repository_by_board_run_id(pool, board_run_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("board run repo lookup failed: {e}");
+            AppError::internal_error("database error", request_id)
+        })?
+        .ok_or_else(|| AppError::not_found("board run not found", request_id))?;
+
+    check_repo_access(access_checker, github_access_token, &repo.owner, &repo.name, "board run not found", request_id).await?;
+
+    Ok(repo)
+}
+
+/// パターンC: board_project_id → repo lookup → check_access
+/// 使用箇所: list_board_runs
+pub async fn ensure_board_project_access(
+    pool: &PgPool,
+    access_checker: &DynGithubAccessChecker,
+    github_access_token: &str,
+    board_project_id: Uuid,
+    request_id: &str,
+) -> Result<Repository, AppError> {
+    let repo = boardflow_db::queries::board_project::find_repository_by_board_project_id(pool, board_project_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("board project repo lookup failed: {e}");
+            AppError::internal_error("database error", request_id)
+        })?
+        .ok_or_else(|| AppError::not_found("board project not found", request_id))?;
+
+    check_repo_access(access_checker, github_access_token, &repo.owner, &repo.name, "board project not found", request_id).await?;
+
+    Ok(repo)
+}
+
+/// 低レベルヘルパー: owner/name を直接受け取って check_access → AppError 変換
+/// 使用箇所: get_board_project（find_by_id_with_repository で取得済みの repo_owner/repo_name を使う）
+pub async fn check_repo_access(
+    access_checker: &DynGithubAccessChecker,
+    github_access_token: &str,
+    owner: &str,
+    name: &str,
+    not_found_msg: &str,
+    request_id: &str,
+) -> Result<(), AppError> {
+    let result = access_checker
+        .check_access(github_access_token, owner, name)
+        .await;
+    if let Some(err) = access_result_to_error(&result, not_found_msg, request_id) {
+        return Err(err);
+    }
+    Ok(())
+}
+```
+
+**設計判断**:
+- `ensure_*` は `Result<Repository, AppError>` を返す。後続処理で `repo.id` や `repo.installation_id` を使う箇所があるため。
+- `check_repo_access` は `Result<(), AppError>` を返す低レベル版。`get_board_project` のように既に owner/name が手元にある場合に使用する。`ensure_*` 内部からも呼ばれる。
+- tracing のエラーメッセージは汎化する（`"repository lookup failed"` 等）。元の個別メッセージ（`"get_repository failed"`, `"list_board_projects repo lookup failed"` 等）は各 handler 固有であり、機能的意味はないため。
+- `not_found_msg` は各呼び出し元から渡すが、`ensure_*` 関数内にハードコードする（パターンごとに固定のため）。
+
+---
+
+### 影響範囲
+
+#### 変更対象ファイル一覧
+
+| # | ファイル (crates/api/src/ 相対) | 変更内容 |
+|---|------|----------|
+| 1 | `services/mod.rs` | `pub mod authz;` 追加 |
+| 2 | `services/authz.rs` | **新規作成** |
+| 3 | `routes/read/repositories.rs` | `get_repository`: パターンA → `ensure_repository_access` |
+| 4 | `routes/read/board_projects.rs` | `list_board_projects`: パターンA → `ensure_repository_access`, `get_board_project`: 変形 → `check_repo_access` |
+| 5 | `routes/read/board_runs.rs` | `list_board_runs`: パターンC → `ensure_board_project_access`, `get_board_run`: パターンB → `ensure_board_run_access` |
+| 6 | `routes/read/diff.rs` | `get_board_run_diff`: パターンB → `ensure_board_run_access` |
+| 7 | `routes/read/viewer_sources.rs` | `get_viewer_sources`: パターンB → `ensure_board_run_access` |
+| 8 | `routes/read/findings.rs` | `list_findings`: パターンB → `ensure_board_run_access` |
+| 9 | `routes/read/artifacts.rs` | `list_artifacts`: パターンB → `ensure_board_run_access` |
+| 10 | `services/api_token.rs` | 3関数: パターンA → `ensure_repository_access` |
+
+#### 変更しないファイル
+
+- `routes/read/repositories.rs` の `list_repositories` — `list_accessible_repo_ids` パターンは対象外
+- `github_access/error_conversion.rs` — `access_result_to_error` / `access_error_to_app_error` はそのまま
+- `github_access/mod.rs` — 再エクスポートは変更不要（`check_repo_access` は `services/authz.rs` から `access_result_to_error` を使うだけ）
+
+---
+
+### 設計方針
+
+1. **`check_repo_access` を内部ビルディングブロックとする**: `ensure_*` 3関数は内部で `check_repo_access` を呼ぶ。`get_board_project` は直接 `check_repo_access` を使う。
+2. **not_found_msg のハードコード**: `ensure_repository_access` は `"repository not found"` 固定、`ensure_board_run_access` は `"board run not found"` 固定、`ensure_board_project_access` は `"board project not found"` 固定。これは現在の全呼び出し箇所と完全一致。
+3. **tracing メッセージの汎化**: 元の handler 名入りメッセージ（e.g., `"list_board_projects repo lookup failed"`, `"get_board_run repo lookup failed"`）は `"repository lookup failed"`, `"board run repo lookup failed"`, `"board project repo lookup failed"` に統一。error ログの構造化が目的であり、元の handler 名は `tracing::Span` から取得可能なため問題なし。
+4. **import 整理**: 置き換え後に不要になる `use crate::github_access::access_result_to_error` を各ファイルから除去。`repositories.rs` の `list_repositories` は `access_error_to_app_error` を引き続き使うため、そちらの import は残す。
+
+---
+
+### 変更の順序
+
+#### Step 1: `services/authz.rs` 新規作成 + `services/mod.rs` 更新
+
+1. `services/authz.rs` を上記シグネチャで作成
+2. `services/mod.rs` に `pub mod authz;` を追加
+3. `cargo check -p boardflow-api` で型エラーがないことを確認
+
+#### Step 2: パターンA — `ensure_repository_access` への置き換え (5箇所)
+
+##### 2a. `routes/read/repositories.rs` — `get_repository`
+
+Before:
+```rust
+use crate::github_access::{access_error_to_app_error, access_result_to_error};
+...
+    let repo = boardflow_db::queries::repository::find_by_github_id(&pool, github_repository_id)
+        .await
+        .map_err(|e| {
+            tracing::error!("get_repository failed: {e}");
+            AppError::internal_error("database error", &request_id)
+        })?
+        .ok_or_else(|| AppError::not_found("repository not found", &request_id))?;
+
+    let result = access_checker
+        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
+        .await;
+    if let Some(err) = access_result_to_error(&result, "repository not found", &request_id) {
+        return Err(err);
+    }
+```
+
+After:
+```rust
+use crate::services::authz::ensure_repository_access;
+// access_error_to_app_error の import は list_repositories で使うため残す
+// access_result_to_error の import は不要になるため削除
+...
+    let repo = ensure_repository_access(
+        &pool, &access_checker, &session.user.github_access_token,
+        github_repository_id, &request_id,
+    ).await?;
+```
+
+Import 変更: `use crate::github_access::{access_error_to_app_error, access_result_to_error};` → `use crate::github_access::access_error_to_app_error;` + `use crate::services::authz::ensure_repository_access;`
+
+##### 2b. `routes/read/board_projects.rs` — `list_board_projects`
+
+Before:
+```rust
+use crate::github_access::access_result_to_error;
+...
+    let repo = boardflow_db::queries::repository::find_by_github_id(&pool, github_repository_id)
+        ...
+    let result = access_checker.check_access(...).await;
+    if let Some(err) = access_result_to_error(...) { ... }
+```
+
+After:
+```rust
+use crate::services::authz::{ensure_repository_access, check_repo_access};
+// access_result_to_error の import は削除
+...
+    let repo = ensure_repository_access(
+        &pool, &access_checker, &session.user.github_access_token,
+        github_repository_id, &request_id,
+    ).await?;
+```
+
+##### 2c. `routes/read/board_projects.rs` — `get_board_project` (変形パターン)
+
+Before:
+```rust
+    if let Some(err) = access_result_to_error(
+        &access_checker
+            .check_access(
+                &session.user.github_access_token,
+                &row.repo_owner,
+                &row.repo_name,
+            )
+            .await,
+        "board project not found",
+        &request_id,
+    ) {
+        return Err(err);
+    }
+```
+
+After:
+```rust
+    check_repo_access(
+        &access_checker,
+        &session.user.github_access_token,
+        &row.repo_owner,
+        &row.repo_name,
+        "board project not found",
+        &request_id,
+    ).await?;
+```
+
+##### 2d. `services/api_token.rs` — 3関数
+
+`execute_create_api_token`, `execute_list_api_tokens`, `execute_revoke_api_token` の各関数で:
+
+Before:
+```rust
+use crate::github_access::{DynGithubAccessChecker, access_result_to_error};
+...
+    let repo = boardflow_db::queries::repository::find_by_github_id(pool, github_repository_id)
+        ...
+    let result = access_checker.check_access(...).await;
+    if let Some(err) = access_result_to_error(...) { ... }
+```
+
+After:
+```rust
+use crate::github_access::DynGithubAccessChecker;
+use crate::services::authz::ensure_repository_access;
+...
+    let repo = ensure_repository_access(
+        pool, access_checker, github_access_token,
+        github_repository_id, request_id,
+    ).await?;
+```
+
+**注意**: `api_token.rs` の3関数は引数が `pool: &PgPool` (参照) であり、`ensure_repository_access` のシグネチャも `pool: &PgPool` なのでそのまま渡せる。
+
+#### Step 3: パターンB — `ensure_board_run_access` への置き換え (5箇所)
+
+##### 3a. `routes/read/board_runs.rs` — `get_board_run`
+
+Before:
+```rust
+    let repo = boardflow_db::queries::board_run::find_repository_by_board_run_id(&pool, id)
+        .await
+        .map_err(|e| {
+            tracing::error!("get_board_run repo lookup failed: {e}");
+            AppError::internal_error("database error", &request_id)
+        })?
+        .ok_or_else(|| AppError::not_found("board run not found", &request_id))?;
+
+    let result = access_checker
+        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
+        .await;
+    if let Some(err) = access_result_to_error(&result, "board run not found", &request_id) {
+        return Err(err);
+    }
+```
+
+After:
+```rust
+    ensure_board_run_access(
+        &pool, &access_checker, &session.user.github_access_token,
+        id, &request_id,
+    ).await?;
+```
+
+注意: `get_board_run` では repo の戻り値を使わないため `_` で受けるか、戻り値を破棄する。
+
+##### 3b. `routes/read/diff.rs` — `get_board_run_diff`
+
+同パターン。repo 不使用。
+
+##### 3c. `routes/read/viewer_sources.rs` — `get_viewer_sources`
+
+同パターン。repo 不使用。
+
+##### 3d. `routes/read/findings.rs` — `list_findings`
+
+同パターン。repo 不使用。
+
+##### 3e. `routes/read/artifacts.rs` — `list_artifacts`
+
+同パターン。repo 不使用。
+
+#### Step 4: パターンC — `ensure_board_project_access` への置き換え (1箇所)
+
+##### 4a. `routes/read/board_runs.rs` — `list_board_runs`
+
+Before:
+```rust
+    let repo =
+        boardflow_db::queries::board_project::find_repository_by_board_project_id(&pool, bp_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("list_board_runs repo lookup failed: {e}");
+                AppError::internal_error("database error", &request_id)
+            })?
+            .ok_or_else(|| AppError::not_found("board project not found", &request_id))?;
+
+    let result = access_checker
+        .check_access(&session.user.github_access_token, &repo.owner, &repo.name)
+        .await;
+    if let Some(err) = access_result_to_error(&result, "board project not found", &request_id) {
+        return Err(err);
+    }
+```
+
+After:
+```rust
+    ensure_board_project_access(
+        &pool, &access_checker, &session.user.github_access_token,
+        bp_id, &request_id,
+    ).await?;
+```
+
+注意: repo の戻り値は `list_board_runs` で使用しないため破棄。
+
+#### Step 5: import 整理 + cargo check/clippy/test
+
+1. 各ファイルで不要になった `use crate::github_access::access_result_to_error` を削除
+2. `cargo fmt --all`
+3. `cargo clippy --workspace --all-targets -- -D warnings`
+4. `cargo test --workspace`
+
+---
+
+### テスト観点
+
+| テスト | 検証内容 |
+|--------|---------|
+| `read_api_test.rs` — `AllowAll` テスト群 | 正常系が変わらないこと |
+| `read_api_test.rs` — `DenyAll` テスト群 | Denied → 404 変換が維持されていること |
+| `read_api_test.rs` — `RateLimited` テスト | RateLimited → 429 変換が維持されていること |
+| `read_api_test.rs` — `UpstreamError` テスト | Upstream → 500 変換が維持されていること |
+| `api_token_test.rs` — `DenyAll` テスト | API token 認可が変わらないこと |
+| `cargo clippy` | unused import の検出・修正 |
+
+新規テストの追加は不要。`ensure_*` 関数は統合テストで間接的にテストされるため、単体テストは過剰。
+
+---
+
+### ドキュメント更新対象
+
+- `docs/logs/97/worklog.md` (本ファイル) — 計画・実装記録
+- `docs/backend/api.md` — 変更不要（外部挙動の変更なし）
+- `docs/backend/summary.md` — services/authz.rs の追加を反映（任意）
+
+---
+
+### リスクと注意点
+
+1. **tracing メッセージの差異**: 元の個別メッセージ（`"get_repository failed"`, `"list_board_projects repo lookup failed"` 等）が汎用メッセージ（`"repository lookup failed"` 等）に変わる。error ログ監視で handler 名を grep している場合に影響するが、tracing span で handler は判別可能なため低リスク。
+2. **`get_board_project` の `check_repo_access`**: `not_found_msg` が呼び出し元で明示される。ensure_* と異なりハードコードされないため、呼び出し元のミスリスクがわずかにある。ただし1箇所のみなので許容。
+3. **`ensure_*` が `Repository` を返すが使わない箇所**: パターンB の5箇所と パターンC の1箇所では repo を後続で使わない。`let _ = ensure_board_run_access(...)` とすると clippy が警告する可能性があるため、`.await?;` だけで十分（`Result` の `Ok` 値を使わなくても clippy は警告しない）。
+
+---
+
+### 実装要否
+
+**`implementation_required`**
+
+### 更新した作業ログパス
+
+`docs/logs/97/worklog.md`

--- a/docs/logs/97/worklog.md
+++ b/docs/logs/97/worklog.md
@@ -696,3 +696,59 @@ After:
 ### 更新した作業ログパス
 
 `docs/logs/97/worklog.md`
+
+---
+
+## 実装結果 (impl フェーズ)
+
+### 実装内容
+
+#### 新規ファイル
+- `crates/api/src/services/authz.rs` — 4つの公開関数 + 5つのユニットテスト
+  - `ensure_repository_access`: github_repository_id → repo lookup → check_access (パターンA)
+  - `ensure_board_run_access`: board_run_id → repo lookup → check_access (パターンB)
+  - `ensure_board_project_access`: board_project_id → repo lookup → check_access (パターンC)
+  - `check_repo_access`: owner/name だけで access check (get_board_project の変形パターン用)
+
+#### 変更ファイル (11箇所の置き換え)
+- `services/mod.rs` — `pub mod authz;` 追加
+- `services/api_token.rs` — 3関数 (`execute_create/list/revoke_api_token`) を `ensure_repository_access` に置き換え
+- `routes/read/repositories.rs` — `get_repository` を `ensure_repository_access` に置き換え
+- `routes/read/board_projects.rs` — `list_board_projects` を `ensure_repository_access`、`get_board_project` を `check_repo_access` に置き換え
+- `routes/read/board_runs.rs` — `list_board_runs` を `ensure_board_project_access`、`get_board_run` を `ensure_board_run_access` に置き換え
+- `routes/read/diff.rs` — `get_board_run_diff` を `ensure_board_run_access` に置き換え
+- `routes/read/viewer_sources.rs` — `get_viewer_sources` を `ensure_board_run_access` に置き換え
+- `routes/read/findings.rs` — `list_findings` を `ensure_board_run_access` に置き換え
+- `routes/read/artifacts.rs` — `list_artifacts` を `ensure_board_run_access` に置き換え
+
+#### import 整理
+- `access_result_to_error` の直接 import を 8 ファイルから削除 (authz.rs 内部で使用)
+- `access_error_to_app_error` は `repositories.rs` の `list_repositories` で引き続き使用 (共通化対象外のパターン)
+- `DynGithubAccessChecker` は全 handler の Extension 抽出で引き続き使用
+
+### テスト結果
+
+#### ユニットテスト (5件, services::authz::tests)
+- `check_repo_access_allowed` — Allowed → Ok(())
+- `check_repo_access_denied_returns_not_found` — Denied → not_found (セキュリティ挙動保証)
+- `check_repo_access_token_expired` — TokenExpired → 401
+- `check_repo_access_rate_limited` — RateLimited → 429
+- `check_repo_access_upstream_error` — UpstreamError → 500
+
+#### 統合テスト (63件, boardflow-api 全テスト)
+- 全テスト通過。認可関連テスト (`test_get_board_run_denied_returns_404`, `test_list_repositories_denied_returns_empty` 等) も変更なしでパス。
+
+#### CI チェック
+- `cargo fmt --all -- --check` — OK
+- `cargo clippy --workspace --all-targets -- -D warnings` — OK (warning なし)
+
+### 更新ドキュメント
+- `docs/logs/97/worklog.md` (本ファイル)
+
+### 未変更 (対象外)
+- `list_repositories` — `list_accessible_repo_ids` を使う特殊パターン。共通化対象外。
+- `error_conversion.rs` — `access_result_to_error` / `access_error_to_app_error` は変更なし。authz.rs から内部利用。
+
+### 残リスク
+- `database::tests::from_env_succeeds_when_database_url_set` (boardflow-config) が環境変数未設定で失敗するが、本Issue とは無関係の既存問題。
+- tracing ログメッセージが `ensure_*` 関数のものに統一されたため、既存のログ文字列に依存するモニタリングがあれば調整が必要 (ただし内部ログのため外部影響なし)。


### PR DESCRIPTION
## 要件

APIの repository access check が handler/service 層に散在しており、同じパターン（repo lookup → access check → AppError変換）が重複していた。これを `services/authz.rs` に共通ヘルパーとして集約し、重複コードを削減する。挙動変更なしの純粋リファクタリング。

Closes #97

## 調査結果

- `routes/read/` 配下の8ファイルと `services/api_token.rs` で同一パターンが繰り返されていた
- `Denied → not_found` の情報秘匿は `github_access/error_conversion.rs` 側の `access_result_to_error()` が担っており、呼び出し側を集約しても挙動は変わらない
- `list_repositories` は `list_accessible_repo_ids` を使う別パターンのため共通化対象外

## 実装概要

### 新規ファイル
- `crates/api/src/services/authz.rs`: 4つの公開関数 + 5ユニットテスト
  - `ensure_repository_access`: github_repository_id → repo lookup → access check
  - `ensure_board_run_access`: board_run_id → repo lookup → access check
  - `ensure_board_project_access`: board_project_id → repo lookup → access check
  - `check_repo_access`: owner/name → access check（低レベル版）

### 変更ファイル (9ファイル)
- `crates/api/src/services/mod.rs`: `pub mod authz;` 追加
- `crates/api/src/routes/read/repositories.rs`: `get_repository` — ensure_repository_access に置き換え
- `crates/api/src/routes/read/board_projects.rs`: `list_board_projects` — ensure_repository_access、`get_board_project` — check_repo_access に置き換え
- `crates/api/src/routes/read/board_runs.rs`: `get_board_run` — ensure_board_run_access、`list_board_runs` — ensure_board_project_access に置き換え
- `crates/api/src/routes/read/diff.rs`: ensure_board_run_access に置き換え
- `crates/api/src/routes/read/viewer_sources.rs`: ensure_board_run_access に置き換え
- `crates/api/src/routes/read/findings.rs`: ensure_board_run_access に置き換え
- `crates/api/src/routes/read/artifacts.rs`: ensure_board_run_access に置き換え
- `crates/api/src/services/api_token.rs`: 3関数 — ensure_repository_access に置き換え

## テスト結果

| テスト種別 | 件数 | 結果 |
|-----------|------|------|
| ユニットテスト (check_repo_access) | 5件 | 全パス |
| 統合テスト read_api_test | 多数 | 全パス |
| 統合テスト api_token_test | 多数 | 全パス |
| 統合テスト合計 | 63件 | 全パス |
| cargo clippy | - | クリーン |
| cargo fmt | - | クリーン |

## セキュリティ挙動の維持

- `Denied → not_found` の情報秘匿は変更前後で同一。`check_repo_access()` は `access_result_to_error()` に委譲しており、`github_access/error_conversion.rs` の変換ロジックはそのまま利用されている。
- `not_found_msg` の固定文字列は各ハンドラで変更前と同一のまま維持。
- routes/read 配下への `access_result_to_error()` 直接呼び出しは残っていない。

## 更新ドキュメント

- `docs/logs/97/worklog.md`: 作業ログ（research / plan / impl / review / docs フェーズ）

## 外部調査メモ

本 Issue は内部リファクタリングのため外部調査なし。

## 残リスク

- `database::tests::from_env_succeeds_when_database_url_set` (boardflow-config) が環境変数未設定で失敗するが、本 Issue とは無関係の既存問題。
- tracing ログメッセージが `ensure_*` 関数のものに統一されたため、既存のログ文字列に依存するモニタリングがあれば調整が必要（ただし内部ログのため外部影響なし）。

## レビュー / ドキュメント確認

- review: `pr_ready: true` — blocking な指摘なし
- docs: `docs_ready: true` — 外部挙動変更なし、追加ドキュメント更新不要