### PR TITLE
feat: add Dockerfiles and image build CI for frontend/backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target
+.git
+.github
+docs
+samples
+boardflow/node_modules
+boardflow/.next

--- a/.github/workflows/backend-image.yml
+++ b/.github/workflows/backend-image.yml
@@ -1,0 +1,75 @@
+name: Backend Images
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/backend-image.yml
+      - crates/**
+      - Cargo.toml
+      - Cargo.lock
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+    paths:
+      - .github/workflows/backend-image.yml
+      - crates/**
+      - Cargo.toml
+      - Cargo.lock
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  DOCKER_METADATA_SHORT_SHA_LENGTH: 12
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        service:
+          - name: api
+            dockerfile: crates/api/Dockerfile
+          - name: worker
+            dockerfile: crates/worker/Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/f0reacharr/boardflow-${{ matrix.service.name }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-
+
+      - name: Build and publish ${{ matrix.service.name }} image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.service.dockerfile }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=backend-${{ matrix.service.name }}
+          cache-to: type=gha,mode=max,scope=backend-${{ matrix.service.name }}

--- a/.github/workflows/frontend-image.yml
+++ b/.github/workflows/frontend-image.yml
@@ -1,0 +1,65 @@
+name: Frontend Image
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/frontend-image.yml
+      - boardflow/**
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+    paths:
+      - .github/workflows/frontend-image.yml
+      - boardflow/**
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: f0reacharr/boardflow-frontend
+  DOCKER_METADATA_SHORT_SHA_LENGTH: 12
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,prefix=sha-
+
+      - name: Build and publish frontend image
+        uses: docker/build-push-action@v7
+        with:
+          context: boardflow
+          file: boardflow/Dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/boardflow/.dockerignore
+++ b/boardflow/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+.next
+.git
+*.tsbuildinfo

--- a/boardflow/Dockerfile
+++ b/boardflow/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: Install dependencies
+FROM node:22-slim AS deps
+WORKDIR /app
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+# Stage 2: Build
+FROM node:22-slim AS builder
+WORKDIR /app
+RUN corepack enable
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN pnpm build
+
+# Stage 3: Runtime
+FROM node:22-slim AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+RUN useradd --system --create-home --shell /usr/sbin/nologin nextjs
+
+COPY --from=builder /app/public ./public
+COPY --from=builder --chown=nextjs:nextjs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nextjs /app/.next/static ./.next/static
+
+USER nextjs
+
+EXPOSE 3000
+
+ENTRYPOINT ["node", "server.js"]

--- a/boardflow/next.config.ts
+++ b/boardflow/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   experimental: {
     optimizePackageImports: ['@chakra-ui/react'],
   },

--- a/boardflow/package.json
+++ b/boardflow/package.json
@@ -2,6 +2,12 @@
   "name": "boardflow-frontend",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.33.2",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
+  },
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/crates/api/Dockerfile
+++ b/crates/api/Dockerfile
@@ -1,0 +1,38 @@
+# Stage 1: Plan dependencies
+FROM rust:1.95-bookworm AS planner
+WORKDIR /app
+RUN cargo install cargo-chef --locked
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 2: Cache dependencies
+FROM rust:1.95-bookworm AS cacher
+WORKDIR /app
+RUN cargo install cargo-chef --locked
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p boardflow-api
+
+# Stage 3: Build binary
+FROM rust:1.95-bookworm AS builder
+WORKDIR /app
+COPY . .
+COPY --from=cacher /app/target target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
+RUN cargo build --release -p boardflow-api
+
+# Stage 4: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --system --create-home --shell /usr/sbin/nologin boardflow
+USER boardflow
+
+COPY --from=builder /app/target/release/boardflow-api /usr/local/bin/boardflow-api
+
+EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/boardflow-api"]

--- a/crates/worker/Dockerfile
+++ b/crates/worker/Dockerfile
@@ -1,0 +1,36 @@
+# Stage 1: Plan dependencies
+FROM rust:1.95-bookworm AS planner
+WORKDIR /app
+RUN cargo install cargo-chef --locked
+COPY . .
+RUN cargo chef prepare --recipe-path recipe.json
+
+# Stage 2: Cache dependencies
+FROM rust:1.95-bookworm AS cacher
+WORKDIR /app
+RUN cargo install cargo-chef --locked
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json -p boardflow-worker
+
+# Stage 3: Build binary
+FROM rust:1.95-bookworm AS builder
+WORKDIR /app
+COPY . .
+COPY --from=cacher /app/target target
+COPY --from=cacher /usr/local/cargo /usr/local/cargo
+RUN cargo build --release -p boardflow-worker
+
+# Stage 4: Runtime
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN useradd --system --create-home --shell /usr/sbin/nologin boardflow
+USER boardflow
+
+COPY --from=builder /app/target/release/boardflow-worker /usr/local/bin/boardflow-worker
+
+ENTRYPOINT ["/usr/local/bin/boardflow-worker"]


### PR DESCRIPTION
## Summary
- `crates/api` (boardflow-api) / `crates/worker` (boardflow-worker) / `boardflow`（フロントエンド）をそれぞれコンテナ化
- 3イメージを GHCR (`ghcr.io/f0reacharr/boardflow-{api,worker,frontend}`) にビルド・pushするCIワークフローを追加（`action-image.yml` と同じ構成: PRではbuildのみ、main/tagsへのpushでpush）

## Details
- `crates/api/Dockerfile`, `crates/worker/Dockerfile`: `action/Dockerfile` と同じ cargo-chef 多段ビルドパターンを踏襲。ランタイムは `debian:bookworm-slim` + `ca-certificates` + `libssl3`（reqwest/native-tls依存のため）、非rootユーザーで実行
- `boardflow/Dockerfile`: pnpm install → `next build` → standalone runtime の3段構成。`next.config.ts` に `output: 'standalone'` を追加
- `boardflow/package.json`: `packageManager: pnpm@10.33.2` を固定（`mise.toml` の pnpm バージョンと不一致だと corepack が pnpm 11 系を落としてきて `ERR_PNPM_IGNORED_BUILDS` で落ちたため）。`pnpm.onlyBuiltDependencies: ["sharp"]` を追加してビルドスクリプトを許可
- `.dockerignore`（ルート・`boardflow/`）を追加してビルドコンテキストを削減
- `.github/workflows/backend-image.yml`: `matrix` で api/worker を並列ビルド、GHAキャッシュはサービスごとにスコープ分離
- `.github/workflows/frontend-image.yml`: `boardflow/` 配下の変更をトリガーにビルド

## Test plan
- [x] `docker build -f boardflow/Dockerfile boardflow` → ビルド成功、コンテナ起動して `/login` にHTTP 200を確認
- [x] `docker build -f crates/api/Dockerfile .` → ビルド成功、`docker-compose` の postgres と接続して `/api/v1/openapi.json` にHTTP 200を確認
- [x] `docker build -f crates/worker/Dockerfile .` → ビルド成功
- [ ] CIワークフロー自体はこのPRのCI実行で動作確認（GHCRへのpushはmainマージ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)